### PR TITLE
docs(runtime): add session layer boundary design document

### DIFF
--- a/packages/runtime/docs/session-boundary.md
+++ b/packages/runtime/docs/session-boundary.md
@@ -1,0 +1,158 @@
+# Session 层边界设计
+
+## 1. 当前架构问题
+
+```
+packages/runtime/             ← 纯逻辑，平台无关。✅
+packages/shared/              ← 共享类型和接口。✅
+src/main/agent/adapters/      ← 平台适配器，实现 shared 接口。✅
+src/main/agent/runtime/agentTurnService.ts  ← 编排逻辑，直接 import @main/db/services。❌
+```
+
+编排逻辑（创建 conversation、写入消息、加载历史、构建上下文、启动 runtime loop）被硬编码在 Electron 主进程中。做 Web 版时这些逻辑无法复用。
+
+## 2. Session 定义
+
+在 ant-chat 中，**Session** 指一次用户交互的完整生命周期：
+
+```
+用户发送消息 → 创建 conversation / message → 加载历史 → 构建上下文
+→ 启动 AgentRuntime loop → 流式响应 → 工具调用 → 审批 → 完成/失败
+```
+
+session 层负责**编排**这个生命周期，runtime 的 loop 层负责**执行**单个 turn 内的 step 循环。
+
+## 3. 目标架构
+
+```
+                        ┌─────────────────────────────────────┐
+                        │    packages/runtime/src/session/    │  ← 新增核心
+                        │    SessionOrchestrator               │
+                        │    .startTurn(options) → TurnResult  │
+                        │    内部编排：                         │
+                        │    1. 创建/获取 conversation          │
+                        │    2. 创建 user message              │
+                        │    3. 加载历史 → LoopMessage[]       │
+                        │    4. 构建 system prompt + tools      │
+                        │    5. 启动 AgentRuntime.startTask()  │
+                        │    6. 监听事件处理完成/失败           │
+                        └──────┬──────────────┬───────────────┘
+                               │ 依赖接口      │
+                        ┌──────┴──────────────┴───────────────┐
+                        │  ISessionStore      (新增)          │
+                        │  IModelResolver     (已有)          │
+                        │  IToolProvider      (已有，隐式)     │
+                        │  IAIProviderFactory (已有)           │
+                        │  IAgentEventEmitter (已有)           │
+                        │  ILogger            (已有)          │
+                        └─────────────────────────────────────┘
+                               │              │
+                        ┌──────┴──┐    ┌──────┴──┐
+                        │ Electron│    │   Web   │
+                        │  Dexie  │    │  PG/REST│
+                        └─────────┘    └─────────┘
+```
+
+## 4. 各层职责边界
+
+| 层           | 负责                                                                               | 不负责                                        |
+| ------------ | ---------------------------------------------------------------------------------- | --------------------------------------------- |
+| **session**  | 编排完整 turn 生命周期；管理 conversation/message CRUD 流程；协调 adapter 调用顺序 | 不执行 AI loop；不处理工具调用；不直接访问 DB |
+| **loop**     | 单 turn 内的 step 循环；模型流式调用；工具执行；token 压缩                         | 不创建 conversation/message；不知道 IPC/DB    |
+| **policy**   | 工具调用前的策略检查；审批流程控制                                                 | 不关心业务上下文                              |
+| **adapters** | 实现接口绑定具体平台（DB/IPC/AI）                                                  | 不含业务逻辑                                  |
+
+## 5. 核心抽象：`ISessionStore`
+
+统一 session 层的读写操作，替代目前散落在 `@main/db/services` 的直接调用：
+
+```typescript
+export interface ISessionStore {
+  // Conversation
+  getConversation: (id: string) => Promise<IConversations | null>
+  createConversation: (data: CreateConversationInput) => Promise<IConversations>
+
+  // Messages
+  getMessages: (convId: string) => Promise<IMessage[]>
+  addMessage: (data: AddMessage) => Promise<IMessage>
+
+  // Task 管理（会话维度的活跃任务查询）
+  listActiveTasks: (conversationId?: string) => Promise<AgentTaskSnapshot[]>
+}
+```
+
+`ISessionStore` 与已有的 `IConversationQuery` 区别：
+
+- `IConversationQuery` —— 只读查询接口，已存在
+- `ISessionStore` —— 包含**写入**操作的完整接口，新增
+
+## 6. `SessionOrchestrator` 接口
+
+```typescript
+export interface SessionOrchestratorConfig {
+  sessionStore: ISessionStore
+  modelResolver: IModelResolver
+  toolProvider: ToolProvider
+  aiProviderFactory: AIProviderFactory
+  eventEmitter: IAgentEventEmitter
+  logger: ILogger
+}
+
+export interface SessionOrchestrator {
+  startTurn: (options: StartAgentTurnOptions) => Promise<AgentTurnResult>
+}
+
+export function createSessionOrchestrator(
+  config: SessionOrchestratorConfig
+): SessionOrchestrator
+```
+
+## 7. 与 AgentRuntime 的关系
+
+```
+SessionOrchestrator.startTurn()
+  │
+  ├─ 前置：准备数据（DB 读/写，构建上下文，解析 model）
+  │
+  ├─ 调用 agentRuntime.startTask(RuntimeStartInput)
+  │     └─ runAgentLoop()   ← loop 层
+  │           ├─ emitTurnStarted
+  │           ├─ for each step: stream → emitTurnChunk → tool calls → emitTurnToolCalls
+  │           └─ emitTurnFinished / emitTaskUpdated
+  │
+  └─ 后置：agentRuntime 只 emit 事件，session 层或适配器层消费事件做持久化
+```
+
+关键点：AgentRuntime **不知道** session 层的存在。session 层调用 runtime，runtime 通过事件回调通知状态变化。
+
+## 8. 数据流：Electron vs Web
+
+```
+Electron 实现:
+  ElectronSessionStore implements ISessionStore
+    → Dexie (IndexedDB)
+  ElectronEventEmitter implements IAgentEventEmitter
+    → IPC → renderer Zustand store
+
+Web 实现:
+  WebSessionStore implements ISessionStore
+    → REST API / PostgreSQL
+  WebEventEmitter implements IAgentEventEmitter
+    → WebSocket / SSE → 浏览器状态管理
+```
+
+两个平台**共用** `packages/runtime/src/session/SessionOrchestrator`，只换 `ISessionStore` 和 `IAgentEventEmitter` 的实现。
+
+## 9. 迁移计划
+
+1. 定义 `ISessionStore` 接口（`packages/shared/`）
+2. 实现 `SessionOrchestrator`（`packages/runtime/src/session/`）
+3. Electron 侧：`ElectronSessionStore` 适配现有 `@main/db/services`
+4. `agentTurnService.ts` 瘦身 → 仅做依赖注入，编排逻辑移到 `SessionOrchestrator`
+5. Web 侧：`WebSessionStore` 对接后端 API
+
+## 10. 遗留问题
+
+- **`WorkspaceStore`**：当前 `agentTurnService` 用 Electron 专用的 `WorkspaceStore.getInstance()` 获取 `workspacePath`。需要抽象为 `IWorkspaceResolver` 或由调用方传入。
+- **Compaction 持久化**：当前在 compaction gate 内直接调用 `eventEmitter.emitCompactionSaved()`，持久化逻辑在适配器层完成。session 层不需要关心。
+- **Skill 管理**：skill 的安装/选择涉及文件系统操作，暂留在平台适配器层。

