### PR TITLE
[codex] avoid leading newline in rendered messages

### DIFF
--- a/src/renderer/src/utils/__tests__/messageTransform.spec.ts
+++ b/src/renderer/src/utils/__tests__/messageTransform.spec.ts
@@ -1,0 +1,32 @@
+import type { IMessage } from '@ant-chat/shared'
+import { describe, expect, it } from 'vitest'
+import { transformMessageContent } from '../messageTransform'
+
+function createMessage(content: IMessage['content']): IMessage {
+  return {
+    attachments: [],
+    content,
+    convId: 'conv-1',
+    createdAt: 1,
+    id: 'msg-1',
+    images: [],
+    role: 'user',
+    status: 'success',
+    updatedAt: 1,
+  } as IMessage
+}
+
+describe('messageTransform', () => {
+  it('数组文本内容不会在首段前增加换行', () => {
+    expect(transformMessageContent(createMessage([
+      { text: '@resume.md 现在看下效果', type: 'text' },
+    ]))).toBe('@resume.md 现在看下效果')
+  })
+
+  it('多个内容块之间保留单个换行', () => {
+    expect(transformMessageContent(createMessage([
+      { text: '第一段', type: 'text' },
+      { text: '第二段', type: 'text' },
+    ]))).toBe('第一段\n第二段')
+  })
+})

--- a/src/renderer/src/utils/messageTransform.ts
+++ b/src/renderer/src/utils/messageTransform.ts
@@ -37,17 +37,19 @@ export function transformMessageContent(message: IMessage): string {
     return message.content
   }
 
-  return message.content.reduce((acc, block, index) => {
+  return message.content.reduce((acc, block) => {
+    const prefix = acc ? '\n' : ''
+
     if (block.type === 'image') {
       return block?.url
-        ? `\n![](${block.url})`
-        : `${acc}\n![](data:${block.mimeType};base64,${block.data})\n`
+        ? `${acc}${prefix}![](${block.url})`
+        : `${acc}${prefix}![](data:${block.mimeType};base64,${block.data})`
     }
     else if (block.type === 'error') {
-      return index === 0 ? `${acc}\n${block.error}` : `${acc}\n> [!CAUTION]\n> ${block.error}`
+      return acc ? `${acc}\n> [!CAUTION]\n> ${block.error}` : block.error
     }
     else {
-      return `${acc}\n${block.text}`
+      return `${acc}${prefix}${block.text}`
     }
   }, '')
 }


### PR DESCRIPTION
## Summary

- Fix `transformMessageContent` so the first content block is not prefixed with a newline.
- Preserve single newline separators between multiple content blocks.
- Add regression coverage for array text message rendering.

## User Impact

- User messages rendered through the reference-token path no longer show an extra blank line before the text.
- Mixed message content still keeps readable block separation.

## Validation

- `pnpm vitest -c ./vitest.config.ts run src/renderer/src/utils/__tests__/messageTransform.spec.ts src/renderer/src/components/Sender/__tests__/inputReferences.spec.ts src/renderer/src/components/Sender/__tests__/Sender.spec.tsx`
- `pnpm test:ui`
- `pnpm type-check`
- `pnpm lint`