### PR TITLE
[codex] render sender reference tokens

### DIFF
--- a/packages/shared/src/interfaces/agent-runtime.ts
+++ b/packages/shared/src/interfaces/agent-runtime.ts
@@ -61,6 +61,8 @@ export interface StartAgentTurnOptions {
   prompt: string
   images?: IAttachment[]
   attachments?: IAttachment[]
+  referencedFiles?: string[]
+  selectedSkill?: string
   workspacePath?: string
   mode?: AgentMode
   chatSettings: Omit<ChatSettings, 'model' | 'features'> & {

--- a/packages/shared/src/interfaces/workspace.ts
+++ b/packages/shared/src/interfaces/workspace.ts
@@ -18,3 +18,9 @@ export interface ListWorkspacesData {
   currentWorkspacePath: string
   workspaces: WorkspaceItem[]
 }
+
+export interface WorkspaceFileSearchResult {
+  path: string
+  name: string
+  type: 'file'
+}

--- a/src/main/agent/runtime/__tests__/turnContext.spec.ts
+++ b/src/main/agent/runtime/__tests__/turnContext.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { buildPromptWithTurnContext } from '../turnContext'
+
+describe('buildPromptWithTurnContext', () => {
+  it('不带上下文时返回原始 prompt', () => {
+    expect(buildPromptWithTurnContext({ prompt: '分析项目' })).toBe('分析项目')
+  })
+
+  it('注入 @ 文件引用并要求通过 read_file 读取', () => {
+    const result = buildPromptWithTurnContext({
+      prompt: '分析这些文件',
+      referencedFiles: ['src/a.ts', '../bad.ts', '/tmp/outside.ts', 'src/a.ts'],
+    })
+
+    expect(result).toContain('- src/a.ts')
+    expect(result).toContain('必须使用 read_file')
+    expect(result).not.toContain('../bad.ts')
+    expect(result).not.toContain('/tmp/outside.ts')
+  })
+
+  it('注入 / skill 强制 use_skill 指令', () => {
+    const result = buildPromptWithTurnContext({
+      prompt: '检查代码',
+      selectedSkill: 'code-review',
+    })
+
+    expect(result).toContain('必须先加载 Skill "code-review"')
+    expect(result).toContain('调用 use_skill')
+    expect(result).toContain('name="code-review"')
+  })
+})

--- a/src/main/agent/runtime/agentTurnService.ts
+++ b/src/main/agent/runtime/agentTurnService.ts
@@ -2,6 +2,7 @@ import type { AddMessage, AgentTurnResult, StartAgentTurnOptions } from '@ant-ch
 import { addConversation, addMessage, getConversationById } from '@main/db/services'
 import { WorkspaceStore } from '@main/store/workspace'
 import { agentRuntime } from './agentRuntime'
+import { buildPromptWithTurnContext } from './turnContext'
 
 const DEFAULT_CONVERSATION_TITLE = 'Untitled'
 
@@ -50,7 +51,13 @@ export async function startAgentTurn(options: StartAgentTurnOptions): Promise<Ag
   const task = await agentRuntime.startTask({
     conversationId: conversation.id,
     userMessageId: userMessage.id,
-    prompt,
+    prompt: buildPromptWithTurnContext({
+      prompt,
+      referencedFiles: options.referencedFiles,
+      selectedSkill: options.selectedSkill,
+    }),
+    referencedFiles: options.referencedFiles,
+    selectedSkill: options.selectedSkill,
     mode: options.mode,
     workspacePath,
     chatSettings: options.chatSettings,

--- a/src/main/agent/runtime/turnContext.ts
+++ b/src/main/agent/runtime/turnContext.ts
@@ -1,0 +1,51 @@
+export interface TurnContextOptions {
+  prompt: string
+  referencedFiles?: string[]
+  selectedSkill?: string
+}
+
+export function buildPromptWithTurnContext(options: TurnContextOptions): string {
+  const prompt = options.prompt.trim()
+  const referencedFiles = normalizeReferencedFiles(options.referencedFiles)
+  const selectedSkill = options.selectedSkill?.trim()
+
+  if (referencedFiles.length === 0 && !selectedSkill) {
+    return prompt
+  }
+
+  const context: string[] = ['<turn_context>']
+
+  if (referencedFiles.length > 0) {
+    context.push('用户通过 @ 引用了以下当前工作区文件。需要文件内容时，必须使用 read_file 读取，不要臆测内容：')
+    for (const file of referencedFiles) {
+      context.push(`- ${file}`)
+    }
+  }
+
+  if (selectedSkill) {
+    context.push(`用户通过 / 指定本轮必须先加载 Skill "${selectedSkill}"。请先调用 use_skill，参数 name="${selectedSkill}"，再继续完成用户任务。`)
+  }
+
+  context.push('</turn_context>')
+
+  return `${context.join('\n')}\n\n${prompt}`
+}
+
+function normalizeReferencedFiles(files?: string[]): string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+
+  for (const file of files || []) {
+    const value = file.trim()
+    if (!value || value.startsWith('/') || value.includes('..')) {
+      continue
+    }
+    if (seen.has(value)) {
+      continue
+    }
+    seen.add(value)
+    result.push(value)
+  }
+
+  return result
+}

--- a/src/main/agent/runtime/types.ts
+++ b/src/main/agent/runtime/types.ts
@@ -4,6 +4,8 @@ export interface AgentRuntimeStartOptions {
   conversationId: string
   userMessageId: string
   prompt: string
+  referencedFiles?: string[]
+  selectedSkill?: string
   workspacePath?: string
   mode?: AgentMode
   chatSettings?: Omit<ChatSettings, 'model'> & { modelId: string }

--- a/src/main/domains/settings/ipc.ts
+++ b/src/main/domains/settings/ipc.ts
@@ -1,6 +1,6 @@
 import type { GeneralSettingsState, IpcResponse } from '@ant-chat/shared'
 import { createErrorIpcResponse, createIpcResponse } from '@ant-chat/shared'
-import { SettingsWindow } from '@main/settings-window'
+import { getSettingsWindow, openSettingsWindow } from '@main/settings-window'
 import { GeneralSettingsStore } from '@main/store/generalSettings'
 import { logger } from '@main/utils/logger'
 import { ProxyManager } from '@main/utils/proxy-manager'
@@ -11,15 +11,10 @@ import { IpcMethod, IpcService } from 'electron-ipc-decorator'
 export class SettingsIpcService extends IpcService {
   static readonly groupName = 'settings'
 
-  private static settingsWindowInstance: SettingsWindow | null = null
-
   @IpcMethod()
   async openSettingsWindow(): Promise<IpcResponse<void>> {
     try {
-      if (!SettingsIpcService.settingsWindowInstance) {
-        SettingsIpcService.settingsWindowInstance = new SettingsWindow()
-      }
-      await SettingsIpcService.settingsWindowInstance.createWindow()
+      await openSettingsWindow()
       return createIpcResponse(true, undefined)
     }
     catch (error) {
@@ -52,7 +47,7 @@ export class SettingsIpcService extends IpcService {
 
       // 广播 settings:updated 事件
       const mainWindow = getMainWindow()
-      const settingsWindow = SettingsIpcService.settingsWindowInstance?.getWindow()
+      const settingsWindow = getSettingsWindow()
       const keys = Object.keys(updates)
 
       if (mainWindow && !mainWindow.isDestroyed()) {
@@ -81,7 +76,7 @@ export class SettingsIpcService extends IpcService {
 
       // 广播 settings:updated 事件
       const mainWindow = getMainWindow()
-      const settingsWindow = SettingsIpcService.settingsWindowInstance?.getWindow()
+      const settingsWindow = getSettingsWindow()
 
       if (mainWindow && !mainWindow.isDestroyed()) {
         mainWindow.webContents.send('settings:updated', { keys: ['all'] })

--- a/src/main/domains/workspace/ipc.ts
+++ b/src/main/domains/workspace/ipc.ts
@@ -1,6 +1,7 @@
-import type { IpcResponse, ListWorkspacesData } from '@ant-chat/shared'
+import type { IpcResponse, ListWorkspacesData, WorkspaceFileSearchResult } from '@ant-chat/shared'
 import { createErrorIpcResponse, createIpcResponse } from '@ant-chat/shared'
 import { WorkspaceStore } from '@main/store/workspace'
+import { searchWorkspaceFiles } from '@main/store/workspaceFileSearch'
 import { sendToRenderer } from '@main/utils/ipc-events'
 import { logger } from '@main/utils/logger'
 import { getMainWindow } from '@main/window'
@@ -82,6 +83,22 @@ export class WorkspaceIpcService extends IpcService {
     }
     catch (error) {
       logger.error('选择工作区失败:', error)
+      return createErrorIpcResponse(error as Error)
+    }
+  }
+
+  @IpcMethod()
+  async searchWorkspaceFiles(query = '', limit = 50): Promise<IpcResponse<WorkspaceFileSearchResult[]>> {
+    try {
+      const workspacePath = WorkspaceStore.getInstance().getCurrentWorkspacePath()
+      if (!workspacePath) {
+        return createIpcResponse(true, [])
+      }
+
+      return createIpcResponse(true, await searchWorkspaceFiles(workspacePath, query, limit))
+    }
+    catch (error) {
+      logger.error('搜索工作区文件失败:', error)
       return createErrorIpcResponse(error as Error)
     }
   }

--- a/src/main/settings-window.ts
+++ b/src/main/settings-window.ts
@@ -2,6 +2,7 @@ import type { BrowserWindow } from 'electron'
 import { BaseWindow } from './base-window'
 
 let settingsWindow: null | BrowserWindow = null
+let settingsWindowInstance: SettingsWindow | null = null
 
 export class SettingsWindow extends BaseWindow {
   constructor() {
@@ -22,4 +23,12 @@ export class SettingsWindow extends BaseWindow {
 
 export function getSettingsWindow(): typeof settingsWindow {
   return settingsWindow
+}
+
+export async function openSettingsWindow(): Promise<void> {
+  if (!settingsWindowInstance) {
+    settingsWindowInstance = new SettingsWindow()
+  }
+
+  await settingsWindowInstance.createWindow()
 }

--- a/src/main/store/__tests__/workspaceFileSearch.spec.ts
+++ b/src/main/store/__tests__/workspaceFileSearch.spec.ts
@@ -1,0 +1,41 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { searchWorkspaceFiles } from '../workspaceFileSearch'
+
+describe('searchWorkspaceFiles', () => {
+  let workspacePath: string
+
+  beforeEach(async () => {
+    workspacePath = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ant-chat-workspace-files-'))
+    await fs.promises.mkdir(path.join(workspacePath, 'src'), { recursive: true })
+    await fs.promises.mkdir(path.join(workspacePath, 'node_modules/pkg'), { recursive: true })
+    await fs.promises.mkdir(path.join(workspacePath, '.git'), { recursive: true })
+    await fs.promises.writeFile(path.join(workspacePath, 'src/a.ts'), 'a')
+    await fs.promises.writeFile(path.join(workspacePath, 'README.md'), 'readme')
+    await fs.promises.writeFile(path.join(workspacePath, 'node_modules/pkg/index.ts'), 'ignored')
+    await fs.promises.writeFile(path.join(workspacePath, '.git/config'), 'ignored')
+  })
+
+  afterEach(async () => {
+    await fs.promises.rm(workspacePath, { recursive: true, force: true })
+  })
+
+  it('搜索工作区文件并跳过忽略目录', async () => {
+    const results = await searchWorkspaceFiles(workspacePath, '', 20)
+    const paths = results.map(item => item.path)
+
+    expect(paths).toContain('README.md')
+    expect(paths).toContain('src/a.ts')
+    expect(paths).not.toContain('node_modules/pkg/index.ts')
+    expect(paths).not.toContain('.git/config')
+  })
+
+  it('按相对路径查询并限制结果数量', async () => {
+    const results = await searchWorkspaceFiles(workspacePath, 'src', 1)
+
+    expect(results).toHaveLength(1)
+    expect(results[0]).toMatchObject({ path: 'src/a.ts', name: 'a.ts', type: 'file' })
+  })
+})

--- a/src/main/store/workspaceFileSearch.ts
+++ b/src/main/store/workspaceFileSearch.ts
@@ -1,0 +1,79 @@
+import type { WorkspaceFileSearchResult } from '@ant-chat/shared'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const IGNORED_DIRS = new Set([
+  '.git',
+  'node_modules',
+  'out',
+  'dist',
+  'build',
+  'release',
+])
+
+const DEFAULT_LIMIT = 50
+const MAX_VISITED_ENTRIES = 5000
+
+export async function searchWorkspaceFiles(
+  workspacePath: string,
+  query = '',
+  limit = DEFAULT_LIMIT,
+): Promise<WorkspaceFileSearchResult[]> {
+  const root = path.resolve(workspacePath)
+  const normalizedQuery = query.trim().toLowerCase()
+  const maxResults = Math.max(1, Math.min(limit, 100))
+  const results: WorkspaceFileSearchResult[] = []
+  let visited = 0
+
+  async function walk(dir: string): Promise<void> {
+    if (results.length >= maxResults || visited >= MAX_VISITED_ENTRIES) {
+      return
+    }
+
+    let entries: fs.Dirent[]
+    try {
+      entries = await fs.promises.readdir(dir, { withFileTypes: true })
+    }
+    catch {
+      return
+    }
+
+    entries.sort((a, b) => a.name.localeCompare(b.name, 'en'))
+
+    for (const entry of entries) {
+      if (results.length >= maxResults || visited >= MAX_VISITED_ENTRIES) {
+        return
+      }
+      visited += 1
+
+      if (entry.isDirectory()) {
+        if (!IGNORED_DIRS.has(entry.name)) {
+          await walk(path.join(dir, entry.name))
+        }
+        continue
+      }
+
+      if (!entry.isFile()) {
+        continue
+      }
+
+      const absolutePath = path.join(dir, entry.name)
+      const relativePath = path.relative(root, absolutePath).split(path.sep).join('/')
+      if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+        continue
+      }
+      if (normalizedQuery && !relativePath.toLowerCase().includes(normalizedQuery)) {
+        continue
+      }
+
+      results.push({
+        path: relativePath,
+        name: entry.name,
+        type: 'file',
+      })
+    }
+  }
+
+  await walk(root)
+  return results
+}

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -1,6 +1,7 @@
 import type { BrowserWindow } from 'electron'
 import { app, Menu } from 'electron'
 import { BaseWindow } from './base-window'
+import { openSettingsWindow } from './settings-window'
 import { isDev, isMacOS } from './utils/env'
 import { logger } from './utils/logger'
 
@@ -40,6 +41,16 @@ export class MainWindow extends BaseWindow {
             label: app.name,
             submenu: [
               { role: 'about' },
+              { type: 'separator' },
+              {
+                label: 'Settings...',
+                accelerator: 'Command+,',
+                click: () => {
+                  openSettingsWindow().catch((error) => {
+                    logger.error('Failed to open settings window:', error)
+                  })
+                },
+              },
               { type: 'separator' },
               { role: 'services' },
               { type: 'separator' },

--- a/src/renderer/src/api/workspaceApi.ts
+++ b/src/renderer/src/api/workspaceApi.ts
@@ -1,4 +1,4 @@
-import type { ListWorkspacesData } from '@ant-chat/shared'
+import type { ListWorkspacesData, WorkspaceFileSearchResult } from '@ant-chat/shared'
 import { ipc, unwrapIpcResponse } from '@/utils/ipc-bus'
 
 async function listWorkspaces(): Promise<ListWorkspacesData> {
@@ -21,10 +21,15 @@ async function chooseWorkspace(): Promise<ListWorkspacesData | null> {
   return unwrapIpcResponse(await ipc.workspace.chooseWorkspace())
 }
 
+async function searchWorkspaceFiles(query: string, limit = 50): Promise<WorkspaceFileSearchResult[]> {
+  return unwrapIpcResponse(await ipc.workspace.searchWorkspaceFiles(query, limit))
+}
+
 export default {
   listWorkspaces,
   addWorkspace,
   removeWorkspace,
   openWorkspace,
   chooseWorkspace,
+  searchWorkspaceFiles,
 }

--- a/src/renderer/src/components/Chat/Chat.tsx
+++ b/src/renderer/src/components/Chat/Chat.tsx
@@ -36,6 +36,8 @@ export default function Chat() {
     message: string,
     images: IImage[],
     attachments: IAttachment[],
+    referencedFiles: string[],
+    selectedSkill: string | undefined,
     features: ChatFeatures,
     agentMode: AgentMode,
   ) {
@@ -50,6 +52,8 @@ export default function Chat() {
       prompt: message,
       images,
       attachments,
+      referencedFiles,
+      selectedSkill,
       mode: agentMode,
       workspacePath: currentWorkspacePath || undefined,
       chatSettings: {

--- a/src/renderer/src/components/Chat/MessageBubble.tsx
+++ b/src/renderer/src/components/Chat/MessageBubble.tsx
@@ -83,7 +83,7 @@ export function MessageBubble({ messages, collapseIntermediate, onCopyMessage }:
         ...pick(item, pickList),
         content,
       }
-      return <MessageContent {...messageContentProps} />
+      return <MessageContent {...messageContentProps} enableReferenceTokens={itemIsUser} />
     }
 
     return (

--- a/src/renderer/src/components/Chat/MessageContent.tsx
+++ b/src/renderer/src/components/Chat/MessageContent.tsx
@@ -16,7 +16,11 @@ import {
   ReasoningTrigger,
 } from '@workspace/ui/components/ai-elements/reasoning'
 import { Alert, AlertDescription } from '@workspace/ui/components/alert'
-import { Loader2Icon } from 'lucide-react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@workspace/ui/components/tooltip'
+import { FileIcon, Loader2Icon, SparklesIcon } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { skillApi } from '@/api/skillApi'
+import { tokenizeMessageReferences } from './messageReferenceTokens'
 
 function toAttachmentData(item: NonNullable<BubbleContent['attachments']>[number]): AttachmentData {
   return {
@@ -36,7 +40,7 @@ function getAttachmentUrl(item: AttachmentData): string {
   return item.url || ''
 }
 
-export default function MessageContent({ content = '', images = [], attachments = [], reasoningContent = '', status }: Partial<BubbleContent>) {
+export default function MessageContent({ content = '', images = [], attachments = [], reasoningContent = '', status, enableReferenceTokens = false }: Partial<BubbleContent> & { enableReferenceTokens?: boolean }) {
   if (status === 'error') {
     return (
       <Alert variant="destructive">
@@ -78,7 +82,11 @@ export default function MessageContent({ content = '', images = [], attachments 
         </Reasoning>
       )}
 
-      {content && <MessageResponse isAnimating={isStreaming}>{content}</MessageResponse>}
+      {content && (
+        enableReferenceTokens
+          ? <ReferenceTokenMessage content={content} />
+          : <MessageResponse isAnimating={isStreaming}>{content}</MessageResponse>
+      )}
 
       {imageItems.length > 0 && (
         <Attachments variant="grid" className="ml-0">
@@ -112,5 +120,65 @@ export default function MessageContent({ content = '', images = [], attachments 
         </Attachments>
       )}
     </div>
+  )
+}
+
+function ReferenceTokenMessage({ content }: { content: string }) {
+  const [skillDescriptions, setSkillDescriptions] = useState<Record<string, string>>({})
+  const skillNames = useMemo(
+    () => tokenizeMessageReferences(content)
+      .filter(part => part.type === 'skill')
+      .map(part => part.value),
+    [content],
+  )
+
+  useEffect(() => {
+    if (skillNames.length === 0) {
+      return
+    }
+
+    void skillApi.listSkills()
+      .then((data) => {
+        const next: Record<string, string> = {}
+        for (const skill of data.skills) {
+          if (skill.description) {
+            next[skill.name] = skill.description
+          }
+        }
+        setSkillDescriptions(next)
+      })
+      .catch(() => {})
+  }, [skillNames])
+
+  return (
+    <p className="wrap-break-word whitespace-pre-wrap">
+      {tokenizeMessageReferences(content).map((part) => {
+        if (part.type === 'text') {
+          return <span key={`text-${part.offset}`}>{part.text}</span>
+        }
+
+        const isFile = part.type === 'file'
+        return (
+          <Tooltip key={`${part.type}-${part.offset}-${part.value}`}>
+            <TooltipTrigger asChild>
+              <span
+                className="
+                  inline-flex max-w-full translate-y-[2px] items-center gap-1 rounded-md border
+                  bg-muted px-1.5 py-0.5 text-xs text-foreground
+                "
+              >
+                {isFile
+                  ? <FileIcon className="size-3 shrink-0" />
+                  : <SparklesIcon className="size-3 shrink-0" />}
+                <span className="max-w-72 truncate">{part.text}</span>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              {isFile ? part.value : (skillDescriptions[part.value] || `Skill: ${part.value}`)}
+            </TooltipContent>
+          </Tooltip>
+        )
+      })}
+    </p>
   )
 }

--- a/src/renderer/src/components/Chat/__tests__/messageReferenceTokens.spec.ts
+++ b/src/renderer/src/components/Chat/__tests__/messageReferenceTokens.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { tokenizeMessageReferences } from '../messageReferenceTokens'
+
+describe('tokenizeMessageReferences', () => {
+  it('识别 @ 文件和 / skill token', () => {
+    expect(tokenizeMessageReferences('分析 @src/a.ts /code-review')).toEqual([
+      { type: 'text', text: '分析 ', offset: 0 },
+      { type: 'file', text: '@src/a.ts', value: 'src/a.ts', offset: 3 },
+      { type: 'text', text: ' ', offset: 12 },
+      { type: 'skill', text: '/code-review', value: 'code-review', offset: 13 },
+    ])
+  })
+
+  it('普通文本保持不变', () => {
+    expect(tokenizeMessageReferences('hello')).toEqual([{ type: 'text', text: 'hello', offset: 0 }])
+  })
+})

--- a/src/renderer/src/components/Chat/messageReferenceTokens.ts
+++ b/src/renderer/src/components/Chat/messageReferenceTokens.ts
@@ -1,0 +1,35 @@
+export type MessageTokenPart
+  = | { type: 'text', text: string, offset: number }
+    | { type: 'file', text: string, value: string, offset: number }
+    | { type: 'skill', text: string, value: string, offset: number }
+
+const TOKEN_PATTERN = /(^|\s)(@\S+|\/[\w.-]+)/g
+
+export function tokenizeMessageReferences(content: string): MessageTokenPart[] {
+  const parts: MessageTokenPart[] = []
+  let cursor = 0
+
+  for (const match of content.matchAll(TOKEN_PATTERN)) {
+    const prefix = match[1]
+    const token = match[2]
+    const tokenStart = (match.index || 0) + prefix.length
+
+    if (tokenStart > cursor) {
+      parts.push({ type: 'text', text: content.slice(cursor, tokenStart), offset: cursor })
+    }
+
+    parts.push({
+      type: token.startsWith('@') ? 'file' : 'skill',
+      text: token,
+      value: token.slice(1),
+      offset: tokenStart,
+    })
+    cursor = tokenStart + token.length
+  }
+
+  if (cursor < content.length) {
+    parts.push({ type: 'text', text: content.slice(cursor), offset: cursor })
+  }
+
+  return parts.length > 0 ? parts : [{ type: 'text', text: content, offset: 0 }]
+}

--- a/src/renderer/src/components/Sender/ReferenceSuggestionPanel.tsx
+++ b/src/renderer/src/components/Sender/ReferenceSuggestionPanel.tsx
@@ -1,0 +1,122 @@
+import type { SkillManifest, WorkspaceFileSearchResult } from '@ant-chat/shared'
+import type { ActiveReferenceTrigger } from './inputReferences'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+} from '@workspace/ui/components/command'
+import { FileIcon, SparklesIcon } from 'lucide-react'
+import { useEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
+
+interface ReferenceSuggestionPanelProps {
+  trigger: ActiveReferenceTrigger | null
+  files: WorkspaceFileSearchResult[]
+  skills: SkillManifest[]
+  hasWorkspace: boolean
+  hasEnabledSkills: boolean
+  highlightedIndex: number
+  anchorRect: DOMRect | null
+  onSelectFile: (file: WorkspaceFileSearchResult) => void
+  onSelectSkill: (skill: SkillManifest) => void
+}
+
+export function ReferenceSuggestionPanel({
+  trigger,
+  files,
+  skills,
+  hasWorkspace,
+  hasEnabledSkills,
+  highlightedIndex,
+  anchorRect,
+  onSelectFile,
+  onSelectSkill,
+}: ReferenceSuggestionPanelProps) {
+  const listRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const activeItem = listRef.current?.querySelector('[data-highlighted="true"]')
+    activeItem?.scrollIntoView({ block: 'nearest' })
+  }, [highlightedIndex, files, skills])
+
+  if (!trigger || !anchorRect) {
+    return null
+  }
+
+  const isFile = trigger.type === 'file'
+  const itemCount = isFile ? files.length : skills.length
+  const emptyText = isFile
+    ? hasWorkspace ? '没有匹配的工作区文件' : '未选择工作区'
+    : hasEnabledSkills ? '没有匹配的 Skill' : '没有已启用的 Skill'
+  const style = {
+    bottom: `${Math.max(12, window.innerHeight - anchorRect.top + 8)}px`,
+    left: `${anchorRect.left + 8}px`,
+    width: `${Math.max(240, anchorRect.width - 16)}px`,
+  }
+
+  return createPortal(
+    <div
+      className="
+        fixed z-50 overflow-hidden rounded-xl border bg-popover text-popover-foreground shadow-md
+      "
+      style={style}
+    >
+      <Command shouldFilter={false}>
+        <CommandList ref={listRef} className="max-h-64">
+          <CommandGroup heading={isFile ? '@ 选择工作区文件' : '/ 指定 Skill'}>
+            {isFile && files.map((file, index) => (
+              <CommandItem
+                key={file.path}
+                value={file.path}
+                className="data-[highlighted=true]:bg-muted"
+                data-highlighted={index === highlightedIndex}
+                onMouseDown={(event) => {
+                  event.preventDefault()
+                  onSelectFile(file)
+                }}
+              >
+                <FileIcon className="text-muted-foreground" />
+                <span className="truncate">{file.path}</span>
+              </CommandItem>
+            ))}
+
+            {!isFile && skills.map((skill, index) => (
+              <CommandItem
+                key={skill.name}
+                value={skill.name}
+                className="
+                  items-start
+                  data-[highlighted=true]:bg-muted
+                "
+                data-highlighted={index === highlightedIndex}
+                onMouseDown={(event) => {
+                  event.preventDefault()
+                  onSelectSkill(skill)
+                }}
+              >
+                <SparklesIcon className="mt-0.5 text-muted-foreground" />
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-sm">{skill.name}</span>
+                  {skill.description && (
+                    <span className="block truncate text-xs text-muted-foreground">
+                      {skill.description}
+                    </span>
+                  )}
+                </span>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+
+          {itemCount === 0 && (
+            <CommandEmpty className="text-muted-foreground">
+              {emptyText}
+            </CommandEmpty>
+          )}
+        </CommandList>
+      </Command>
+    </div>,
+    document.body,
+  )
+}

--- a/src/renderer/src/components/Sender/Sender.tsx
+++ b/src/renderer/src/components/Sender/Sender.tsx
@@ -58,6 +58,7 @@ import { setActiveConversationsId, useMessagesStore } from '@/store/messages'
 import { fileToBase64 } from '@/utils'
 import TypingEffect from '../TypingEffect'
 import {
+  buildReferenceInputParts,
   getActiveReferenceTrigger,
   insertReferenceToken,
   isCompletedReferenceTrigger,
@@ -215,6 +216,52 @@ function SenderContextUsageButton() {
   )
 }
 
+function ReferenceInputOverlay({
+  text,
+  referencedFiles,
+  selectedSkill,
+  scrollTop,
+}: {
+  text: string
+  referencedFiles: string[]
+  selectedSkill?: string
+  scrollTop: number
+}) {
+  const parts = useMemo(
+    () => buildReferenceInputParts(text, referencedFiles, selectedSkill),
+    [text, referencedFiles, selectedSkill],
+  )
+
+  return (
+    <div
+      aria-hidden="true"
+      className="
+        pointer-events-none absolute inset-0 z-0 max-h-48 min-h-24 overflow-hidden p-1 text-left
+        text-base wrap-break-word whitespace-pre-wrap
+        md:text-sm
+      "
+    >
+      <div style={{ transform: `translateY(-${scrollTop}px)` }}>
+        {parts.map((part) => {
+          if (part.type === 'text') {
+            return <span key={`${part.offset}-text`}>{part.text}</span>
+          }
+
+          return (
+            <span
+              key={`${part.offset}-${part.type}-${part.text}`}
+              data-testid="reference-token"
+              className="rounded-sm bg-primary/10 text-primary ring-2 ring-primary/10"
+            >
+              {part.text}
+            </span>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
 function Sender({ actions, ...props }: SenderProps) {
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
   const senderRef = useRef<HTMLDivElement | null>(null)
@@ -231,6 +278,7 @@ function Sender({ actions, ...props }: SenderProps) {
   const [fileResults, setFileResults] = useState<WorkspaceFileSearchResult[]>([])
   const [skills, setSkills] = useState<SkillManifest[]>([])
   const [highlightedIndex, setHighlightedIndex] = useState(0)
+  const [textareaScrollTop, setTextareaScrollTop] = useState(0)
   const [suggestionAnchorRect, setSuggestionAnchorRect] = useState<DOMRect | null>(null)
 
   const activeConversationsId = useMessagesStore(
@@ -584,6 +632,7 @@ function Sender({ actions, ...props }: SenderProps) {
     setCursor(0)
     setReferencedFiles([])
     setSelectedSkill(undefined)
+    setTextareaScrollTop(0)
   }
 
   return (
@@ -612,19 +661,33 @@ function Sender({ actions, ...props }: SenderProps) {
       >
         <PromptInputBody className="bg-transparent px-1 pt-1">
           <SenderAttachmentsPreview />
-          <PromptInputTextarea
-            ref={textareaRef}
-            className="max-h-48 min-h-24 border-0 bg-transparent p-1"
-            data-testid="chat-input"
-            value={draft}
-            onChange={(event) => {
-              updateDraft(event.currentTarget.value, event.currentTarget.selectionStart)
-            }}
-            onClick={event => updateCursorFromTextarea(event.currentTarget)}
-            onKeyDown={handleTextareaKeyDown}
-            onKeyUp={handleTextareaKeyUp}
-            placeholder="Enter发送消息，Shift+Enter换行"
-          />
+          <div className="relative min-h-24 w-full">
+            <ReferenceInputOverlay
+              text={draft}
+              referencedFiles={referencedFiles}
+              selectedSkill={selectedSkill}
+              scrollTop={textareaScrollTop}
+            />
+            <PromptInputTextarea
+              ref={textareaRef}
+              className="
+                relative z-10 max-h-48 min-h-24 border-0 bg-transparent p-1 text-transparent
+                caret-foreground
+                selection:bg-primary/20 selection:text-foreground
+                placeholder:text-muted-foreground
+              "
+              data-testid="chat-input"
+              value={draft}
+              onChange={(event) => {
+                updateDraft(event.currentTarget.value, event.currentTarget.selectionStart)
+              }}
+              onClick={event => updateCursorFromTextarea(event.currentTarget)}
+              onKeyDown={handleTextareaKeyDown}
+              onKeyUp={handleTextareaKeyUp}
+              onScroll={event => setTextareaScrollTop(event.currentTarget.scrollTop)}
+              placeholder="Enter发送消息，Shift+Enter换行"
+            />
+          </div>
           <ReferenceSuggestionPanel
             trigger={activeReferenceTrigger}
             files={fileResults}

--- a/src/renderer/src/components/Sender/Sender.tsx
+++ b/src/renderer/src/components/Sender/Sender.tsx
@@ -1,4 +1,4 @@
-import type { AgentMode, ChatFeatures, IAttachment, IImage } from '@ant-chat/shared'
+import type { AgentMode, ChatFeatures, IAttachment, IImage, SkillManifest, WorkspaceFileSearchResult } from '@ant-chat/shared'
 import type { FileUIPart, LanguageModelUsage } from 'ai'
 import {
   Attachment,
@@ -37,9 +37,12 @@ import {
 import { Cable, ChevronDownIcon, FolderOpenIcon, GlobeIcon, HandIcon, PaperclipIcon, ShieldAlertIcon, ShieldCheckIcon } from 'lucide-react'
 import {
   useEffect,
+  useLayoutEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react'
+import { skillApi } from '@/api/skillApi'
 import workspaceApi from '@/api/workspaceApi'
 import { useChatSettingsContext } from '@/contexts/chatSettings'
 import {
@@ -54,7 +57,18 @@ import {
 import { setActiveConversationsId, useMessagesStore } from '@/store/messages'
 import { fileToBase64 } from '@/utils'
 import TypingEffect from '../TypingEffect'
+import {
+  getActiveReferenceTrigger,
+  insertReferenceToken,
+  isCompletedReferenceTrigger,
+  moveCursorAcrossReferenceToken,
+  removeReferenceTokenAtCursor,
+  snapCursorToReferenceTokenBoundary,
+  syncReferencedFiles,
+  syncSelectedSkill,
+} from './inputReferences'
 import MCPManagementPanel from './MCPManagementPanel'
+import { ReferenceSuggestionPanel } from './ReferenceSuggestionPanel'
 
 interface SenderProps {
   actions?: React.ReactNode
@@ -62,6 +76,8 @@ interface SenderProps {
     message: string,
     images: IImage[],
     attachments: IAttachment[],
+    referencedFiles: string[],
+    selectedSkill: string | undefined,
     features: ChatFeatures,
     agentMode: AgentMode,
   ) => void
@@ -200,12 +216,22 @@ function SenderContextUsageButton() {
 }
 
 function Sender({ actions, ...props }: SenderProps) {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const senderRef = useRef<HTMLDivElement | null>(null)
   const [workspaceLoading, setWorkspaceLoading] = useState(false)
   const [workspacePickerOpen, setWorkspacePickerOpen] = useState(false)
   const [workspaceData, setWorkspaceData] = useState<
     Awaited<ReturnType<typeof workspaceApi.listWorkspaces>> | null
   >(null)
   const [notice, setNotice] = useState('')
+  const [draft, setDraft] = useState('')
+  const [cursor, setCursor] = useState(0)
+  const [referencedFiles, setReferencedFiles] = useState<string[]>([])
+  const [selectedSkill, setSelectedSkill] = useState<string>()
+  const [fileResults, setFileResults] = useState<WorkspaceFileSearchResult[]>([])
+  const [skills, setSkills] = useState<SkillManifest[]>([])
+  const [highlightedIndex, setHighlightedIndex] = useState(0)
+  const [suggestionAnchorRect, setSuggestionAnchorRect] = useState<DOMRect | null>(null)
 
   const activeConversationsId = useMessagesStore(
     state => state.activeConversationsId,
@@ -228,6 +254,33 @@ function Sender({ actions, ...props }: SenderProps) {
     { value: 'full_managed', label: '完全访问权限', icon: <ShieldAlertIcon className="size-4" /> },
   ]
   const currentAgentModeOption = agentModeOptions.find(item => item.value === agentMode) || agentModeOptions[1]
+  const activeReferenceTrigger = useMemo(() => {
+    const trigger = getActiveReferenceTrigger(draft, cursor)
+    return isCompletedReferenceTrigger(trigger, referencedFiles, selectedSkill)
+      ? null
+      : trigger
+  }, [draft, cursor, referencedFiles, selectedSkill])
+  const enabledSkills = useMemo(
+    () => skills.filter(skill => skill.enabled),
+    [skills],
+  )
+  const filteredSkills = useMemo(() => {
+    if (!activeReferenceTrigger || activeReferenceTrigger.type !== 'skill') {
+      return []
+    }
+    const query = activeReferenceTrigger.query.toLowerCase()
+    return enabledSkills
+      .filter(skill =>
+        skill.name.toLowerCase().includes(query)
+        || (skill.description || '').toLowerCase().includes(query),
+      )
+      .slice(0, 20)
+  }, [activeReferenceTrigger, enabledSkills])
+  const suggestionItemCount = activeReferenceTrigger?.type === 'file'
+    ? fileResults.length
+    : activeReferenceTrigger?.type === 'skill'
+      ? filteredSkills.length
+      : 0
 
   const canSwitchWorkspace = !activeConversationsId && !hasMessage && !loading
   const selectableWorkspaces = useMemo(
@@ -247,7 +300,49 @@ function Sender({ actions, ...props }: SenderProps) {
 
   useEffect(() => {
     void refreshWorkspaceData()
+    void refreshSkills()
   }, [])
+
+  useEffect(() => {
+    if (!activeReferenceTrigger || activeReferenceTrigger.type !== 'file') {
+      setFileResults([])
+      return
+    }
+
+    const timer = window.setTimeout(() => {
+      void workspaceApi.searchWorkspaceFiles(activeReferenceTrigger.query, 50)
+        .then(setFileResults)
+        .catch(() => setFileResults([]))
+    }, 120)
+
+    return () => window.clearTimeout(timer)
+  }, [activeReferenceTrigger])
+
+  useLayoutEffect(() => {
+    if (!activeReferenceTrigger) {
+      setSuggestionAnchorRect(null)
+      return
+    }
+
+    const updateRect = () => {
+      const anchor = senderRef.current?.querySelector('[data-testid="chat-input-form"]')
+      const rect = anchor?.getBoundingClientRect()
+      setSuggestionAnchorRect(rect ?? null)
+    }
+
+    updateRect()
+    window.addEventListener('resize', updateRect)
+    window.addEventListener('scroll', updateRect, true)
+
+    return () => {
+      window.removeEventListener('resize', updateRect)
+      window.removeEventListener('scroll', updateRect, true)
+    }
+  }, [activeReferenceTrigger, draft])
+
+  useEffect(() => {
+    setHighlightedIndex(0)
+  }, [activeReferenceTrigger?.type, activeReferenceTrigger?.query, suggestionItemCount])
 
   useEffect(() => {
     if (!currentWorkspacePath) {
@@ -269,6 +364,11 @@ function Sender({ actions, ...props }: SenderProps) {
   async function refreshWorkspaceData() {
     const data = await workspaceApi.listWorkspaces()
     setWorkspaceData(data)
+  }
+
+  async function refreshSkills() {
+    const data = await skillApi.listSkills()
+    setSkills(data.skills)
   }
 
   async function handleSwitchWorkspace(nextWorkspacePath: string) {
@@ -300,9 +400,164 @@ function Sender({ actions, ...props }: SenderProps) {
     }
   }
 
+  function updateDraft(nextText: string, nextCursor?: number) {
+    setDraft(nextText)
+    setReferencedFiles(prev => syncReferencedFiles(nextText, prev))
+    setSelectedSkill(prev => syncSelectedSkill(nextText, prev))
+    if (typeof nextCursor === 'number') {
+      setCursor(nextCursor)
+    }
+  }
+
+  function selectFileReference(file: WorkspaceFileSearchResult) {
+    if (!activeReferenceTrigger || activeReferenceTrigger.type !== 'file') {
+      return
+    }
+
+    const token = `@${file.path}`
+    const next = insertReferenceToken(draft, activeReferenceTrigger, token)
+    updateDraft(next.text, next.cursor)
+    setReferencedFiles(prev => Array.from(new Set([...prev, file.path])))
+    requestAnimationFrame(() => {
+      textareaRef.current?.focus()
+      textareaRef.current?.setSelectionRange(next.cursor, next.cursor)
+    })
+  }
+
+  function selectSkillReference(skill: SkillManifest) {
+    if (!activeReferenceTrigger || activeReferenceTrigger.type !== 'skill') {
+      return
+    }
+
+    const token = `/${skill.name}`
+    const next = insertReferenceToken(draft, activeReferenceTrigger, token)
+    updateDraft(next.text, next.cursor)
+    setSelectedSkill(skill.name)
+    requestAnimationFrame(() => {
+      textareaRef.current?.focus()
+      textareaRef.current?.setSelectionRange(next.cursor, next.cursor)
+    })
+  }
+
+  function selectHighlightedReference() {
+    if (!activeReferenceTrigger || suggestionItemCount === 0) {
+      return false
+    }
+
+    const index = Math.min(highlightedIndex, suggestionItemCount - 1)
+    if (activeReferenceTrigger.type === 'file') {
+      selectFileReference(fileResults[index])
+      return true
+    }
+
+    selectSkillReference(filteredSkills[index])
+    return true
+  }
+
+  function handleTextareaKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (
+      (event.key === 'ArrowLeft' || event.key === 'ArrowRight')
+      && !event.shiftKey
+      && !event.altKey
+      && !event.metaKey
+      && !event.ctrlKey
+      && event.currentTarget.selectionStart === event.currentTarget.selectionEnd
+    ) {
+      const nextCursor = moveCursorAcrossReferenceToken(
+        draft,
+        event.currentTarget.selectionStart,
+        event.key,
+        referencedFiles,
+        selectedSkill,
+      )
+      if (nextCursor !== null) {
+        event.preventDefault()
+        setCursor(nextCursor)
+        requestAnimationFrame(() => {
+          textareaRef.current?.setSelectionRange(nextCursor, nextCursor)
+        })
+        return
+      }
+    }
+
+    if (
+      (event.key === 'Backspace' || event.key === 'Delete')
+      && event.currentTarget.selectionStart === event.currentTarget.selectionEnd
+    ) {
+      const next = removeReferenceTokenAtCursor(
+        draft,
+        event.currentTarget.selectionStart,
+        event.key,
+        referencedFiles,
+        selectedSkill,
+      )
+      if (next) {
+        event.preventDefault()
+        updateDraft(next.text, next.cursor)
+        requestAnimationFrame(() => {
+          textareaRef.current?.focus()
+          textareaRef.current?.setSelectionRange(next.cursor, next.cursor)
+        })
+        return
+      }
+    }
+
+    if (!activeReferenceTrigger) {
+      return
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      setCursor(0)
+      return
+    }
+
+    if (event.key === 'ArrowDown' && suggestionItemCount > 0) {
+      event.preventDefault()
+      setHighlightedIndex(prev => (prev + 1) % suggestionItemCount)
+      return
+    }
+
+    if (event.key === 'ArrowUp' && suggestionItemCount > 0) {
+      event.preventDefault()
+      setHighlightedIndex(prev => (prev - 1 + suggestionItemCount) % suggestionItemCount)
+      return
+    }
+
+    if (event.key === 'Enter' && !event.shiftKey && suggestionItemCount > 0) {
+      event.preventDefault()
+      selectHighlightedReference()
+    }
+  }
+
+  function updateCursorFromTextarea(element: HTMLTextAreaElement) {
+    const nextCursor = snapCursorToReferenceTokenBoundary(
+      draft,
+      element.selectionStart,
+      referencedFiles,
+      selectedSkill,
+    )
+    setCursor(nextCursor)
+    if (nextCursor !== element.selectionStart) {
+      requestAnimationFrame(() => {
+        textareaRef.current?.setSelectionRange(nextCursor, nextCursor)
+      })
+    }
+  }
+
+  function handleTextareaKeyUp(event: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (['ArrowDown', 'ArrowUp', 'Enter', 'Escape'].includes(event.key)) {
+      return
+    }
+
+    updateCursorFromTextarea(event.currentTarget)
+  }
+
   async function handleSubmit(message: { text: string, files: FileUIPart[] }) {
     const images: IImage[] = []
     const attachments: IAttachment[] = []
+    const nextReferencedFiles = syncReferencedFiles(message.text, referencedFiles)
+    const nextSelectedSkill = syncSelectedSkill(message.text, selectedSkill)
 
     const files = await Promise.all(
       message.files.map((part, index) => filePartToAttachment(part, index)),
@@ -321,14 +576,19 @@ function Sender({ actions, ...props }: SenderProps) {
       }
     })
 
-    props.onSubmit?.(message.text, images, attachments, {
+    props.onSubmit?.(message.text, images, attachments, nextReferencedFiles, nextSelectedSkill, {
       enableMCP: mcpEnabled,
       onlineSearch,
     }, agentMode)
+    setDraft('')
+    setCursor(0)
+    setReferencedFiles([])
+    setSelectedSkill(undefined)
   }
 
   return (
     <div
+      ref={senderRef}
       className={`
         ${!hasMessage ? 'absolute inset-x-3 top-[50%] translate-y-[-50%]' : ''}
       `}
@@ -353,9 +613,28 @@ function Sender({ actions, ...props }: SenderProps) {
         <PromptInputBody className="bg-transparent px-1 pt-1">
           <SenderAttachmentsPreview />
           <PromptInputTextarea
+            ref={textareaRef}
             className="max-h-48 min-h-24 border-0 bg-transparent p-1"
             data-testid="chat-input"
+            value={draft}
+            onChange={(event) => {
+              updateDraft(event.currentTarget.value, event.currentTarget.selectionStart)
+            }}
+            onClick={event => updateCursorFromTextarea(event.currentTarget)}
+            onKeyDown={handleTextareaKeyDown}
+            onKeyUp={handleTextareaKeyUp}
             placeholder="Enter发送消息，Shift+Enter换行"
+          />
+          <ReferenceSuggestionPanel
+            trigger={activeReferenceTrigger}
+            files={fileResults}
+            skills={filteredSkills}
+            hasWorkspace={Boolean(workspaceData?.currentWorkspacePath)}
+            hasEnabledSkills={enabledSkills.length > 0}
+            highlightedIndex={highlightedIndex}
+            anchorRect={suggestionAnchorRect}
+            onSelectFile={selectFileReference}
+            onSelectSkill={selectSkillReference}
           />
         </PromptInputBody>
 

--- a/src/renderer/src/components/Sender/__tests__/Sender.spec.tsx
+++ b/src/renderer/src/components/Sender/__tests__/Sender.spec.tsx
@@ -1,0 +1,151 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { TooltipProvider } from '@workspace/ui/components/tooltip'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ChatSettingsContext, DEFAULT_SETTINGS } from '@/contexts/chatSettings'
+import { useChatSttingsStore } from '@/store/chatSettings'
+import { useConversationsStore } from '@/store/conversation'
+import { useMessagesStore } from '@/store/messages'
+import Sender from '../Sender'
+
+const mocks = vi.hoisted(() => ({
+  searchWorkspaceFiles: vi.fn(),
+}))
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.mock('@/api/workspaceApi', () => ({
+  default: {
+    listWorkspaces: vi.fn(async () => ({
+      currentWorkspacePath: '/tmp/workspace',
+      workspaces: [
+        { path: '/tmp/workspace', displayName: 'workspace' },
+      ],
+    })),
+    openWorkspace: vi.fn(),
+    searchWorkspaceFiles: mocks.searchWorkspaceFiles,
+  },
+}))
+
+vi.mock('@/api/skillApi', () => ({
+  skillApi: {
+    listSkills: vi.fn(async () => ({ skills: [] })),
+  },
+}))
+
+function renderSender(onSubmit = vi.fn()) {
+  render(
+    <TooltipProvider>
+      <ChatSettingsContext
+        value={{
+          settings: { ...DEFAULT_SETTINGS, modelId: 'test-model' },
+          updateSettings: vi.fn(),
+        }}
+      >
+        <Sender onSubmit={onSubmit} />
+      </ChatSettingsContext>
+    </TooltipProvider>,
+  )
+
+  return onSubmit
+}
+
+function setTextareaValue(textarea: HTMLTextAreaElement, value: string) {
+  fireEvent.change(textarea, {
+    target: {
+      value,
+      selectionStart: value.length,
+      selectionEnd: value.length,
+    },
+  })
+}
+
+describe('sender reference token overlay', () => {
+  beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+    Element.prototype.scrollIntoView = vi.fn()
+    mocks.searchWorkspaceFiles.mockResolvedValue([
+      { path: 'resume.md', name: 'resume.md', type: 'file' },
+    ])
+    useMessagesStore.setState({
+      activeConversationsId: '',
+      messages: [],
+      pageIndex: 0,
+      pageSize: 6,
+      messageTotal: 1,
+    })
+    useConversationsStore.setState({
+      activeConversationsId: '',
+      conversations: [],
+      abortCallbacks: [],
+      pageIndex: 0,
+      pageSize: 20,
+      conversationsTotal: 1,
+      streamingConversationIds: new Set<string>(),
+      loadVersion: 0,
+      currentWorkspacePath: '/tmp/workspace',
+      workspaceConversations: {},
+    })
+    useChatSttingsStore.setState({
+      onlineSearch: false,
+      enableMCP: false,
+      agentMode: 'hybrid',
+    })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('手动输入未确认引用时不渲染 token', async () => {
+    renderSender()
+    await screen.findByText('workspace')
+
+    const textarea = screen.getByTestId('chat-input') as HTMLTextAreaElement
+    setTextareaValue(textarea, '看 @resume.md')
+
+    expect(screen.queryByTestId('reference-token')).toBeNull()
+    expect(textarea.value).toBe('看 @resume.md')
+  })
+
+  it('选择文件引用后渲染 overlay token，提交后清空', async () => {
+    const onSubmit = renderSender()
+    await screen.findByText('workspace')
+    const textarea = screen.getByTestId('chat-input') as HTMLTextAreaElement
+
+    setTextareaValue(textarea, '看 @res')
+
+    await waitFor(() => {
+      expect(mocks.searchWorkspaceFiles).toHaveBeenCalledWith('res', 50)
+    })
+
+    fireEvent.mouseDown(await screen.findByText('resume.md'))
+
+    await waitFor(() => {
+      expect(textarea.value).toBe('看 @resume.md ')
+    })
+    expect(screen.getByTestId('reference-token').textContent).toBe('@resume.md')
+
+    fireEvent.click(screen.getByTestId('chat-submit'))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        '看 @resume.md ',
+        [],
+        [],
+        ['resume.md'],
+        undefined,
+        { enableMCP: false, onlineSearch: false },
+        'hybrid',
+      )
+    })
+    await waitFor(() => {
+      expect(textarea.value).toBe('')
+    })
+    expect(screen.queryByTestId('reference-token')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/Sender/__tests__/inputReferences.spec.ts
+++ b/src/renderer/src/components/Sender/__tests__/inputReferences.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getActiveReferenceTrigger,
+  insertReferenceToken,
+  isCompletedReferenceTrigger,
+  moveCursorAcrossReferenceToken,
+  removeReferenceTokenAtCursor,
+  snapCursorToReferenceTokenBoundary,
+  syncReferencedFiles,
+  syncSelectedSkill,
+} from '../inputReferences'
+
+describe('inputReferences', () => {
+  it('识别当前光标前的 @ 或 / trigger', () => {
+    expect(getActiveReferenceTrigger('分析 @src', 7)).toEqual({
+      type: 'file',
+      query: 'src',
+      start: 3,
+      end: 7,
+    })
+    expect(getActiveReferenceTrigger('/code', 5)).toMatchObject({
+      type: 'skill',
+      query: 'code',
+      start: 0,
+      end: 5,
+    })
+  })
+
+  it('选择候选后替换 trigger token', () => {
+    const trigger = getActiveReferenceTrigger('分析 @sr', 6)!
+    expect(insertReferenceToken('分析 @sr', trigger, '@src/a.ts')).toEqual({
+      text: '分析 @src/a.ts ',
+      cursor: 13,
+    })
+  })
+
+  it('根据输入文本同步已选上下文', () => {
+    expect(syncReferencedFiles('看 @src/a.ts', ['src/a.ts', 'src/b.ts'])).toEqual(['src/a.ts'])
+    expect(syncSelectedSkill('用 /writer 写', 'writer')).toBe('writer')
+    expect(syncSelectedSkill('用 writer 写', 'writer')).toBeUndefined()
+  })
+
+  it('已选引用 token 不再作为 active trigger', () => {
+    const trigger = getActiveReferenceTrigger('@resume.md', '@resume.md'.length)
+    expect(isCompletedReferenceTrigger(trigger, ['resume.md'])).toBe(true)
+    expect(isCompletedReferenceTrigger(trigger, ['other.md'])).toBe(false)
+  })
+
+  it('backspace/delete 将引用 token 作为整体删除', () => {
+    expect(removeReferenceTokenAtCursor('看 @resume.md 后续', 7, 'Backspace', ['resume.md'])).toEqual({
+      text: '看 后续',
+      cursor: 2,
+    })
+    expect(removeReferenceTokenAtCursor('看 @resume.md 后续', 2, 'Delete', ['resume.md'])).toEqual({
+      text: '看 后续',
+      cursor: 2,
+    })
+    expect(removeReferenceTokenAtCursor('/writer 继续', 8, 'Backspace', [], 'writer')).toEqual({
+      text: '继续',
+      cursor: 0,
+    })
+  })
+
+  it('左右方向键跳过引用 token', () => {
+    expect(moveCursorAcrossReferenceToken('看 @resume.md 后续', 7, 'ArrowLeft', ['resume.md'])).toBe(2)
+    expect(moveCursorAcrossReferenceToken('看 @resume.md 后续', 3, 'ArrowRight', ['resume.md'])).toBe(13)
+    expect(moveCursorAcrossReferenceToken('看 @resume.md 后续', 0, 'ArrowRight', ['resume.md'])).toBeNull()
+  })
+
+  it('点击到引用 token 中间时吸附到边界', () => {
+    expect(snapCursorToReferenceTokenBoundary('看 @resume.md 后续', 7, ['resume.md'])).toBe(13)
+    expect(snapCursorToReferenceTokenBoundary('看 @resume.md 后续', 4, ['resume.md'])).toBe(2)
+  })
+})

--- a/src/renderer/src/components/Sender/__tests__/inputReferences.spec.ts
+++ b/src/renderer/src/components/Sender/__tests__/inputReferences.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  buildReferenceInputParts,
   getActiveReferenceTrigger,
   insertReferenceToken,
   isCompletedReferenceTrigger,
@@ -38,6 +39,8 @@ describe('inputReferences', () => {
     expect(syncReferencedFiles('看 @src/a.ts', ['src/a.ts', 'src/b.ts'])).toEqual(['src/a.ts'])
     expect(syncSelectedSkill('用 /writer 写', 'writer')).toBe('writer')
     expect(syncSelectedSkill('用 writer 写', 'writer')).toBeUndefined()
+    expect(syncReferencedFiles('看 @src/a.tsx', ['src/a.ts'])).toEqual([])
+    expect(syncSelectedSkill('用 /writer-pro 写', 'writer')).toBeUndefined()
   })
 
   it('已选引用 token 不再作为 active trigger', () => {
@@ -70,5 +73,33 @@ describe('inputReferences', () => {
   it('点击到引用 token 中间时吸附到边界', () => {
     expect(snapCursorToReferenceTokenBoundary('看 @resume.md 后续', 7, ['resume.md'])).toBe(13)
     expect(snapCursorToReferenceTokenBoundary('看 @resume.md 后续', 4, ['resume.md'])).toBe(2)
+  })
+
+  it('为 overlay 拆分已确认引用 token', () => {
+    expect(buildReferenceInputParts('看 @resume.md 和 @notes.md /writer 后续', ['resume.md', 'notes.md'], 'writer')).toEqual([
+      { type: 'text', text: '看 ', offset: 0 },
+      { type: 'file', text: '@resume.md', offset: 2 },
+      { type: 'text', text: ' 和 ', offset: 12 },
+      { type: 'file', text: '@notes.md', offset: 15 },
+      { type: 'text', text: ' ', offset: 24 },
+      { type: 'skill', text: '/writer', offset: 25 },
+      { type: 'text', text: ' 后续', offset: 32 },
+    ])
+  })
+
+  it('overlay 不高亮未确认或非独立 token', () => {
+    expect(buildReferenceInputParts('看 @resume.md @draft.md @resume.mdx', ['resume.md'])).toEqual([
+      { type: 'text', text: '看 ', offset: 0 },
+      { type: 'file', text: '@resume.md', offset: 2 },
+      { type: 'text', text: ' @draft.md @resume.mdx', offset: 12 },
+    ])
+  })
+
+  it('overlay 支持重复引用同一个 token', () => {
+    expect(buildReferenceInputParts('@resume.md 再看 @resume.md', ['resume.md'])).toEqual([
+      { type: 'file', text: '@resume.md', offset: 0 },
+      { type: 'text', text: ' 再看 ', offset: 10 },
+      { type: 'file', text: '@resume.md', offset: 14 },
+    ])
   })
 })

--- a/src/renderer/src/components/Sender/inputReferences.ts
+++ b/src/renderer/src/components/Sender/inputReferences.ts
@@ -1,0 +1,167 @@
+export interface ActiveReferenceTrigger {
+  type: 'file' | 'skill'
+  query: string
+  start: number
+  end: number
+}
+
+interface ReferenceTokenRange {
+  start: number
+  end: number
+  trailingSpaceEnd: number
+}
+
+export function getActiveReferenceTrigger(text: string, cursor: number): ActiveReferenceTrigger | null {
+  const beforeCursor = text.slice(0, cursor)
+  const match = /(^|\s)([@/])(\S*)$/.exec(beforeCursor)
+  if (!match || match.index === undefined) {
+    return null
+  }
+
+  const prefixLength = match[1].length
+  const start = match.index + prefixLength
+
+  return {
+    type: match[2] === '@' ? 'file' : 'skill',
+    query: match[3],
+    start,
+    end: cursor,
+  }
+}
+
+export function insertReferenceToken(
+  text: string,
+  trigger: ActiveReferenceTrigger,
+  token: string,
+): { text: string, cursor: number } {
+  const before = text.slice(0, trigger.start)
+  const after = text.slice(trigger.end)
+  const needsSpace = after.length === 0 || !/^\s/.test(after)
+  const nextText = `${before}${token}${needsSpace ? ' ' : ''}${after}`
+
+  return {
+    text: nextText,
+    cursor: before.length + token.length + (needsSpace ? 1 : 0),
+  }
+}
+
+export function syncReferencedFiles(text: string, selected: string[]): string[] {
+  return selected.filter(file => text.includes(`@${file}`))
+}
+
+export function syncSelectedSkill(text: string, selected?: string): string | undefined {
+  if (!selected) {
+    return undefined
+  }
+  return text.includes(`/${selected}`) ? selected : undefined
+}
+
+export function isCompletedReferenceTrigger(
+  trigger: ActiveReferenceTrigger | null,
+  referencedFiles: string[],
+  selectedSkill?: string,
+): boolean {
+  if (!trigger) {
+    return false
+  }
+
+  if (trigger.type === 'file') {
+    return referencedFiles.includes(trigger.query)
+  }
+
+  return selectedSkill === trigger.query
+}
+
+export function removeReferenceTokenAtCursor(
+  text: string,
+  cursor: number,
+  key: 'Backspace' | 'Delete',
+  referencedFiles: string[],
+  selectedSkill?: string,
+): { text: string, cursor: number } | null {
+  const ranges = getReferenceTokenRanges(text, referencedFiles, selectedSkill)
+
+  for (const range of ranges) {
+    const shouldRemove = key === 'Backspace'
+      ? cursor > range.start && cursor <= range.trailingSpaceEnd
+      : cursor >= range.start && cursor < range.end
+
+    if (!shouldRemove) {
+      continue
+    }
+
+    return {
+      text: `${text.slice(0, range.start)}${text.slice(range.trailingSpaceEnd)}`,
+      cursor: range.start,
+    }
+  }
+
+  return null
+}
+
+export function moveCursorAcrossReferenceToken(
+  text: string,
+  cursor: number,
+  key: 'ArrowLeft' | 'ArrowRight',
+  referencedFiles: string[],
+  selectedSkill?: string,
+): number | null {
+  const ranges = getReferenceTokenRanges(text, referencedFiles, selectedSkill)
+
+  for (const range of ranges) {
+    if (key === 'ArrowLeft' && cursor > range.start && cursor <= range.end) {
+      return range.start
+    }
+    if (key === 'ArrowRight' && cursor >= range.start && cursor < range.end) {
+      return range.trailingSpaceEnd
+    }
+  }
+
+  return null
+}
+
+export function snapCursorToReferenceTokenBoundary(
+  text: string,
+  cursor: number,
+  referencedFiles: string[],
+  selectedSkill?: string,
+): number {
+  const ranges = getReferenceTokenRanges(text, referencedFiles, selectedSkill)
+
+  for (const range of ranges) {
+    if (cursor > range.start && cursor < range.end) {
+      const distanceToStart = cursor - range.start
+      const distanceToEnd = range.end - cursor
+      return distanceToStart < distanceToEnd ? range.start : range.trailingSpaceEnd
+    }
+  }
+
+  return cursor
+}
+
+function getReferenceTokenRanges(
+  text: string,
+  referencedFiles: string[],
+  selectedSkill?: string,
+): ReferenceTokenRange[] {
+  const tokens = [
+    ...referencedFiles.map(file => `@${file}`),
+    ...(selectedSkill ? [`/${selectedSkill}`] : []),
+  ]
+  const ranges: ReferenceTokenRange[] = []
+
+  for (const token of tokens) {
+    let start = text.indexOf(token)
+    while (start !== -1) {
+      const end = start + token.length
+      ranges.push({
+        start,
+        end,
+        trailingSpaceEnd: text[end] === ' ' ? end + 1 : end,
+      })
+      start = text.indexOf(token, end)
+    }
+  }
+
+  return ranges.sort((a, b) => a.start - b.start)
+}

--- a/src/renderer/src/components/Sender/inputReferences.ts
+++ b/src/renderer/src/components/Sender/inputReferences.ts
@@ -6,10 +6,16 @@ export interface ActiveReferenceTrigger {
 }
 
 interface ReferenceTokenRange {
+  type: 'file' | 'skill'
   start: number
   end: number
   trailingSpaceEnd: number
+  text: string
 }
+
+export type ReferenceInputPart
+  = | { type: 'text', text: string, offset: number }
+    | { type: 'file' | 'skill', text: string, offset: number }
 
 export function getActiveReferenceTrigger(text: string, cursor: number): ActiveReferenceTrigger | null {
   const beforeCursor = text.slice(0, cursor)
@@ -46,14 +52,21 @@ export function insertReferenceToken(
 }
 
 export function syncReferencedFiles(text: string, selected: string[]): string[] {
-  return selected.filter(file => text.includes(`@${file}`))
+  const ranges = getReferenceTokenRanges(text, selected)
+  return selected.filter(file =>
+    ranges.some(range => range.type === 'file' && range.text === `@${file}`),
+  )
 }
 
 export function syncSelectedSkill(text: string, selected?: string): string | undefined {
   if (!selected) {
     return undefined
   }
-  return text.includes(`/${selected}`) ? selected : undefined
+
+  const ranges = getReferenceTokenRanges(text, [], selected)
+  return ranges.some(range => range.type === 'skill' && range.text === `/${selected}`)
+    ? selected
+    : undefined
 }
 
 export function isCompletedReferenceTrigger(
@@ -139,6 +152,35 @@ export function snapCursorToReferenceTokenBoundary(
   return cursor
 }
 
+export function buildReferenceInputParts(
+  text: string,
+  referencedFiles: string[],
+  selectedSkill?: string,
+): ReferenceInputPart[] {
+  const parts: ReferenceInputPart[] = []
+  const ranges = getReferenceTokenRanges(text, referencedFiles, selectedSkill)
+  let cursor = 0
+
+  for (const range of ranges) {
+    if (range.start < cursor) {
+      continue
+    }
+
+    if (range.start > cursor) {
+      parts.push({ type: 'text', text: text.slice(cursor, range.start), offset: cursor })
+    }
+
+    parts.push({ type: range.type, text: range.text, offset: range.start })
+    cursor = range.end
+  }
+
+  if (cursor < text.length) {
+    parts.push({ type: 'text', text: text.slice(cursor), offset: cursor })
+  }
+
+  return parts.length > 0 ? parts : [{ type: 'text', text, offset: 0 }]
+}
+
 function getReferenceTokenRanges(
   text: string,
   referencedFiles: string[],
@@ -154,11 +196,19 @@ function getReferenceTokenRanges(
     let start = text.indexOf(token)
     while (start !== -1) {
       const end = start + token.length
-      ranges.push({
-        start,
-        end,
-        trailingSpaceEnd: text[end] === ' ' ? end + 1 : end,
-      })
+      const hasStartBoundary = start === 0 || /\s/.test(text[start - 1])
+      const hasEndBoundary = end === text.length || /\s/.test(text[end])
+
+      if (hasStartBoundary && hasEndBoundary) {
+        ranges.push({
+          type: token.startsWith('@') ? 'file' : 'skill',
+          start,
+          end,
+          trailingSpaceEnd: text[end] === ' ' ? end + 1 : end,
+          text: token,
+        })
+      }
+
       start = text.indexOf(token, end)
     }
   }

--- a/src/renderer/src/pages/Settings/Settings.tsx
+++ b/src/renderer/src/pages/Settings/Settings.tsx
@@ -15,7 +15,10 @@ export default function SettingsPage() {
 
   return (
     <div className="grid h-(--mainHeight) w-full grid-cols-[max-content_1fr]">
-      <div className="h-full w-50 border-r border-(--border-color) p-2 py-4">
+      <div
+        data-testid="settings-nav"
+        className="h-full w-50 border-r border-(--border-color) px-2 pt-12 pb-4"
+      >
         <div className="flex flex-col gap-3">
           {
             menus.map(item => (

--- a/tests/ui/gui.spec.tsx
+++ b/tests/ui/gui.spec.tsx
@@ -139,16 +139,26 @@ describe('gui ui flow', () => {
     })
   })
 
-  it('启动后进入聊天页，并可在设置和新对话之间路由切换', async () => {
+  it('opens the settings window from chat and keeps new chat available', async () => {
+    vi.mocked(window.electron.ipcRenderer.invoke).mockResolvedValue({ success: true, data: null })
     renderGui('/')
 
     expect(await screen.findByTestId('chat-input')).toBeInTheDocument()
 
     fireEvent.click(screen.getByTestId('sidebar-settings'))
-    expect(await screen.findByTestId('settings-nav-general')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(window.electron.ipcRenderer.invoke).toHaveBeenCalled()
+    })
 
     fireEvent.click(screen.getByTestId('sidebar-new-chat'))
     expect(await screen.findByTestId('chat-input')).toBeInTheDocument()
+  })
+
+  it('reserves top space for native window controls in settings navigation', async () => {
+    renderSettingsWindow('/settings/general')
+
+    expect(await screen.findByTestId('settings-nav-general')).toBeInTheDocument()
+    expect(screen.getByTestId('settings-nav')).toHaveClass('pt-12')
   })
 
   it('未选择模型时发送消息会提示用户先选择模型', async () => {
@@ -290,6 +300,31 @@ function renderGui(initialPath: string) {
             { path: 'general', element: <div data-testid="settings-general-page">通用设置</div> },
           ],
         },
+      ],
+    },
+  ], {
+    initialEntries: [initialPath],
+  })
+
+  return render(<RouterProvider router={router} />)
+}
+
+function renderSettingsWindow(initialPath: string) {
+  const router = createMemoryRouter([
+    {
+      path: '/',
+      Component: SettingsPage,
+      children: [
+        { index: true, element: <Navigate replace to="./general" /> },
+        { path: 'general', element: <div data-testid="settings-general-page">General settings</div> },
+      ],
+    },
+    {
+      path: '/settings',
+      Component: SettingsPage,
+      children: [
+        { index: true, element: <Navigate replace to="./general" /> },
+        { path: 'general', element: <div data-testid="settings-general-page">General settings</div> },
       ],
     },
   ], {

--- a/tests/ui/gui.spec.tsx
+++ b/tests/ui/gui.spec.tsx
@@ -43,6 +43,9 @@ const mocks = vi.hoisted(() => ({
   provider: {
     getAllAbvailableModels: vi.fn(),
   },
+  skill: {
+    listSkills: vi.fn(async () => ({ skills: [] })),
+  },
   workspace: {
     chooseWorkspace: vi.fn(async () => null),
     listWorkspaces: vi.fn(),
@@ -64,6 +67,10 @@ vi.mock('@/api/generalSettingsApi', () => ({
 
 vi.mock('@/api/providerApi', () => ({
   providerApi: mocks.provider,
+}))
+
+vi.mock('@/api/skillApi', () => ({
+  skillApi: mocks.skill,
 }))
 
 vi.mock('@/api/workspaceApi', () => ({
@@ -105,6 +112,7 @@ describe('gui ui flow', () => {
     useAgentStore.setState({ pendingByTask: {}, tasks: {} })
 
     mocks.provider.getAllAbvailableModels.mockResolvedValue([])
+    mocks.skill.listSkills.mockResolvedValue({ skills: [] })
     mocks.workspace.listWorkspaces.mockResolvedValue({
       currentWorkspacePath: guiWorkspacePath,
       workspaces: [{


### PR DESCRIPTION
## Summary

- Render confirmed file and skill references in the sender textarea with a lightweight overlay.
- Keep the native textarea as the source of truth for input, selection, IME, keyboard handling, and submit payloads.
- Tighten reference token matching so selected references only sync on standalone token boundaries.
- Add missing UI-test skill API mock now that Sender loads enabled skills on mount.

## User Impact

- Selected references like `@resume.md` are visually distinguished in the input without switching editors.
- Cursor, selection, and typed text remain aligned with the underlying textarea.
- Unconfirmed or partial references are not styled as tokens.

## Validation

- `pnpm test:ui`
- `pnpm vitest -c ./vitest.config.ts run src/renderer/src/components/Sender/__tests__/inputReferences.spec.ts src/renderer/src/components/Sender/__tests__/Sender.spec.tsx`
- `pnpm type-check`
- `pnpm lint`