--- a/packages/runtime/docs/session-boundary.md
+++ b/packages/runtime/docs/session-boundary.md
@@ -11,148 +11,202 @@ src/main/agent/runtime/agentTurnService.ts  ← 编排逻辑，直接 import @ma
 
 编排逻辑（创建 conversation、写入消息、加载历史、构建上下文、启动 runtime loop）被硬编码在 Electron 主进程中。做 Web 版时这些逻辑无法复用。
 
-## 2. Session 定义
+## 2. AgentRuntime 定位
 
-在 ant-chat 中，**Session** 指一次用户交互的完整生命周期：
+**AgentRuntime 是一个独立、自管理、无 TUI/CLI 的服务进程**，类似 Claude Code 的引擎层但去掉了交互界面。Electron 和 Web 只是它的 UI 壳，通过 IPC/HTTP 协议与之通信。
 
-```
-用户发送消息 → 创建 conversation / message → 加载历史 → 构建上下文
-→ 启动 AgentRuntime loop → 流式响应 → 工具调用 → 审批 → 完成/失败
-```
+核心决策：
 
-session 层负责**编排**这个生命周期，runtime 的 loop 层负责**执行**单个 turn 内的 step 循环。
+| 决策     | 结论                           | 理由                                                                    |
+| -------- | ------------------------------ | ----------------------------------------------------------------------- |
+| 进程模型 | **单例**                       | 一个 agent 服务所有 conversation 并发执行，taskStore 已支持多 task 并发 |
+| 通信方式 | **跨进程**（IPC / HTTP）       | 暂不在浏览器中运行；agent 可独立部署、升级、崩溃恢复                    |
+| 编排归属 | **AgentRuntime 内部**          | 外部只传 prompt + convId + modelId + workspacePath，agent 自己管理会话  |
+| 事件模式 | **push**（IAgentEventEmitter） | 实时推送给 UI，简单直接；后续可加 pull 迭代器做背压                     |
 
 ## 3. 目标架构
 
 ```
-                        ┌─────────────────────────────────────┐
-                        │    packages/runtime/src/session/    │  ← 新增核心
-                        │    SessionOrchestrator               │
-                        │    .startTurn(options) → TurnResult  │
-                        │    内部编排：                         │
-                        │    1. 创建/获取 conversation          │
-                        │    2. 创建 user message              │
-                        │    3. 加载历史 → LoopMessage[]       │
-                        │    4. 构建 system prompt + tools      │
-                        │    5. 启动 AgentRuntime.startTask()  │
-                        │    6. 监听事件处理完成/失败           │
-                        └──────┬──────────────┬───────────────┘
-                               │ 依赖接口      │
-                        ┌──────┴──────────────┴───────────────┐
-                        │  ISessionStore      (新增)          │
-                        │  IModelResolver     (已有)          │
-                        │  IToolProvider      (已有，隐式)     │
-                        │  IAIProviderFactory (已有)           │
-                        │  IAgentEventEmitter (已有)           │
-                        │  ILogger            (已有)          │
-                        └─────────────────────────────────────┘
-                               │              │
-                        ┌──────┴──┐    ┌──────┴──┐
-                        │ Electron│    │   Web   │
-                        │  Dexie  │    │  PG/REST│
-                        └─────────┘    └─────────┘
+                    ┌────────────────────────────────────────┐
+                    │           AgentRuntime                 │
+                    │         (独立进程，自管理)               │
+                    │                                        │
+                    │  构造注入:                              │
+                    │   ISessionStore     IModelResolver      │
+                    │   IAIProviderFactory  IToolProvider     │
+                    │   IAgentEventEmitter  ILogger           │
+                    │                                        │
+                    │  ── 命令接口（写） ──                    │
+                    │  startTask(options)                     │
+                    │    → 内部: 创建/获取 conversation       │
+                    │    → 创建 user message                  │
+                    │    → 加载历史 → LoopMessage[]           │
+                    │    → 构建 system prompt + tools         │
+                    │    → 跑 loop → emit 事件                 │
+                    │  approvePendingAction(...)              │
+                    │  rejectPendingAction(...)               │
+                    │  cancelTask(...)                        │
+                    │                                        │
+                    │  ── 查询接口（读，纯展示用） ──           │
+                    │  listConversations()                    │
+                    │  getConversation(id)                    │
+                    │  getMessages(convId)                    │
+                    │  getTask(taskId)                        │
+                    │  listActiveTasks(convId?)               │
+                    │                                        │
+                    │  ── 事件出口 ──                         │
+                    │  RuntimeEvent (push via eventEmitter)   │
+                    └────────────────────────────────────────┘
+                          ▲ 命令+查询        │ 事件流 (push)
+                  ┌───────┴────────┐  ┌──────┴──────────┐
+                  │  Electron      │  │     Web          │
+                  │  IPC 代理      │  │  HTTP/WS 代理    │
+                  │  Dexie 实现    │  │  PG/REST 实现    │
+                  └────────────────┘  └─────────────────┘
 ```
 
 ## 4. 各层职责边界
 
-| 层           | 负责                                                                               | 不负责                                        |
-| ------------ | ---------------------------------------------------------------------------------- | --------------------------------------------- |
-| **session**  | 编排完整 turn 生命周期；管理 conversation/message CRUD 流程；协调 adapter 调用顺序 | 不执行 AI loop；不处理工具调用；不直接访问 DB |
-| **loop**     | 单 turn 内的 step 循环；模型流式调用；工具执行；token 压缩                         | 不创建 conversation/message；不知道 IPC/DB    |
-| **policy**   | 工具调用前的策略检查；审批流程控制                                                 | 不关心业务上下文                              |
-| **adapters** | 实现接口绑定具体平台（DB/IPC/AI）                                                  | 不含业务逻辑                                  |
+| 层               | 负责                                                                       | 不负责                            |
+| ---------------- | -------------------------------------------------------------------------- | --------------------------------- |
+| **AgentRuntime** | 会话全生命周期（创建 conv、写 msg、加载历史、跑 loop）；审批流程；查询接口 | 不实现具体 DB/HTTP；不直接渲染 UI |
+| **loop**         | 单 turn 内的 step 循环；模型流式调用；工具执行；token 压缩                 | 不创建 conversation/message       |
+| **policy**       | 工具调用前的策略检查；审批流程控制                                         | 不关心业务上下文                  |
+| **adapters**     | 实现接口绑定具体平台（DB/IPC/AI）；代理通信协议                            | 不含业务逻辑                      |
+
+关键变化：**不再有独立的 SessionOrchestrator 层**。原来 `agentTurnService.ts` 的编排逻辑和 `AgentRuntime` 合并为同一个模块，AgentRuntime 直接暴露外部可调用的方法。
 
 ## 5. 核心抽象：`ISessionStore`
 
-统一 session 层的读写操作，替代目前散落在 `@main/db/services` 的直接调用：
+统一 AgentRuntime 对持久化层的读写依赖，替代目前散落在 `@main/db/services` 的直接调用：
 
 ```typescript
 export interface ISessionStore {
   // Conversation
   getConversation: (id: string) => Promise<IConversations | null>
   createConversation: (data: CreateConversationInput) => Promise<IConversations>
+  listConversations: () => Promise<IConversations[]>
 
   // Messages
   getMessages: (convId: string) => Promise<IMessage[]>
   addMessage: (data: AddMessage) => Promise<IMessage>
-
-  // Task 管理（会话维度的活跃任务查询）
-  listActiveTasks: (conversationId?: string) => Promise<AgentTaskSnapshot[]>
 }
 ```
 
-`ISessionStore` 与已有的 `IConversationQuery` 区别：
+`ISessionStore` 合并了原有的 `IConversationQuery`（只读）并补上了写入操作。AgentRuntime 的查询接口直接委托给 `ISessionStore`。
 
-- `IConversationQuery` —— 只读查询接口，已存在
-- `ISessionStore` —— 包含**写入**操作的完整接口，新增
-
-## 6. `SessionOrchestrator` 接口
+## 6. `AgentRuntime` 公共接口
 
 ```typescript
-export interface SessionOrchestratorConfig {
+// ======= 构造 =======
+export interface AgentRuntimeConfig {
   sessionStore: ISessionStore
   modelResolver: IModelResolver
-  toolProvider: ToolProvider
   aiProviderFactory: AIProviderFactory
+  toolProvider: ToolProvider
   eventEmitter: IAgentEventEmitter
   logger: ILogger
 }
 
-export interface SessionOrchestrator {
-  startTurn: (options: StartAgentTurnOptions) => Promise<AgentTurnResult>
+export class AgentRuntime {
+  constructor(config: AgentRuntimeConfig) {}
+
+  // ======= 命令（写） =======
+  startTask: (options: {
+    prompt: string
+    conversationId?: string
+    modelId: string
+    workspacePath: string
+    mode?: AgentMode
+    images?: IAttachment[]
+    attachments?: IAttachment[]
+    referencedFiles?: string[]
+    selectedSkill?: string
+    chatSettings?: {
+      systemPrompt?: string
+      temperature?: number
+      maxTokens?: number
+    }
+  }) => Promise<{ taskId: string, conversationId: string, userMessageId: string }>
+
+  approvePendingAction: (options: { taskId: string, actionId: string }) => void
+  rejectPendingAction: (options: { taskId: string, actionId: string, reason?: string }) => void
+  cancelTask: (options: { taskId: string }) => void
+
+  // ======= 查询（读，纯展示） =======
+  getTask: (taskId: string) => AgentTaskSnapshot
+  listActiveTasks: (conversationId?: string) => AgentTaskSnapshot[]
+  listConversations: () => Promise<IConversations[]>
+  getConversation: (id: string) => Promise<IConversations | null>
+  getMessages: (convId: string) => Promise<IMessage[]>
 }
-
-export function createSessionOrchestrator(
-  config: SessionOrchestratorConfig
-): SessionOrchestrator
 ```
 
-## 7. 与 AgentRuntime 的关系
+## 7. startTask 内部流程
 
 ```
-SessionOrchestrator.startTurn()
+AgentRuntime.startTask(options)
   │
-  ├─ 前置：准备数据（DB 读/写，构建上下文，解析 model）
+  ├─ 1. 创建/获取 conversation（ISessionStore）
   │
-  ├─ 调用 agentRuntime.startTask(RuntimeStartInput)
-  │     └─ runAgentLoop()   ← loop 层
-  │           ├─ emitTurnStarted
-  │           ├─ for each step: stream → emitTurnChunk → tool calls → emitTurnToolCalls
-  │           └─ emitTurnFinished / emitTaskUpdated
+  ├─ 2. 创建 user message（ISessionStore）
   │
-  └─ 后置：agentRuntime 只 emit 事件，session 层或适配器层消费事件做持久化
+  ├─ 3. 解析 model & provider（IModelResolver）
+  │
+  ├─ 4. 创建 AI provider（IAIProviderFactory）
+  │
+  ├─ 5. 加载历史消息 → 构建 LoopMessage[]（ISessionStore + buildConversationContextMessages）
+  │
+  ├─ 6. 准备工具（IToolProvider）
+  │
+  ├─ 7. 构建 system prompt（createLoopSystemPrompt）
+  │
+  ├─ 8. 启动 loop → emit 事件（runAgentLoop）
+  │     ├─ emitTurnStarted
+  │     ├─ for each step: stream → emitTurnChunk → execute tools → emitTurnToolCalls
+  │     ├─ 需要审批时: emitTaskUpdated + emitApprovalRequired
+  │     └─ 结束: emitTurnFinished + emitTaskUpdated
+  │
+  └─ 9. 返回 { taskId, conversationId, userMessageId }
 ```
 
-关键点：AgentRuntime **不知道** session 层的存在。session 层调用 runtime，runtime 通过事件回调通知状态变化。
-
-## 8. 数据流：Electron vs Web
+## 8. 跨进程通信模型
 
 ```
 Electron 实现:
-  ElectronSessionStore implements ISessionStore
-    → Dexie (IndexedDB)
-  ElectronEventEmitter implements IAgentEventEmitter
-    → IPC → renderer Zustand store
+  ┌──────────────┐         IPC          ┌──────────────────┐
+  │   Renderer   │ ←─── 事件 push ──── │   Main Process    │
+  │  (Zustand)   │ ──── 命令/查询 ───→ │   AgentRuntime    │
+  │              │                      │   + Dexie 适配器   │
+  └──────────────┘                      └──────────────────┘
 
 Web 实现:
-  WebSessionStore implements ISessionStore
-    → REST API / PostgreSQL
-  WebEventEmitter implements IAgentEventEmitter
-    → WebSocket / SSE → 浏览器状态管理
+  ┌──────────────┐      HTTP/WS          ┌──────────────────┐
+  │   Browser    │ ←─── WS 事件 push ── │   Agent Server    │
+  │  (状态管理)   │ ──── REST 命令/查询 ─→│   AgentRuntime    │
+  │              │                       │   + PG 适配器     │
+  └──────────────┘                       └──────────────────┘
 ```
 
-两个平台**共用** `packages/runtime/src/session/SessionOrchestrator`，只换 `ISessionStore` 和 `IAgentEventEmitter` 的实现。
+- **命令/查询**：请求-响应模式。Electron 走 IPC `invoke/handle`，Web 走 REST API
+- **事件流**：服务端 push。Electron 走 IPC `send/on`，Web 走 WebSocket
+- 两个平台**共用** `AgentRuntime`，只换 `ISessionStore`、`IAgentEventEmitter` 和通信协议层
 
 ## 9. 迁移计划
 
-1. 定义 `ISessionStore` 接口（`packages/shared/`）
-2. 实现 `SessionOrchestrator`（`packages/runtime/src/session/`）
-3. Electron 侧：`ElectronSessionStore` 适配现有 `@main/db/services`
-4. `agentTurnService.ts` 瘦身 → 仅做依赖注入，编排逻辑移到 `SessionOrchestrator`
-5. Web 侧：`WebSessionStore` 对接后端 API
+1. 补齐 `ISessionStore` 接口（`packages/shared/`）—— 合并原有 `IConversationQuery`
+2. `AgentRuntime` 扩展：纳入编排逻辑、暴露查询接口
+3. Electron 侧：
+   - `ElectronSessionStore` 适配现有 `@main/db/services`
+   - `agentTurnService.ts` 删除，逻辑已移入 AgentRuntime
+   - IPC handler 层做薄代理（转发 invoke → AgentRuntime 方法调用）
+4. Web 侧：
+   - `WebSessionStore` 对接后端 API
+   - HTTP handler + WebSocket 事件推送
+5. 通信协议统一：定义 `IAgentTransport` 接口规范
 
 ## 10. 遗留问题
 
-- **`WorkspaceStore`**：当前 `agentTurnService` 用 Electron 专用的 `WorkspaceStore.getInstance()` 获取 `workspacePath`。需要抽象为 `IWorkspaceResolver` 或由调用方传入。
-- **Compaction 持久化**：当前在 compaction gate 内直接调用 `eventEmitter.emitCompactionSaved()`，持久化逻辑在适配器层完成。session 层不需要关心。
+- **`WorkspaceStore`**：当前用 Electron 专用的 `WorkspaceStore.getInstance()` 获取 `workspacePath`。Web 版需要对应的抽象（`IWorkspaceResolver`）或由调用方传入。
+- **Compaction 持久化**：在 loop 内通过 `eventEmitter.emitCompactionSaved()` 推送，持久化由适配器层完成。AgentRuntime 不关心存储细节。
 - **Skill 管理**：skill 的安装/选择涉及文件系统操作，暂留在平台适配器层。


### PR DESCRIPTION
## Summary
Architecture design document for a platform-agnostic session layer that sits between the pure runtime loop and platform adapters.

## Contents
1. Current architecture problem — orchestration logic coupled to Electron/DB
2. Session definition — the full turn lifecycle
3. Target architecture with session layer
4. Layer responsibility boundaries
5. `ISessionStore` interface definition
6. `SessionOrchestrator` interface
7. Relationship with AgentRuntime
8. Electron vs Web data flow
9. Migration plan (5 steps)
10. Open issues (WorkspaceStore, compaction, skills)