### PR TITLE
feat: merge images/attachments into message content blocks

### DIFF
--- a/apps/web/src/api/dataFactory.ts
+++ b/apps/web/src/api/dataFactory.ts
@@ -30,8 +30,6 @@ export function createUserMessage(option: RequireKey<Partial<IMessageUser>, 'con
     createMessageBase(Role.USER),
     {
       status: 'success',
-      attachments: [],
-      images: [],
     },
     option,
   )

--- a/apps/web/src/components/Chat/Chat.tsx
+++ b/apps/web/src/components/Chat/Chat.tsx
@@ -1,4 +1,4 @@
-import type { AgentMode, ChatFeatures, IAttachment, IImage } from '@ant-chat/shared'
+import type { AgentMode, ChatFeatures, IMessageContent } from '@ant-chat/shared'
 import { Skeleton } from '@workspace/ui/components/skeleton'
 import { lazy, Suspense } from 'react'
 import { toast } from 'sonner'
@@ -33,9 +33,7 @@ export default function Chat() {
   const pending = useAgentStore(state => (agentTaskId ? state.pendingByTask[agentTaskId] : undefined))
 
   async function onSubmit(
-    message: string,
-    images: IImage[],
-    attachments: IAttachment[],
+    content: IMessageContent,
     referencedFiles: string[],
     selectedSkill: string | undefined,
     features: ChatFeatures,
@@ -46,12 +44,15 @@ export default function Chat() {
       return
     }
 
+    // 从 content 中提取文本作为 prompt
+    const textBlocks = content.filter(block => block.type === 'text')
+    const prompt = textBlocks.map(block => block.text).join('\n')
+
     const isNewConversation = !activeConversationsId
     const result = await startAgentTurn({
       conversationId: activeConversationsId || undefined,
-      prompt: message,
-      images,
-      attachments,
+      prompt,
+      content,
       referencedFiles,
       selectedSkill,
       mode: agentMode,

--- a/apps/web/src/components/Chat/MessageBubble.tsx
+++ b/apps/web/src/components/Chat/MessageBubble.tsx
@@ -222,12 +222,8 @@ function MessageContentRenderer({
   const itemIsAI = item.role === Role.AI
 
   if (!itemIsAI) {
-    const pickList = ['status']
-    if (itemIsUser) {
-      pickList.push('images', 'attachments')
-    }
     const messageContentProps: Partial<BubbleContent> = {
-      ...pick(item, pickList),
+      ...pick(item, ['status']),
       content,
     }
     return <MessageContent {...messageContentProps} enableReferenceTokens={itemIsUser} />

--- a/apps/web/src/components/Sender/Sender.tsx
+++ b/apps/web/src/components/Sender/Sender.tsx
@@ -36,6 +36,7 @@ import {
   PopoverTrigger,
 } from '@workspace/ui/components/popover'
 import { Cable, ChevronDownIcon, FolderOpenIcon, HandIcon, PaperclipIcon, ShieldAlertIcon, ShieldCheckIcon } from 'lucide-react'
+import { nanoid } from 'nanoid'
 import {
   useEffect,
   useLayoutEffect,
@@ -99,7 +100,7 @@ async function filePartToAttachment(part: FileUIPart, index: number) {
   const data = await fileToBase64(file)
 
   return {
-    uid: `${filename}-${index}`,
+    uid: (part as FileUIPart & { id?: string }).id ?? nanoid(),
     name: filename,
     size: file.size,
     type: file.type || 'application/octet-stream',
@@ -709,6 +710,7 @@ function Sender({ actions, ...props }: SenderProps) {
           name: file.name,
           media_type: file.type,
           size: file.size,
+          data: file.data,
         })
       }
       else if (category === 'document') {
@@ -721,6 +723,7 @@ function Sender({ actions, ...props }: SenderProps) {
           name: file.name,
           media_type: file.type,
           size: file.size,
+          data: file.data,
         })
       }
       else {
@@ -734,6 +737,7 @@ function Sender({ actions, ...props }: SenderProps) {
           name: file.name,
           media_type: file.type,
           size: file.size,
+          data: file.data,
         })
       }
     })

--- a/apps/web/src/components/Sender/Sender.tsx
+++ b/apps/web/src/components/Sender/Sender.tsx
@@ -1,5 +1,6 @@
 import type { AgentMode, ChatFeatures, IMessageContent, ProviderConfigModelSchema, SkillManifest, WorkspaceFileSearchResult } from '@ant-chat/shared'
 import type { FileUIPart, LanguageModelUsage } from 'ai'
+import { classifyFile } from '@ant-chat/shared'
 import {
   Attachment,
   AttachmentInfo,
@@ -696,7 +697,9 @@ function Sender({ actions, ...props }: SenderProps) {
         return
       }
 
-      if (file.type.includes('image')) {
+      const category = classifyFile(file.name, file.type)
+
+      if (category === 'image') {
         content.push({
           type: 'image-block',
           source: {
@@ -708,38 +711,30 @@ function Sender({ actions, ...props }: SenderProps) {
           size: file.size,
         })
       }
+      else if (category === 'document') {
+        content.push({
+          type: 'document',
+          source: {
+            type: 'file_id',
+            file_id: file.uid,
+          },
+          name: file.name,
+          media_type: file.type,
+          size: file.size,
+        })
+      }
       else {
-        const isDocument = file.type.startsWith('text/')
-          || file.type.includes('pdf')
-          || file.type.includes('document')
-          || file.type.includes('spreadsheet')
-          || file.type.includes('presentation')
-
-        if (isDocument) {
-          content.push({
-            type: 'document',
-            source: {
-              type: 'file_id',
-              file_id: file.uid,
-            },
-            name: file.name,
-            media_type: file.type,
-            size: file.size,
-          })
-        }
-        else {
-          content.push({
-            type: 'file',
-            source: {
-              type: 'file_id',
-              file_id: file.uid,
-            },
-            filename: file.name,
-            name: file.name,
-            media_type: file.type,
-            size: file.size,
-          })
-        }
+        content.push({
+          type: 'file',
+          source: {
+            type: 'file_id',
+            file_id: file.uid,
+          },
+          filename: file.name,
+          name: file.name,
+          media_type: file.type,
+          size: file.size,
+        })
       }
     })
 

--- a/apps/web/src/components/Sender/Sender.tsx
+++ b/apps/web/src/components/Sender/Sender.tsx
@@ -1,4 +1,4 @@
-import type { AgentMode, ChatFeatures, IAttachment, IImage, ProviderConfigModelSchema, SkillManifest, WorkspaceFileSearchResult } from '@ant-chat/shared'
+import type { AgentMode, ChatFeatures, IMessageContent, ProviderConfigModelSchema, SkillManifest, WorkspaceFileSearchResult } from '@ant-chat/shared'
 import type { FileUIPart, LanguageModelUsage } from 'ai'
 import {
   Attachment,
@@ -75,9 +75,7 @@ import { ReferenceSuggestionPanel } from './ReferenceSuggestionPanel'
 interface SenderProps {
   actions?: React.ReactNode
   onSubmit?: (
-    message: string,
-    images: IImage[],
-    attachments: IAttachment[],
+    content: IMessageContent,
     referencedFiles: string[],
     selectedSkill: string | undefined,
     features: ChatFeatures,
@@ -680,8 +678,6 @@ function Sender({ actions, ...props }: SenderProps) {
   }
 
   async function handleSubmit(message: { text: string, files: FileUIPart[] }) {
-    const images: IImage[] = []
-    const attachments: IAttachment[] = []
     const nextReferencedFiles = syncReferencedFiles(message.text, referencedFiles)
     const nextSelectedSkill = syncSelectedSkill(message.text, selectedSkill)
 
@@ -689,20 +685,65 @@ function Sender({ actions, ...props }: SenderProps) {
       message.files.map((part, index) => filePartToAttachment(part, index)),
     )
 
+    // 构建 content blocks
+    const content: IMessageContent = [
+      { type: 'text', text: message.text },
+    ]
+
+    // 添加文件 content blocks
     files.forEach((file) => {
       if (!file) {
         return
       }
 
       if (file.type.includes('image')) {
-        images.push(file)
+        content.push({
+          type: 'image-block',
+          source: {
+            type: 'file_id',
+            file_id: file.uid,
+          },
+          name: file.name,
+          media_type: file.type,
+          size: file.size,
+        })
       }
       else {
-        attachments.push(file)
+        const isDocument = file.type.startsWith('text/')
+          || file.type.includes('pdf')
+          || file.type.includes('document')
+          || file.type.includes('spreadsheet')
+          || file.type.includes('presentation')
+
+        if (isDocument) {
+          content.push({
+            type: 'document',
+            source: {
+              type: 'file_id',
+              file_id: file.uid,
+            },
+            name: file.name,
+            media_type: file.type,
+            size: file.size,
+          })
+        }
+        else {
+          content.push({
+            type: 'file',
+            source: {
+              type: 'file_id',
+              file_id: file.uid,
+            },
+            filename: file.name,
+            name: file.name,
+            media_type: file.type,
+            size: file.size,
+          })
+        }
       }
     })
 
-    props.onSubmit?.(message.text, images, attachments, nextReferencedFiles, nextSelectedSkill, {
+    props.onSubmit?.(content, nextReferencedFiles, nextSelectedSkill, {
       enableMCP: mcpEnabled,
     }, agentMode)
     setDraft('')

--- a/apps/web/src/components/Sender/__tests__/Sender.spec.tsx
+++ b/apps/web/src/components/Sender/__tests__/Sender.spec.tsx
@@ -152,9 +152,7 @@ describe('sender reference token overlay', () => {
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
-        '看 @resume.md ',
-        [],
-        [],
+        [{ type: 'text', text: '看 @resume.md ' }],
         ['resume.md'],
         undefined,
         { enableMCP: false },

--- a/apps/web/src/hooks/useMessageActions.ts
+++ b/apps/web/src/hooks/useMessageActions.ts
@@ -13,6 +13,15 @@ export function useMessageActions() {
       if (b.type === 'image') {
         data.text += `![](data:${b.mimeType};base64,${b.data})\n`
       }
+      else if (b.type === 'image-block') {
+        data.text += `[Image: ${b.name || 'image'}]`
+      }
+      else if (b.type === 'document') {
+        data.text += `[Document: ${b.name || b.title || 'document'}]`
+      }
+      else if (b.type === 'file') {
+        data.text += `[File: ${b.filename || b.name || 'file'}]`
+      }
       else if (b.type === 'error') {
         data.text += `> [!CAUTION]\n> ${b.error}`
       }

--- a/apps/web/src/utils/messageTransform.ts
+++ b/apps/web/src/utils/messageTransform.ts
@@ -26,6 +26,15 @@ export function transformMessageContent(message: IMessage): string {
       const label = block.isError ? 'Error' : 'Result'
       return `${acc}${prefix}[${label}: ${block.toolName}]`
     }
+    else if (block.type === 'image-block') {
+      return `${acc}${prefix}[Image: ${block.name || 'image'}]`
+    }
+    else if (block.type === 'document') {
+      return `${acc}${prefix}[Document: ${block.name || block.title || 'document'}]`
+    }
+    else if (block.type === 'file') {
+      return `${acc}${prefix}[File: ${block.filename || block.name || 'file'}]`
+    }
     else {
       return `${acc}${prefix}${block.text}`
     }

--- a/packages/agent-core/src/loop/loopContext.ts
+++ b/packages/agent-core/src/loop/loopContext.ts
@@ -1,5 +1,5 @@
 import type { IMessage, LoadFileDataFn, LoopMessage } from '@ant-chat/shared'
-import { attachmentsToContentBlocks, imagesToContentBlocks } from '../utils/attachmentUtils'
+import { attachmentsToContentBlocks, contentBlocksToLoopMessageContent, imagesToContentBlocks } from '../utils/attachmentUtils'
 
 export interface LoopSystemPromptMemory {
   memory?: string
@@ -122,71 +122,40 @@ export async function buildConversationContextMessages(
 
   for (const message of valid) {
     const content: LoopMessage['content'] = []
-    for (const block of message.content) {
-      if (block.type === 'text') {
-        content.push(block)
-      }
-      else if (block.type === 'tool-call' && message.role === 'assistant') {
-        content.push({
-          type: 'tool-call',
-          toolCallId: block.toolCallId,
-          toolName: block.toolName,
-          args: block.args,
-        })
-      }
-      else if (block.type === 'tool-result' && message.role === 'tool') {
-        content.push({
-          type: 'tool-result',
-          toolCallId: block.toolCallId,
-          toolName: block.toolName,
-          result: block.result,
-          isError: block.isError,
-        })
+    if (message.role === 'user') {
+      content.push(...await contentBlocksToLoopMessageContent(message.content, loadFileData))
+    }
+    else {
+      for (const block of message.content) {
+        if (block.type === 'text') {
+          content.push(block)
+        }
+        else if (block.type === 'tool-call' && message.role === 'assistant') {
+          content.push({
+            type: 'tool-call',
+            toolCallId: block.toolCallId,
+            toolName: block.toolName,
+            args: block.args,
+          })
+        }
+        else if (block.type === 'tool-result' && message.role === 'tool') {
+          content.push({
+            type: 'tool-result',
+            toolCallId: block.toolCallId,
+            toolName: block.toolName,
+            result: block.result,
+            isError: block.isError,
+          })
+        }
       }
     }
 
-    // 处理用户消息中的附件
     if (message.role === 'user') {
-      // 检查是否有旧格式的 images 和 attachments 字段
       if ('images' in message && message.images?.length) {
         content.push(...imagesToContentBlocks(message.images))
       }
       if ('attachments' in message && message.attachments?.length) {
         content.push(...attachmentsToContentBlocks(message.attachments))
-      }
-
-      // 处理新格式的 content blocks（image-block, document, file）
-      if (loadFileData) {
-        for (const block of message.content) {
-          if (block.type === 'image-block' && block.source.type === 'file_id') {
-            const data = await loadFileData(block.source.file_id)
-            if (data) {
-              content.push({
-                type: 'image',
-                mimeType: block.media_type || 'image/jpeg',
-                data,
-              })
-            }
-          }
-          else if (block.type === 'document' && block.source.type === 'file_id') {
-            const data = await loadFileData(block.source.file_id)
-            if (data) {
-              content.push({
-                type: 'text',
-                text: `<document name="${block.name || 'document'}" type="${block.media_type}">\n${data}\n</document>`,
-              })
-            }
-          }
-          else if (block.type === 'file' && block.source.type === 'file_id') {
-            const data = await loadFileData(block.source.file_id)
-            if (data) {
-              content.push({
-                type: 'text',
-                text: `<file name="${block.filename || block.name || 'file'}" type="${block.media_type}">\n${data}\n</file>`,
-              })
-            }
-          }
-        }
       }
     }
 

--- a/packages/agent-core/src/loop/loopContext.ts
+++ b/packages/agent-core/src/loop/loopContext.ts
@@ -144,12 +144,34 @@ export function buildConversationContextMessages(
       }
     }
 
+    // 处理用户消息中的附件
     if (message.role === 'user') {
-      if (message.images?.length) {
+      // 检查是否有旧格式的 images 和 attachments 字段
+      if ('images' in message && message.images?.length) {
         content.push(...imagesToContentBlocks(message.images))
       }
-      if (message.attachments?.length) {
+      if ('attachments' in message && message.attachments?.length) {
         content.push(...attachmentsToContentBlocks(message.attachments))
+      }
+
+      // 处理新格式的 content blocks（image-block, document, file）
+      // 注意：这些类型需要先加载文件数据，这里只处理元数据
+      for (const block of message.content) {
+        if (block.type === 'image-block') {
+          // 图片块需要先加载数据，这里跳过
+          // 实际使用时需要通过 AttachmentService 加载数据
+          continue
+        }
+        if (block.type === 'document') {
+          // 文档块需要先加载数据，这里跳过
+          // 实际使用时需要通过 AttachmentService 加载数据
+          continue
+        }
+        if (block.type === 'file') {
+          // 文件块需要先加载数据，这里跳过
+          // 实际使用时需要通过 AttachmentService 加载数据
+          continue
+        }
       }
     }
 

--- a/packages/agent-core/src/loop/loopContext.ts
+++ b/packages/agent-core/src/loop/loopContext.ts
@@ -1,4 +1,4 @@
-import type { IMessage, LoopMessage } from '@ant-chat/shared'
+import type { IMessage, LoadFileDataFn, LoopMessage } from '@ant-chat/shared'
 import { attachmentsToContentBlocks, imagesToContentBlocks } from '../utils/attachmentUtils'
 
 export interface LoopSystemPromptMemory {
@@ -79,8 +79,6 @@ export function createLoopSystemPrompt(workspacePath: string, customPrompt?: str
 
   return sections.join('\n\n')
 }
-
-export type LoadFileDataFn = (fileId: string) => Promise<string | null>
 
 export async function buildConversationContextMessages(
   messages: IMessage[],

--- a/packages/agent-core/src/loop/loopContext.ts
+++ b/packages/agent-core/src/loop/loopContext.ts
@@ -80,12 +80,15 @@ export function createLoopSystemPrompt(workspacePath: string, customPrompt?: str
   return sections.join('\n\n')
 }
 
-export function buildConversationContextMessages(
+export type LoadFileDataFn = (fileId: string) => Promise<string | null>
+
+export async function buildConversationContextMessages(
   messages: IMessage[],
   currentUserMessageId: string,
   lastCompactedAt?: number,
   lastCompactionSummary?: string,
-): LoopMessage[] {
+  loadFileData?: LoadFileDataFn,
+): Promise<LoopMessage[]> {
   const valid = messages
     .filter((message): message is IMessage & { role: 'user' | 'assistant' | 'tool' } => {
       if (message.id === currentUserMessageId)
@@ -155,22 +158,36 @@ export function buildConversationContextMessages(
       }
 
       // 处理新格式的 content blocks（image-block, document, file）
-      // 注意：这些类型需要先加载文件数据，这里只处理元数据
-      for (const block of message.content) {
-        if (block.type === 'image-block') {
-          // 图片块需要先加载数据，这里跳过
-          // 实际使用时需要通过 AttachmentService 加载数据
-          continue
-        }
-        if (block.type === 'document') {
-          // 文档块需要先加载数据，这里跳过
-          // 实际使用时需要通过 AttachmentService 加载数据
-          continue
-        }
-        if (block.type === 'file') {
-          // 文件块需要先加载数据，这里跳过
-          // 实际使用时需要通过 AttachmentService 加载数据
-          continue
+      if (loadFileData) {
+        for (const block of message.content) {
+          if (block.type === 'image-block' && block.source.type === 'file_id') {
+            const data = await loadFileData(block.source.file_id)
+            if (data) {
+              content.push({
+                type: 'image',
+                mimeType: block.media_type || 'image/jpeg',
+                data,
+              })
+            }
+          }
+          else if (block.type === 'document' && block.source.type === 'file_id') {
+            const data = await loadFileData(block.source.file_id)
+            if (data) {
+              content.push({
+                type: 'text',
+                text: `<document name="${block.name || 'document'}" type="${block.media_type}">\n${data}\n</document>`,
+              })
+            }
+          }
+          else if (block.type === 'file' && block.source.type === 'file_id') {
+            const data = await loadFileData(block.source.file_id)
+            if (data) {
+              content.push({
+                type: 'text',
+                text: `<file name="${block.filename || block.name || 'file'}" type="${block.media_type}">\n${data}\n</file>`,
+              })
+            }
+          }
         }
       }
     }

--- a/packages/agent-core/src/loop/loopContext.ts
+++ b/packages/agent-core/src/loop/loopContext.ts
@@ -1,5 +1,5 @@
 import type { IMessage, LoadFileDataFn, LoopMessage } from '@ant-chat/shared'
-import { attachmentsToContentBlocks, contentBlocksToLoopMessageContent, imagesToContentBlocks } from '../utils/attachmentUtils'
+import { contentBlocksToLoopMessageContent } from '../utils/attachmentUtils'
 
 export interface LoopSystemPromptMemory {
   memory?: string
@@ -147,15 +147,6 @@ export async function buildConversationContextMessages(
             isError: block.isError,
           })
         }
-      }
-    }
-
-    if (message.role === 'user') {
-      if ('images' in message && message.images?.length) {
-        content.push(...imagesToContentBlocks(message.images))
-      }
-      if ('attachments' in message && message.attachments?.length) {
-        content.push(...attachmentsToContentBlocks(message.attachments))
       }
     }
 

--- a/packages/agent-core/src/session/SessionRuntime.ts
+++ b/packages/agent-core/src/session/SessionRuntime.ts
@@ -21,7 +21,7 @@ import {
 } from '../loop/loopContext'
 import { taskStore } from '../taskStore'
 import { ToolRegistry } from '../tools/toolRegistry'
-import { attachmentsToContentBlocks, imagesToContentBlocks } from '../utils/attachmentUtils'
+import { contentBlocksToLoopMessageContent } from '../utils/attachmentUtils'
 import { buildPromptWithTurnContext } from './turnContext'
 
 const DEFAULT_CONVERSATION_TITLE = 'Untitled'
@@ -80,9 +80,7 @@ export class SessionRuntime {
       convId: conversation.id,
       role: 'user',
       status: 'success',
-      content: [{ type: 'text', text: prompt }],
-      images: options.images ?? [],
-      attachments: options.attachments ?? [],
+      content: options.content ?? [{ type: 'text', text: prompt }],
       turnId: undefined,
     })
 
@@ -113,12 +111,14 @@ export class SessionRuntime {
       selectedSkill: options.selectedSkill,
     })
 
-    const userContent: LoopMessage['content'] = [{ type: 'text', text: enrichedPrompt }]
-    if (options.images?.length) {
-      userContent.push(...imagesToContentBlocks(options.images))
+    // 构建用户内容：优先使用 options.content，否则使用 enrichedPrompt
+    let userContent: LoopMessage['content']
+    if (options.content && options.content.length > 0) {
+      // 使用新的 content 格式，转换为 LoopMessage 格式
+      userContent = contentBlocksToLoopMessageContent(options.content)
     }
-    if (options.attachments?.length) {
-      userContent.push(...attachmentsToContentBlocks(options.attachments))
+    else {
+      userContent = [{ type: 'text', text: enrichedPrompt }]
     }
 
     const messages: LoopMessage[] = [
@@ -214,8 +214,6 @@ export class SessionRuntime {
       role: 'user',
       status: 'success',
       content: [{ type: 'text', text }],
-      images: [],
-      attachments: [],
       turnId,
     })
 

--- a/packages/agent-core/src/session/SessionRuntime.ts
+++ b/packages/agent-core/src/session/SessionRuntime.ts
@@ -98,11 +98,12 @@ export class SessionRuntime {
       : await createProvider(provider)
     const currentConversation = await store.getConversation(conversation.id)
     const historyMessages = await store.getMessages(conversation.id)
-    const contextMessages = buildConversationContextMessages(
+    const contextMessages = await buildConversationContextMessages(
       historyMessages,
       userMessage.id,
       currentConversation?.settings?.lastCompactedAt,
       currentConversation?.settings?.lastCompactionSummary,
+      this.config.loadFileData,
     )
 
     const enrichedPrompt = buildPromptWithTurnContext({
@@ -111,11 +112,17 @@ export class SessionRuntime {
       selectedSkill: options.selectedSkill,
     })
 
-    // 构建用户内容：优先使用 options.content，否则使用 enrichedPrompt
+    // 构建用户内容
     let userContent: LoopMessage['content']
     if (options.content && options.content.length > 0) {
-      // 使用新的 content 格式，转换为 LoopMessage 格式
-      userContent = contentBlocksToLoopMessageContent(options.content)
+      // 使用新的 content 格式，将 enrichedPrompt 替换到第一个 text block
+      const contentWithEnrichedPrompt = options.content.map((block) => {
+        if (block.type === 'text') {
+          return { ...block, text: enrichedPrompt }
+        }
+        return block
+      })
+      userContent = await contentBlocksToLoopMessageContent(contentWithEnrichedPrompt, this.config.loadFileData)
     }
     else {
       userContent = [{ type: 'text', text: enrichedPrompt }]

--- a/packages/agent-core/src/session/SessionRuntime.ts
+++ b/packages/agent-core/src/session/SessionRuntime.ts
@@ -92,6 +92,7 @@ export class SessionRuntime {
     if (!provider) {
       throw new Error(`Provider not found for model: ${model.model}`)
     }
+    const loadFileData = createCachedLoadFileData(this.config.loadFileData)
 
     const aiProvider = this.config.aiProviderFactory
       ? await this.config.aiProviderFactory({ model, provider })
@@ -103,7 +104,7 @@ export class SessionRuntime {
       userMessage.id,
       currentConversation?.settings?.lastCompactedAt,
       currentConversation?.settings?.lastCompactionSummary,
-      this.config.loadFileData,
+      loadFileData,
     )
 
     const enrichedPrompt = buildPromptWithTurnContext({
@@ -122,7 +123,7 @@ export class SessionRuntime {
         }
         return block
       })
-      userContent = await contentBlocksToLoopMessageContent(contentWithEnrichedPrompt, this.config.loadFileData)
+      userContent = await contentBlocksToLoopMessageContent(contentWithEnrichedPrompt, loadFileData)
     }
     else {
       userContent = [{ type: 'text', text: enrichedPrompt }]
@@ -258,6 +259,24 @@ function requireConfig<T>(value: T | undefined, name: string): T {
     throw new Error(`AgentRuntime missing required config: ${name}`)
   }
   return value
+}
+
+function createCachedLoadFileData(loadFileData: AgentRuntimeConfig['loadFileData']): AgentRuntimeConfig['loadFileData'] {
+  if (!loadFileData) {
+    return undefined
+  }
+
+  const cache = new Map<string, Promise<string | null>>()
+  return (fileId) => {
+    const cached = cache.get(fileId)
+    if (cached) {
+      return cached
+    }
+
+    const next = loadFileData(fileId)
+    cache.set(fileId, next)
+    return next
+  }
 }
 
 async function getExistingConversation(store: ISessionStore, id: string) {

--- a/packages/agent-core/src/utils/__tests__/attachmentUtils.spec.ts
+++ b/packages/agent-core/src/utils/__tests__/attachmentUtils.spec.ts
@@ -1,0 +1,65 @@
+import { Buffer } from 'node:buffer'
+import { describe, expect, it, vi } from 'vitest'
+import { contentBlocksToLoopMessageContent } from '../attachmentUtils'
+
+describe('contentBlocksToLoopMessageContent', () => {
+  it('loads image file references as base64 image content', async () => {
+    const loadFileData = vi.fn(async () => 'image-base64')
+
+    const content = await contentBlocksToLoopMessageContent([
+      {
+        type: 'image-block',
+        source: { type: 'file_id', file_id: 'img-1' },
+        name: 'image.png',
+        media_type: 'image/png',
+      },
+    ], loadFileData)
+
+    expect(loadFileData).toHaveBeenCalledWith('img-1')
+    expect(content).toEqual([
+      {
+        type: 'image',
+        mimeType: 'image/png',
+        data: 'image-base64',
+      },
+    ])
+  })
+
+  it('decodes text file references before sending them to the model', async () => {
+    const loadFileData = vi.fn(async () => Buffer.from('hello\n', 'utf8').toString('base64'))
+
+    const content = await contentBlocksToLoopMessageContent([
+      {
+        type: 'document',
+        source: { type: 'file_id', file_id: 'doc-1' },
+        name: 'note.txt',
+        media_type: 'text/plain',
+      },
+    ], loadFileData)
+
+    expect(content).toEqual([
+      {
+        type: 'text',
+        text: '<document name="note.txt" type="text/plain">\nhello\n\n</document>',
+      },
+    ])
+  })
+
+  it('keeps existing inline image content without requiring a url', async () => {
+    const content = await contentBlocksToLoopMessageContent([
+      {
+        type: 'image',
+        mimeType: 'image/png',
+        data: 'image-base64',
+      },
+    ])
+
+    expect(content).toEqual([
+      {
+        type: 'image',
+        mimeType: 'image/png',
+        data: 'image-base64',
+      },
+    ])
+  })
+})

--- a/packages/agent-core/src/utils/attachmentUtils.ts
+++ b/packages/agent-core/src/utils/attachmentUtils.ts
@@ -97,7 +97,12 @@ export function imagesToContentBlocks(images: IAttachment[]): LoopMessage['conte
  * 注意：对于 file_id 类型，需要先加载文件数据
  * 这个函数假设文件数据已经加载到 content blocks 中
  */
-export function contentBlocksToLoopMessageContent(content: IMessageContent): LoopMessage['content'] {
+export type LoadFileDataFn = (fileId: string) => Promise<string | null>
+
+export async function contentBlocksToLoopMessageContent(
+  content: IMessageContent,
+  loadFileData?: LoadFileDataFn,
+): Promise<LoopMessage['content']> {
   const result: LoopMessage['content'] = []
 
   for (const block of content) {
@@ -118,21 +123,43 @@ export function contentBlocksToLoopMessageContent(content: IMessageContent): Loo
         break
 
       case 'image-block':
-        // 新增的图片块（需要先加载数据）
-        // 注意：这里假设 block.source 已经包含 data 字段
-        // 实际使用时需要通过 AttachmentService 加载数据
+        // 新增的图片块
+        if (block.source.type === 'file_id' && loadFileData) {
+          const data = await loadFileData(block.source.file_id)
+          if (data) {
+            result.push({
+              type: 'image',
+              mimeType: block.media_type || 'image/jpeg',
+              data,
+            })
+          }
+        }
         break
 
       case 'document':
-        // 文档块（需要先加载数据）
-        // 注意：这里假设 block.source 已经包含 data 字段
-        // 实际使用时需要通过 AttachmentService 加载数据
+        // 文档块
+        if (block.source.type === 'file_id' && loadFileData) {
+          const data = await loadFileData(block.source.file_id)
+          if (data) {
+            result.push({
+              type: 'text',
+              text: `<document name="${block.name || 'document'}" type="${block.media_type}">\n${data}\n</document>`,
+            })
+          }
+        }
         break
 
       case 'file':
-        // 文件块（需要先加载数据）
-        // 注意：这里假设 block.source 已经包含 data 字段
-        // 实际使用时需要通过 AttachmentService 加载数据
+        // 文件块
+        if (block.source.type === 'file_id' && loadFileData) {
+          const data = await loadFileData(block.source.file_id)
+          if (data) {
+            result.push({
+              type: 'text',
+              text: `<file name="${block.filename || block.name || 'file'}" type="${block.media_type}">\n${data}\n</file>`,
+            })
+          }
+        }
         break
 
       case 'error':

--- a/packages/agent-core/src/utils/attachmentUtils.ts
+++ b/packages/agent-core/src/utils/attachmentUtils.ts
@@ -1,4 +1,4 @@
-import type { IAttachment, LoopMessage } from '@ant-chat/shared'
+import type { IAttachment, IMessageContent, LoopMessage } from '@ant-chat/shared'
 import { Buffer } from 'node:buffer'
 
 const TEXT_MIME_PREFIXES = ['text/', 'application/json', 'application/xml', 'application/javascript', 'application/typescript', 'application/x-yaml', 'application/yaml', 'application/toml']
@@ -90,4 +90,64 @@ export function imagesToContentBlocks(images: IAttachment[]): LoopMessage['conte
     mimeType: image.type,
     data: image.data,
   }))
+}
+
+/**
+ * 将新的 content blocks 格式转换为 LoopMessage['content'] 格式
+ * 注意：对于 file_id 类型，需要先加载文件数据
+ * 这个函数假设文件数据已经加载到 content blocks 中
+ */
+export function contentBlocksToLoopMessageContent(content: IMessageContent): LoopMessage['content'] {
+  const result: LoopMessage['content'] = []
+
+  for (const block of content) {
+    switch (block.type) {
+      case 'text':
+        result.push({ type: 'text', text: block.text })
+        break
+
+      case 'image':
+        // 原有的 image 类型（URL 图片）
+        if (block.url) {
+          result.push({
+            type: 'image',
+            mimeType: block.mimeType || 'image/jpeg',
+            data: block.data,
+          })
+        }
+        break
+
+      case 'image-block':
+        // 新增的图片块（需要先加载数据）
+        // 注意：这里假设 block.source 已经包含 data 字段
+        // 实际使用时需要通过 AttachmentService 加载数据
+        break
+
+      case 'document':
+        // 文档块（需要先加载数据）
+        // 注意：这里假设 block.source 已经包含 data 字段
+        // 实际使用时需要通过 AttachmentService 加载数据
+        break
+
+      case 'file':
+        // 文件块（需要先加载数据）
+        // 注意：这里假设 block.source 已经包含 data 字段
+        // 实际使用时需要通过 AttachmentService 加载数据
+        break
+
+      case 'error':
+        result.push({ type: 'text', text: `Error: ${block.error}` })
+        break
+
+      case 'tool-call':
+        result.push(block)
+        break
+
+      case 'tool-result':
+        result.push(block)
+        break
+    }
+  }
+
+  return result
 }

--- a/packages/agent-core/src/utils/attachmentUtils.ts
+++ b/packages/agent-core/src/utils/attachmentUtils.ts
@@ -110,8 +110,7 @@ export async function contentBlocksToLoopMessageContent(
         break
 
       case 'image':
-        // 原有的 image 类型（URL 图片）
-        if (block.url) {
+        if (block.data) {
           result.push({
             type: 'image',
             mimeType: block.mimeType || 'image/jpeg',
@@ -121,9 +120,8 @@ export async function contentBlocksToLoopMessageContent(
         break
 
       case 'image-block':
-        // 新增的图片块
-        if (block.source.type === 'file_id' && loadFileData) {
-          const data = await loadFileData(block.source.file_id)
+        if (block.source.type === 'file_id') {
+          const data = getBase64Payload(block.data) ?? (loadFileData ? await loadFileData(block.source.file_id) : null)
           if (data) {
             result.push({
               type: 'image',
@@ -135,26 +133,34 @@ export async function contentBlocksToLoopMessageContent(
         break
 
       case 'document':
-        // 文档块
-        if (block.source.type === 'file_id' && loadFileData) {
-          const data = await loadFileData(block.source.file_id)
+        if (block.source.type === 'file_id') {
+          const data = getBase64Payload(block.data) ?? (loadFileData ? await loadFileData(block.source.file_id) : null)
           if (data) {
             result.push({
               type: 'text',
-              text: `<document name="${block.name || 'document'}" type="${block.media_type}">\n${data}\n</document>`,
+              text: formatAttachedFileText({
+                data,
+                mediaType: block.media_type,
+                name: block.name || 'document',
+                tagName: 'document',
+              }),
             })
           }
         }
         break
 
       case 'file':
-        // 文件块
-        if (block.source.type === 'file_id' && loadFileData) {
-          const data = await loadFileData(block.source.file_id)
+        if (block.source.type === 'file_id') {
+          const data = getBase64Payload(block.data) ?? (loadFileData ? await loadFileData(block.source.file_id) : null)
           if (data) {
             result.push({
               type: 'text',
-              text: `<file name="${block.filename || block.name || 'file'}" type="${block.media_type}">\n${data}\n</file>`,
+              text: formatAttachedFileText({
+                data,
+                mediaType: block.media_type,
+                name: block.filename || block.name || 'file',
+                tagName: 'file',
+              }),
             })
           }
         }
@@ -175,4 +181,30 @@ export async function contentBlocksToLoopMessageContent(
   }
 
   return result
+}
+
+function getBase64Payload(data?: string): string | null {
+  if (!data) {
+    return null
+  }
+
+  const commaIndex = data.indexOf(',')
+  return data.startsWith('data:') && commaIndex !== -1
+    ? data.slice(commaIndex + 1)
+    : data
+}
+
+function formatAttachedFileText(input: {
+  data: string
+  mediaType?: string
+  name: string
+  tagName: 'document' | 'file'
+}): string {
+  const type = input.mediaType || 'application/octet-stream'
+  if (!isTextAttachment(type, input.name)) {
+    return `[Attached ${input.tagName}: ${input.name} (${type})]`
+  }
+
+  const decoded = Buffer.from(input.data, 'base64').toString('utf-8')
+  return `<${input.tagName} name="${input.name}" type="${type}">\n${decoded}\n</${input.tagName}>`
 }

--- a/packages/agent-core/src/utils/attachmentUtils.ts
+++ b/packages/agent-core/src/utils/attachmentUtils.ts
@@ -1,4 +1,4 @@
-import type { IAttachment, IMessageContent, LoopMessage } from '@ant-chat/shared'
+import type { IAttachment, IMessageContent, LoadFileDataFn, LoopMessage } from '@ant-chat/shared'
 import { Buffer } from 'node:buffer'
 
 const TEXT_MIME_PREFIXES = ['text/', 'application/json', 'application/xml', 'application/javascript', 'application/typescript', 'application/x-yaml', 'application/yaml', 'application/toml']
@@ -97,8 +97,6 @@ export function imagesToContentBlocks(images: IAttachment[]): LoopMessage['conte
  * 注意：对于 file_id 类型，需要先加载文件数据
  * 这个函数假设文件数据已经加载到 content blocks 中
  */
-export type LoadFileDataFn = (fileId: string) => Promise<string | null>
-
 export async function contentBlocksToLoopMessageContent(
   content: IMessageContent,
   loadFileData?: LoadFileDataFn,

--- a/packages/agent-core/src/utils/attachmentUtils.ts
+++ b/packages/agent-core/src/utils/attachmentUtils.ts
@@ -1,4 +1,4 @@
-import type { IAttachment, IMessageContent, LoadFileDataFn, LoopMessage } from '@ant-chat/shared'
+import type { IMessageContent, LoadFileDataFn, LoopMessage } from '@ant-chat/shared'
 import { Buffer } from 'node:buffer'
 
 const TEXT_MIME_PREFIXES = ['text/', 'application/json', 'application/xml', 'application/javascript', 'application/typescript', 'application/x-yaml', 'application/yaml', 'application/toml']
@@ -71,25 +71,6 @@ export function isTextAttachment(mimeType: string, fileName?: string): boolean {
       return true
   }
   return false
-}
-
-export function attachmentsToContentBlocks(attachments: IAttachment[]): LoopMessage['content'] {
-  const blocks: LoopMessage['content'] = []
-  for (const attachment of attachments) {
-    if (isTextAttachment(attachment.type, attachment.name)) {
-      const decoded = Buffer.from(attachment.data, 'base64').toString('utf-8')
-      blocks.push({ type: 'text', text: `<attached_file name="${attachment.name}">\n${decoded}\n</attached_file>` })
-    }
-  }
-  return blocks
-}
-
-export function imagesToContentBlocks(images: IAttachment[]): LoopMessage['content'] {
-  return images.map(image => ({
-    type: 'image' as const,
-    mimeType: image.type,
-    data: image.data,
-  }))
 }
 
 /**

--- a/packages/agent-runtime/src/__tests__/agentService.spec.ts
+++ b/packages/agent-runtime/src/__tests__/agentService.spec.ts
@@ -74,8 +74,11 @@ describe('createAgentRuntimeController', () => {
       mode: 'strict',
       referencedFiles: ['src/main.ts'],
       selectedSkill: 'review',
-      images: [{ uid: 'img-1', name: 'a.png', size: 1, type: 'image/png', data: 'base64' }],
-      attachments: [{ uid: 'file-1', name: 'a.txt', size: 1, type: 'text/plain', data: 'text' }],
+      content: [
+        { type: 'text', text: 'run it' },
+        { type: 'image-block', source: { type: 'file_id', file_id: 'img-1' }, name: 'a.png', media_type: 'image/png', size: 1 },
+        { type: 'document', source: { type: 'file_id', file_id: 'file-1' }, name: 'a.txt', media_type: 'text/plain', size: 1 },
+      ],
       modelConfig: {
         modelId: 'model-1',
         systemPrompt: 'custom',
@@ -93,8 +96,11 @@ describe('createAgentRuntimeController', () => {
       mode: 'strict',
       referencedFiles: ['src/main.ts'],
       selectedSkill: 'review',
-      images: [{ uid: 'img-1', name: 'a.png', size: 1, type: 'image/png', data: 'base64' }],
-      attachments: [{ uid: 'file-1', name: 'a.txt', size: 1, type: 'text/plain', data: 'text' }],
+      content: [
+        { type: 'text', text: 'run it' },
+        { type: 'image-block', source: { type: 'file_id', file_id: 'img-1' }, name: 'a.png', media_type: 'image/png', size: 1 },
+        { type: 'document', source: { type: 'file_id', file_id: 'file-1' }, name: 'a.txt', media_type: 'text/plain', size: 1 },
+      ],
     }))
   })
 })

--- a/packages/agent-runtime/src/__tests__/paths.spec.ts
+++ b/packages/agent-runtime/src/__tests__/paths.spec.ts
@@ -13,6 +13,7 @@ describe('createAgentRuntimePaths', () => {
       mcpSettingsFile: path.join('/data/ant-chat', 'mcp.json'),
       memoryRoot: path.join('/data/ant-chat', 'agent-memory'),
       workspaceSettingsFile: path.join('/data/ant-chat', 'workspace.json'),
+      attachmentsRoot: path.join('/data/ant-chat', 'attachments'),
       skillsRoot: path.join('/data/ant-chat', 'skills'),
       logsRoot: path.join('/data/ant-chat', 'logs'),
       taskLogsRoot: path.join('/data/ant-chat', 'logs', 'tasks'),

--- a/packages/agent-runtime/src/agentRuntimeController.ts
+++ b/packages/agent-runtime/src/agentRuntimeController.ts
@@ -79,10 +79,8 @@ function toRuntimeStartOptions(
 
   if (options.conversationId)
     startOptions.conversationId = options.conversationId
-  if (options.images)
-    startOptions.images = options.images
-  if (options.attachments)
-    startOptions.attachments = options.attachments
+  if (options.content)
+    startOptions.content = options.content
   if (options.referencedFiles)
     startOptions.referencedFiles = options.referencedFiles
   if (options.selectedSkill)

--- a/packages/agent-runtime/src/environment.ts
+++ b/packages/agent-runtime/src/environment.ts
@@ -48,6 +48,7 @@ export function createAgentRuntimeEnvironment(
     mcpSettingsFilePath: paths.mcpSettingsFile,
     memoryRootPath: paths.memoryRoot,
     workspaceSettingsFilePath: paths.workspaceSettingsFile,
+    attachmentsRootPath: paths.attachmentsRoot,
   })
   return {
     ...createAgentRuntimeEnvironmentFromContext({
@@ -74,6 +75,7 @@ export function createAgentRuntimeEnvironmentFromContext(
       memoryReader: appDataContext.memoryManager,
       skillReader: skillManagementService,
       mcpClientHub,
+      loadFileData: appDataContext.loadAttachmentData,
       createTaskLogger: createTaskLoggerFactory(paths.taskLogsRoot),
       getToolApprovalWhitelistEntries: () => appDataContext.toolApprovalWhitelistRepository.getAll(),
     },

--- a/packages/agent-runtime/src/paths.ts
+++ b/packages/agent-runtime/src/paths.ts
@@ -7,6 +7,7 @@ export interface AgentRuntimePaths {
   mcpSettingsFile: string
   memoryRoot: string
   workspaceSettingsFile: string
+  attachmentsRoot: string
   skillsRoot: string
   logsRoot: string
   taskLogsRoot: string
@@ -22,6 +23,7 @@ export function createAgentRuntimePaths(root: string): AgentRuntimePaths {
     mcpSettingsFile: path.join(root, 'mcp.json'),
     memoryRoot: path.join(root, 'agent-memory'),
     workspaceSettingsFile: path.join(root, 'workspace.json'),
+    attachmentsRoot: path.join(root, 'attachments'),
     skillsRoot: path.join(root, 'skills'),
     logsRoot,
     taskLogsRoot: path.join(logsRoot, 'tasks'),

--- a/packages/app-data/src/sqlite/attachmentFiles.ts
+++ b/packages/app-data/src/sqlite/attachmentFiles.ts
@@ -1,0 +1,24 @@
+import path from 'node:path'
+
+export function getAttachmentFilePath(root: string, fileId: string): string {
+  validateAttachmentFileId(fileId)
+  return path.join(root, fileId.slice(0, 2), fileId)
+}
+
+export function getLegacyAttachmentFilePath(root: string, fileId: string): string {
+  validateAttachmentFileId(fileId)
+  return path.join(root, fileId)
+}
+
+export function getAttachmentFileCandidates(root: string, fileId: string): string[] {
+  return [
+    getAttachmentFilePath(root, fileId),
+    getLegacyAttachmentFilePath(root, fileId),
+  ]
+}
+
+function validateAttachmentFileId(fileId: string): void {
+  if (!/^[\w-]+$/.test(fileId)) {
+    throw new Error(`Invalid attachment file id: ${fileId}`)
+  }
+}

--- a/packages/app-data/src/sqlite/createAppDataContext.ts
+++ b/packages/app-data/src/sqlite/createAppDataContext.ts
@@ -28,9 +28,12 @@ export function createAppDataContext(options: CreateAppDataContextOptions) {
   const appSettingsStore = new AppSettingsStore({ filePath: settingsFilePath, resetInvalidFile: true })
   const providerSettingsRepository = new ProviderSettingsRepository(appSettingsStore)
   const messageRepository = new SqliteMessageRepository(db, { attachmentsRoot: attachmentsRootPath })
+  const conversationRepository = new SqliteConversationRepository(db, {
+    prepareConversationAttachmentCleanup: messageRepository.prepareConversationAttachmentCleanup.bind(messageRepository),
+  })
 
   return {
-    conversationRepository: new SqliteConversationRepository(db),
+    conversationRepository,
     messageRepository,
     messageSearchQuery: new SqliteMessageSearchQuery(db),
     loadAttachmentData: messageRepository.loadAttachmentData.bind(messageRepository),

--- a/packages/app-data/src/sqlite/createAppDataContext.ts
+++ b/packages/app-data/src/sqlite/createAppDataContext.ts
@@ -1,8 +1,10 @@
 import type { AppDataDatabase } from './types'
+import path from 'node:path'
 import { McpSettingsRepository, McpSettingsStore } from '../mcp'
 import { AgentMemoryManager } from '../memory'
 import { AppSettingsStore, createModelCatalog, GeneralSettingsRepository, ProviderSettingsRepository, ToolApprovalWhitelistRepository } from '../settings'
 import { WorkspaceService } from '../workspace'
+import { migrateMessageAttachments, rebuildMessagesTable } from './migrations/migrateAttachments'
 import { SqliteMessageSearchQuery } from './queries'
 import { SqliteConversationRepository, SqliteMessageRepository } from './repositories'
 import { initializeAppDataSchema } from './schema'
@@ -13,19 +15,25 @@ export interface CreateAppDataContextOptions {
   mcpSettingsFilePath: string
   memoryRootPath: string
   workspaceSettingsFilePath: string
+  attachmentsRootPath?: string
 }
 
 export function createAppDataContext(options: CreateAppDataContextOptions) {
   const { db, settingsFilePath, mcpSettingsFilePath, memoryRootPath, workspaceSettingsFilePath } = options
+  const attachmentsRootPath = options.attachmentsRootPath ?? path.join(path.dirname(settingsFilePath), 'attachments')
   initializeAppDataSchema(db)
+  migrateMessageAttachments(db, attachmentsRootPath)
+  rebuildMessagesTable(db)
 
   const appSettingsStore = new AppSettingsStore({ filePath: settingsFilePath, resetInvalidFile: true })
   const providerSettingsRepository = new ProviderSettingsRepository(appSettingsStore)
+  const messageRepository = new SqliteMessageRepository(db, { attachmentsRoot: attachmentsRootPath })
 
   return {
     conversationRepository: new SqliteConversationRepository(db),
-    messageRepository: new SqliteMessageRepository(db),
+    messageRepository,
     messageSearchQuery: new SqliteMessageSearchQuery(db),
+    loadAttachmentData: messageRepository.loadAttachmentData.bind(messageRepository),
     settingsRepository: new GeneralSettingsRepository({
       filePath: settingsFilePath,
       store: appSettingsStore,

--- a/packages/app-data/src/sqlite/index.ts
+++ b/packages/app-data/src/sqlite/index.ts
@@ -1,3 +1,4 @@
+export * from './attachmentFiles'
 export * from './createAppDataContext'
 export * from './queries'
 export * from './repositories'

--- a/packages/app-data/src/sqlite/migrations/__tests__/migrateAttachments.spec.ts
+++ b/packages/app-data/src/sqlite/migrations/__tests__/migrateAttachments.spec.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { createRequire } from 'node:module'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { getAttachmentFilePath } from '../../attachmentFiles'
 import { initializeAppDataSchema } from '../../schema'
 import { migrateMessageAttachments } from '../migrateAttachments'
 
@@ -96,8 +97,8 @@ describe.skipIf(!canRunDbIntegrationTests())('migrateMessageAttachments', () => 
       size: textBytes.length,
     })
 
-    expect(readFileSync(path.join(attachmentsRoot, imageBlock.source.file_id))).toEqual(imageBytes)
-    expect(readFileSync(path.join(attachmentsRoot, documentBlock.source.file_id))).toEqual(textBytes)
+    expect(readFileSync(getAttachmentFilePath(attachmentsRoot, imageBlock.source.file_id))).toEqual(imageBytes)
+    expect(readFileSync(getAttachmentFilePath(attachmentsRoot, documentBlock.source.file_id))).toEqual(textBytes)
 
     const attachmentRows = sqlite.prepare(`
       SELECT id, name, media_type, size FROM attachments ORDER BY name

--- a/packages/app-data/src/sqlite/migrations/__tests__/migrateAttachments.spec.ts
+++ b/packages/app-data/src/sqlite/migrations/__tests__/migrateAttachments.spec.ts
@@ -1,0 +1,138 @@
+import type { Database } from 'better-sqlite3'
+import { Buffer } from 'node:buffer'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { createRequire } from 'node:module'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { initializeAppDataSchema } from '../../schema'
+import { migrateMessageAttachments } from '../migrateAttachments'
+
+describe.skipIf(!canRunDbIntegrationTests())('migrateMessageAttachments', () => {
+  let sqlite: Database
+  let attachmentsRoot: string
+
+  beforeEach(() => {
+    const BetterSqlite = loadBetterSqlite()
+    sqlite = new BetterSqlite(':memory:')
+    initializeAppDataSchema(sqlite)
+    sqlite.exec(`
+      ALTER TABLE messages ADD COLUMN images text DEFAULT '[]';
+      ALTER TABLE messages ADD COLUMN attachments text DEFAULT '[]';
+    `)
+    attachmentsRoot = mkdtempSync(path.join(tmpdir(), 'ant-chat-attachments-'))
+  })
+
+  afterEach(() => {
+    sqlite.close()
+    rmSync(attachmentsRoot, { force: true, recursive: true })
+  })
+
+  it('writes old base64 attachment data as decoded file bytes', () => {
+    const imageBytes = Buffer.from([0x89, 0x50, 0x4E, 0x47])
+    const textBytes = Buffer.from('hello attachment\n', 'utf8')
+
+    sqlite.prepare(`
+      INSERT INTO conversations (id, title, created_at, updated_at, settings)
+      VALUES (?, ?, ?, ?, ?)
+    `).run('conv-1', 'Test', 1, 1, '{}')
+
+    sqlite.prepare(`
+      INSERT INTO messages (
+        id,
+        conv_id,
+        role,
+        content,
+        created_at,
+        status,
+        images,
+        attachments
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      'msg-1',
+      'conv-1',
+      'user',
+      JSON.stringify([{ type: 'text', text: 'prompt' }]),
+      1,
+      'success',
+      JSON.stringify([{
+        uid: 'image-1',
+        name: 'image.png',
+        size: imageBytes.length,
+        type: 'image/png',
+        data: imageBytes.toString('base64'),
+      }]),
+      JSON.stringify([{
+        uid: 'file-1',
+        name: 'note.txt',
+        size: textBytes.length,
+        type: 'text/plain',
+        data: `data:text/plain;base64,${textBytes.toString('base64')}`,
+      }]),
+    )
+
+    migrateMessageAttachments(sqlite, attachmentsRoot)
+
+    const message = sqlite.prepare('SELECT content FROM messages WHERE id = ?').get('msg-1') as { content: string }
+    const content = JSON.parse(message.content)
+    const imageBlock = content[1]
+    const documentBlock = content[2]
+
+    expect(content[0]).toEqual({ type: 'text', text: 'prompt' })
+    expect(imageBlock).toEqual({
+      type: 'image-block',
+      source: { type: 'file_id', file_id: imageBlock.source.file_id },
+      name: 'image.png',
+      media_type: 'image/png',
+      size: imageBytes.length,
+    })
+    expect(documentBlock).toEqual({
+      type: 'document',
+      source: { type: 'file_id', file_id: documentBlock.source.file_id },
+      name: 'note.txt',
+      media_type: 'text/plain',
+      size: textBytes.length,
+    })
+
+    expect(readFileSync(path.join(attachmentsRoot, imageBlock.source.file_id))).toEqual(imageBytes)
+    expect(readFileSync(path.join(attachmentsRoot, documentBlock.source.file_id))).toEqual(textBytes)
+
+    const attachmentRows = sqlite.prepare(`
+      SELECT id, name, media_type, size FROM attachments ORDER BY name
+    `).all()
+
+    expect(attachmentRows).toEqual([
+      {
+        id: imageBlock.source.file_id,
+        name: 'image.png',
+        media_type: 'image/png',
+        size: imageBytes.length,
+      },
+      {
+        id: documentBlock.source.file_id,
+        name: 'note.txt',
+        media_type: 'text/plain',
+        size: textBytes.length,
+      },
+    ])
+  })
+})
+
+function canRunDbIntegrationTests() {
+  const result = spawnSync(process.execPath, ['-e', `
+    const { createRequire } = require('node:module')
+    const requireFromTest = createRequire(${JSON.stringify(import.meta.url)})
+    const Database = requireFromTest('better-sqlite3')
+    const db = new Database(':memory:')
+    db.close()
+  `], { stdio: 'ignore' })
+
+  return result.status === 0 && result.signal === null
+}
+
+function loadBetterSqlite(): new (filename: string) => Database {
+  const require = createRequire(import.meta.url)
+  return require('better-sqlite3') as new (filename: string) => Database
+}

--- a/packages/app-data/src/sqlite/migrations/migrateAttachments.ts
+++ b/packages/app-data/src/sqlite/migrations/migrateAttachments.ts
@@ -1,9 +1,10 @@
 import type { AppDataDatabase } from '../types'
 import { Buffer } from 'node:buffer'
 import * as fs from 'node:fs'
-import * as path from 'node:path'
+import path from 'node:path'
 import { classifyFile } from '@ant-chat/shared'
 import { nanoid } from 'nanoid'
+import { getAttachmentFilePath } from '../attachmentFiles'
 
 interface OldAttachment {
   uid: string
@@ -81,7 +82,8 @@ export function migrateMessageAttachments(
         // 将 images 保存到文件并创建引用
         const imageBlocks = images.map((img) => {
           const fileId = nanoid()
-          const filePath = path.join(attachmentsRoot, fileId)
+          const filePath = getAttachmentFilePath(attachmentsRoot, fileId)
+          fs.mkdirSync(path.dirname(filePath), { recursive: true })
           fs.writeFileSync(filePath, decodeAttachmentData(img.data))
 
           // 插入 attachments 表记录
@@ -108,7 +110,8 @@ export function migrateMessageAttachments(
         // 将 attachments 保存到文件并创建引用
         const attachmentBlocks = attachments.map((att) => {
           const fileId = nanoid()
-          const filePath = path.join(attachmentsRoot, fileId)
+          const filePath = getAttachmentFilePath(attachmentsRoot, fileId)
+          fs.mkdirSync(path.dirname(filePath), { recursive: true })
           fs.writeFileSync(filePath, decodeAttachmentData(att.data))
 
           // 插入 attachments 表记录

--- a/packages/app-data/src/sqlite/migrations/migrateAttachments.ts
+++ b/packages/app-data/src/sqlite/migrations/migrateAttachments.ts
@@ -1,4 +1,5 @@
 import type { AppDataDatabase } from '../types'
+import { Buffer } from 'node:buffer'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { classifyFile } from '@ant-chat/shared'
@@ -12,10 +13,28 @@ interface OldAttachment {
   data: string
 }
 
+export function decodeAttachmentData(data: string): Buffer {
+  const commaIndex = data.indexOf(',')
+  const base64Data = data.startsWith('data:') && commaIndex !== -1
+    ? data.slice(commaIndex + 1)
+    : data
+
+  return Buffer.from(base64Data, 'base64')
+}
+
+function hasColumn(db: AppDataDatabase, table: string, column: string): boolean {
+  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>
+  return rows.some(row => row.name === column)
+}
+
 export function migrateMessageAttachments(
   db: AppDataDatabase,
   attachmentsRoot: string,
 ): void {
+  if (!hasColumn(db, 'messages', 'images') || !hasColumn(db, 'messages', 'attachments')) {
+    return
+  }
+
   // 检查是否需要迁移
   const needsMigration = db.prepare(`
     SELECT COUNT(*) as count FROM messages
@@ -63,7 +82,7 @@ export function migrateMessageAttachments(
         const imageBlocks = images.map((img) => {
           const fileId = nanoid()
           const filePath = path.join(attachmentsRoot, fileId)
-          fs.writeFileSync(filePath, img.data, 'utf-8')
+          fs.writeFileSync(filePath, decodeAttachmentData(img.data))
 
           // 插入 attachments 表记录
           insertAttachmentStmt.run(
@@ -90,7 +109,7 @@ export function migrateMessageAttachments(
         const attachmentBlocks = attachments.map((att) => {
           const fileId = nanoid()
           const filePath = path.join(attachmentsRoot, fileId)
-          fs.writeFileSync(filePath, att.data, 'utf-8')
+          fs.writeFileSync(filePath, decodeAttachmentData(att.data))
 
           // 插入 attachments 表记录
           insertAttachmentStmt.run(
@@ -148,6 +167,10 @@ export function migrateMessageAttachments(
 
 // 重建 messages 表，删除 images 和 attachments 列
 export function rebuildMessagesTable(db: AppDataDatabase): void {
+  if (!hasColumn(db, 'messages', 'images') || !hasColumn(db, 'messages', 'attachments')) {
+    return
+  }
+
   db.exec(`
     CREATE TABLE IF NOT EXISTS messages_new (
       id text PRIMARY KEY NOT NULL,

--- a/packages/app-data/src/sqlite/migrations/migrateAttachments.ts
+++ b/packages/app-data/src/sqlite/migrations/migrateAttachments.ts
@@ -1,0 +1,180 @@
+import type { AppDataDatabase } from '../types'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { nanoid } from 'nanoid'
+
+interface OldAttachment {
+  uid: string
+  name: string
+  size: number
+  type: string
+  data: string
+}
+
+export function migrateMessageAttachments(
+  db: AppDataDatabase,
+  attachmentsRoot: string,
+): void {
+  // 检查是否需要迁移
+  const needsMigration = db.prepare(`
+    SELECT COUNT(*) as count FROM messages
+    WHERE images != '[]' OR attachments != '[]'
+  `).get() as { count: number }
+
+  if (needsMigration.count === 0) {
+    return
+  }
+
+  console.log(`Migrating ${needsMigration.count} messages with attachments...`)
+
+  // 确保 attachments 目录存在
+  fs.mkdirSync(attachmentsRoot, { recursive: true })
+
+  // 获取需要迁移的消息
+  const messages = db.prepare(`
+    SELECT id, content, images, attachments FROM messages
+    WHERE images != '[]' OR attachments != '[]'
+  `).all() as Array<{
+    id: string
+    content: string
+    images: string
+    attachments: string
+  }>
+
+  const updateMsgStmt = db.prepare(`
+    UPDATE messages SET content = ? WHERE id = ?
+  `)
+
+  const insertAttachmentStmt = db.prepare(`
+    INSERT INTO attachments (id, name, media_type, size, created_at)
+    VALUES (?, ?, ?, ?, ?)
+  `)
+
+  // 在事务中处理迁移
+  const migrationTransaction = db.transaction(() => {
+    for (const message of messages) {
+      try {
+        const content = JSON.parse(message.content)
+        const images: OldAttachment[] = JSON.parse(message.images || '[]')
+        const attachments: OldAttachment[] = JSON.parse(message.attachments || '[]')
+
+        // 将 images 保存到文件并创建引用
+        const imageBlocks = images.map((img) => {
+          const fileId = nanoid()
+          const filePath = path.join(attachmentsRoot, fileId)
+          fs.writeFileSync(filePath, img.data, 'utf-8')
+
+          // 插入 attachments 表记录
+          insertAttachmentStmt.run(
+            fileId,
+            img.name,
+            img.type,
+            img.size,
+            Date.now(),
+          )
+
+          return {
+            type: 'image-block',
+            source: {
+              type: 'file_id',
+              file_id: fileId,
+            },
+            name: img.name,
+            media_type: img.type,
+            size: img.size,
+          }
+        })
+
+        // 将 attachments 保存到文件并创建引用
+        const attachmentBlocks = attachments.map((att) => {
+          const fileId = nanoid()
+          const filePath = path.join(attachmentsRoot, fileId)
+          fs.writeFileSync(filePath, att.data, 'utf-8')
+
+          // 插入 attachments 表记录
+          insertAttachmentStmt.run(
+            fileId,
+            att.name,
+            att.type,
+            att.size,
+            Date.now(),
+          )
+
+          const isDocument = att.type.startsWith('text/')
+            || att.type.includes('pdf')
+            || att.type.includes('document')
+            || att.type.includes('spreadsheet')
+            || att.type.includes('presentation')
+
+          if (isDocument) {
+            return {
+              type: 'document',
+              source: {
+                type: 'file_id',
+                file_id: fileId,
+              },
+              name: att.name,
+              media_type: att.type,
+              size: att.size,
+            }
+          }
+          else {
+            return {
+              type: 'file',
+              source: {
+                type: 'file_id',
+                file_id: fileId,
+              },
+              filename: att.name,
+              name: att.name,
+              media_type: att.type,
+              size: att.size,
+            }
+          }
+        })
+
+        // 合并到 content 数组
+        const newContent = [...content, ...imageBlocks, ...attachmentBlocks]
+
+        updateMsgStmt.run(JSON.stringify(newContent), message.id)
+      }
+      catch (error) {
+        console.error(`Failed to migrate message ${message.id}:`, error)
+        throw error // 重新抛出错误，让事务回滚
+      }
+    }
+  })
+
+  migrationTransaction()
+  console.log('Message attachment migration completed.')
+}
+
+// 重建 messages 表，删除 images 和 attachments 列
+export function rebuildMessagesTable(db: AppDataDatabase): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS messages_new (
+      id text PRIMARY KEY NOT NULL,
+      conv_id text NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      role text NOT NULL,
+      content text NOT NULL,
+      created_at integer NOT NULL,
+      status text NOT NULL,
+      reasoning_content text,
+      model_info text DEFAULT NULL,
+      usage text DEFAULT NULL,
+      turn_id text DEFAULT NULL,
+      event_type text DEFAULT NULL
+    );
+
+    INSERT INTO messages_new
+    SELECT id, conv_id, role, content, created_at, status,
+           reasoning_content, model_info, usage, turn_id, event_type
+    FROM messages;
+
+    DROP TABLE messages;
+
+    ALTER TABLE messages_new RENAME TO messages;
+  `)
+
+  console.log('Messages table rebuilt without images/attachments columns.')
+}

--- a/packages/app-data/src/sqlite/migrations/migrateAttachments.ts
+++ b/packages/app-data/src/sqlite/migrations/migrateAttachments.ts
@@ -1,6 +1,7 @@
 import type { AppDataDatabase } from '../types'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
+import { classifyFile } from '@ant-chat/shared'
 import { nanoid } from 'nanoid'
 
 interface OldAttachment {
@@ -100,13 +101,9 @@ export function migrateMessageAttachments(
             Date.now(),
           )
 
-          const isDocument = att.type.startsWith('text/')
-            || att.type.includes('pdf')
-            || att.type.includes('document')
-            || att.type.includes('spreadsheet')
-            || att.type.includes('presentation')
+          const category = classifyFile(att.name, att.type)
 
-          if (isDocument) {
+          if (category === 'document') {
             return {
               type: 'document',
               source: {

--- a/packages/app-data/src/sqlite/repositories/__tests__/sqliteRepositories.spec.ts
+++ b/packages/app-data/src/sqlite/repositories/__tests__/sqliteRepositories.spec.ts
@@ -1,6 +1,10 @@
 import type { Database } from 'better-sqlite3'
+import { Buffer } from 'node:buffer'
 import { spawnSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { initializeAppDataSchema } from '../../schema'
 import { SqliteMessageSearchQuery } from '../../queries'
@@ -9,20 +13,23 @@ import { SqliteMessageRepository } from '../sqliteMessageRepository'
 
 describe.skipIf(!canRunDbIntegrationTests())('sqlite repositories', () => {
   let sqlite: Database
+  let attachmentsRoot: string
 
   beforeEach(() => {
     const BetterSqlite = loadBetterSqlite()
     sqlite = new BetterSqlite(':memory:')
     initializeAppDataSchema(sqlite)
+    attachmentsRoot = mkdtempSync(path.join(tmpdir(), 'ant-chat-repository-attachments-'))
   })
 
   afterEach(() => {
     sqlite.close()
+    rmSync(attachmentsRoot, { force: true, recursive: true })
   })
 
   it('creates conversations and paginates messages', async () => {
     const conversationRepository = new SqliteConversationRepository(sqlite)
-    const messageRepository = new SqliteMessageRepository(sqlite)
+    const messageRepository = new SqliteMessageRepository(sqlite, { attachmentsRoot })
 
     const conversation = await conversationRepository.create({
       title: 'Test',
@@ -52,7 +59,7 @@ describe.skipIf(!canRunDbIntegrationTests())('sqlite repositories', () => {
 
   it('searches text messages by keyword grouped by conversation', async () => {
     const conversationRepository = new SqliteConversationRepository(sqlite)
-    const messageRepository = new SqliteMessageRepository(sqlite)
+    const messageRepository = new SqliteMessageRepository(sqlite, { attachmentsRoot })
     const searchService = new SqliteMessageSearchQuery(sqlite)
 
     const olderConversation = await conversationRepository.create({
@@ -129,6 +136,55 @@ describe.skipIf(!canRunDbIntegrationTests())('sqlite repositories', () => {
         ],
       },
     ])
+  })
+
+  it('persists inline attachment data and stores file references in message content', async () => {
+    const conversationRepository = new SqliteConversationRepository(sqlite)
+    const messageRepository = new SqliteMessageRepository(sqlite, { attachmentsRoot })
+    const bytes = Buffer.from([0x89, 0x50, 0x4E, 0x47])
+
+    const conversation = await conversationRepository.create({
+      title: 'Attachments',
+      workspacePath: '/workspace',
+      createdAt: 1,
+      updatedAt: 1,
+      settings: {
+        modelId: 'model-1',
+        systemPrompt: '',
+        temperature: 0.7,
+        maxTokens: 1024,
+      },
+    })
+
+    const message = await messageRepository.create({
+      convId: conversation.id,
+      role: 'user',
+      status: 'success',
+      content: [
+        { type: 'text', text: 'see image' },
+        {
+          type: 'image-block',
+          source: { type: 'file_id', file_id: 'img-1' },
+          name: 'image.png',
+          media_type: 'image/png',
+          size: bytes.length,
+          data: `data:image/png;base64,${bytes.toString('base64')}`,
+        },
+      ],
+    })
+
+    expect(message.content).toEqual([
+      { type: 'text', text: 'see image' },
+      {
+        type: 'image-block',
+        source: { type: 'file_id', file_id: 'img-1' },
+        name: 'image.png',
+        media_type: 'image/png',
+        size: bytes.length,
+      },
+    ])
+    expect(readFileSync(path.join(attachmentsRoot, 'img-1'))).toEqual(bytes)
+    await expect(messageRepository.loadAttachmentData('img-1')).resolves.toBe(bytes.toString('base64'))
   })
 })
 

--- a/packages/app-data/src/sqlite/repositories/__tests__/sqliteRepositories.spec.ts
+++ b/packages/app-data/src/sqlite/repositories/__tests__/sqliteRepositories.spec.ts
@@ -6,6 +6,7 @@ import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { getAttachmentFilePath } from '../../attachmentFiles'
 import { initializeAppDataSchema } from '../../schema'
 import { SqliteMessageSearchQuery } from '../../queries'
 import { SqliteConversationRepository } from '../sqliteConversationRepository'
@@ -183,8 +184,72 @@ describe.skipIf(!canRunDbIntegrationTests())('sqlite repositories', () => {
         size: bytes.length,
       },
     ])
-    expect(readFileSync(path.join(attachmentsRoot, 'img-1'))).toEqual(bytes)
+    expect(readFileSync(getAttachmentFilePath(attachmentsRoot, 'img-1'))).toEqual(bytes)
     await expect(messageRepository.loadAttachmentData('img-1')).resolves.toBe(bytes.toString('base64'))
+  })
+
+  it('removes attachment files when messages and conversations are deleted', async () => {
+    const messageRepository = new SqliteMessageRepository(sqlite, { attachmentsRoot })
+    const conversationRepository = new SqliteConversationRepository(sqlite, {
+      prepareConversationAttachmentCleanup: messageRepository.prepareConversationAttachmentCleanup.bind(messageRepository),
+    })
+    const bytes = Buffer.from('file content', 'utf8')
+
+    const conversation = await conversationRepository.create({
+      title: 'Cleanup',
+      workspacePath: '/workspace',
+      createdAt: 1,
+      updatedAt: 1,
+      settings: {
+        modelId: 'model-1',
+        systemPrompt: '',
+        temperature: 0.7,
+        maxTokens: 1024,
+      },
+    })
+
+    const first = await messageRepository.create({
+      convId: conversation.id,
+      role: 'user',
+      status: 'success',
+      content: [
+        { type: 'text', text: 'first' },
+        {
+          type: 'document',
+          source: { type: 'file_id', file_id: 'doc-1' },
+          name: 'doc.txt',
+          media_type: 'text/plain',
+          size: bytes.length,
+          data: bytes.toString('base64'),
+        },
+      ],
+    })
+    await messageRepository.create({
+      convId: conversation.id,
+      role: 'user',
+      status: 'success',
+      content: [
+        { type: 'text', text: 'second' },
+        {
+          type: 'file',
+          source: { type: 'file_id', file_id: 'file-1' },
+          filename: 'archive.zip',
+          media_type: 'application/zip',
+          size: bytes.length,
+          data: bytes.toString('base64'),
+        },
+      ],
+    })
+
+    expect(readFileSync(getAttachmentFilePath(attachmentsRoot, 'doc-1'))).toEqual(bytes)
+    expect(readFileSync(getAttachmentFilePath(attachmentsRoot, 'file-1'))).toEqual(bytes)
+
+    await messageRepository.delete(first.id)
+    await expect(messageRepository.loadAttachmentData('doc-1')).resolves.toBeNull()
+    expect(readFileSync(getAttachmentFilePath(attachmentsRoot, 'file-1'))).toEqual(bytes)
+
+    await conversationRepository.delete(conversation.id)
+    await expect(messageRepository.loadAttachmentData('file-1')).resolves.toBeNull()
   })
 })
 

--- a/packages/app-data/src/sqlite/repositories/__tests__/sqliteRepositories.spec.ts
+++ b/packages/app-data/src/sqlite/repositories/__tests__/sqliteRepositories.spec.ts
@@ -41,8 +41,6 @@ describe.skipIf(!canRunDbIntegrationTests())('sqlite repositories', () => {
       role: 'user',
       status: 'success',
       content: [{ type: 'text', text: 'hello' }],
-      images: [],
-      attachments: [],
     })
 
     const messages = await messageRepository.listByConversation(conversation.id)
@@ -87,24 +85,18 @@ describe.skipIf(!canRunDbIntegrationTests())('sqlite repositories', () => {
       role: 'user',
       status: 'success',
       content: [{ type: 'text', text: 'needle in older conversation' }],
-      images: [],
-      attachments: [],
     })
     await messageRepository.create({
       convId: newerConversation.id,
       role: 'user',
       status: 'success',
       content: [{ type: 'image', mimeType: 'image/png', data: 'base64' }],
-      images: [],
-      attachments: [],
     })
     const matchedMessage = await messageRepository.create({
       convId: newerConversation.id,
       role: 'user',
       status: 'success',
       content: [{ type: 'text', text: 'newer conversation has needle' }],
-      images: [],
-      attachments: [],
     })
 
     const results = await searchService.searchMessagesByKeyword('needle')

--- a/packages/app-data/src/sqlite/repositories/sqliteConversationRepository.ts
+++ b/packages/app-data/src/sqlite/repositories/sqliteConversationRepository.ts
@@ -6,6 +6,10 @@ import { AddConversationsSchema as AddConversationInput, UpdateConversationsSche
 import { nanoid } from 'nanoid'
 import { mapConversationRow, stringifyJson } from '../rows'
 
+interface SqliteConversationRepositoryOptions {
+  prepareConversationAttachmentCleanup?: (conversationId: string) => () => void
+}
+
 const CONVERSATION_COLUMNS = `
   id,
   workspace_path,
@@ -16,7 +20,10 @@ const CONVERSATION_COLUMNS = `
 `
 
 export class SqliteConversationRepository implements ConversationRepository {
-  constructor(private readonly db: AppDataDatabase) {}
+  constructor(
+    private readonly db: AppDataDatabase,
+    private readonly options: SqliteConversationRepositoryOptions = {},
+  ) {}
 
   async list(pageIndex: number, pageSize: number = 10, workspacePath?: string, includeNullWorkspace = false) {
     const workspaceWhere = getWorkspaceWhere(workspacePath, includeNullWorkspace)
@@ -120,10 +127,16 @@ export class SqliteConversationRepository implements ConversationRepository {
   }
 
   async delete(id: string): Promise<boolean> {
-    const result = this.db.prepare('DELETE FROM conversations WHERE id = ?').run(id)
-    if (result.changes === 0)
-      throw new Error('会话未找到')
+    let cleanupFiles = () => {}
+    const deleteConversation = this.db.transaction(() => {
+      cleanupFiles = this.options.prepareConversationAttachmentCleanup?.(id) ?? cleanupFiles
+      const result = this.db.prepare('DELETE FROM conversations WHERE id = ?').run(id)
+      if (result.changes === 0)
+        throw new Error('会话未找到')
+    })
 
+    deleteConversation()
+    cleanupFiles()
     return true
   }
 

--- a/packages/app-data/src/sqlite/repositories/sqliteMessageRepository.ts
+++ b/packages/app-data/src/sqlite/repositories/sqliteMessageRepository.ts
@@ -13,8 +13,6 @@ const MESSAGE_COLUMNS = `
   content,
   created_at,
   status,
-  images,
-  attachments,
   reasoning_content,
   model_info,
   usage,
@@ -64,15 +62,13 @@ export class SqliteMessageRepository implements MessageRepository {
         content,
         created_at,
         status,
-        images,
-        attachments,
         reasoning_content,
         model_info,
         usage,
         turn_id,
         event_type
       )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       RETURNING ${MESSAGE_COLUMNS}
     `).get(
       id,
@@ -81,8 +77,6 @@ export class SqliteMessageRepository implements MessageRepository {
       stringifyJson(message.content),
       Date.now(),
       message.status,
-      'images' in message ? stringifyJson(message.images) : stringifyJson([]),
-      'attachments' in message ? stringifyJson(message.attachments) : stringifyJson([]),
       'reasoningContent' in message ? message.reasoningContent ?? null : null,
       'modelInfo' in message ? stringifyNullableJson(message.modelInfo) : null,
       'usage' in message ? stringifyNullableJson(message.usage) : null,

--- a/packages/app-data/src/sqlite/repositories/sqliteMessageRepository.ts
+++ b/packages/app-data/src/sqlite/repositories/sqliteMessageRepository.ts
@@ -2,11 +2,12 @@ import type { AddMessage, AIMessage, IMessage, MessageContent, UpdateMessageSche
 import type { MessageRepository } from '../../repositories'
 import type { MessageRow } from '../rows'
 import type { AppDataDatabase } from '../types'
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import { nanoid } from 'nanoid'
+import { getAttachmentFileCandidates, getAttachmentFilePath } from '../attachmentFiles'
 import { decodeAttachmentData } from '../migrations/migrateAttachments'
-import { mapMessageRow, stringifyJson } from '../rows'
+import { mapMessageRow, parseMessageContent, stringifyJson } from '../rows'
 import { SqliteConversationRepository } from './sqliteConversationRepository'
 
 interface SqliteMessageRepositoryOptions {
@@ -64,42 +65,52 @@ export class SqliteMessageRepository implements MessageRepository {
     await this.conversations.getById(message.convId)
 
     const id = `msg-${nanoid()}`
-    const content = this.persistAttachmentData(message.content)
-    const result = this.db.prepare<unknown[], MessageRow>(`
-      INSERT INTO messages (
-        id,
-        conv_id,
-        role,
-        content,
-        created_at,
-        status,
-        reasoning_content,
-        model_info,
-        usage,
-        turn_id,
-        event_type
-      )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      RETURNING ${MESSAGE_COLUMNS}
-    `).get(
-      id,
-      message.convId,
-      message.role,
-      stringifyJson(content),
-      Date.now(),
-      message.status,
-      'reasoningContent' in message ? message.reasoningContent ?? null : null,
-      'modelInfo' in message ? stringifyNullableJson(message.modelInfo) : null,
-      'usage' in message ? stringifyNullableJson(message.usage) : null,
-      'turnId' in message ? message.turnId ?? null : null,
-      'eventType' in message ? message.eventType ?? null : null,
-    )
+    const writtenFiles: string[] = []
+    try {
+      const createMessage = this.db.transaction(() => {
+        const content = this.persistAttachmentData(message.content, writtenFiles)
+        return this.db.prepare<unknown[], MessageRow>(`
+          INSERT INTO messages (
+            id,
+            conv_id,
+            role,
+            content,
+            created_at,
+            status,
+            reasoning_content,
+            model_info,
+            usage,
+            turn_id,
+            event_type
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          RETURNING ${MESSAGE_COLUMNS}
+        `).get(
+          id,
+          message.convId,
+          message.role,
+          stringifyJson(content),
+          Date.now(),
+          message.status,
+          'reasoningContent' in message ? message.reasoningContent ?? null : null,
+          'modelInfo' in message ? stringifyNullableJson(message.modelInfo) : null,
+          'usage' in message ? stringifyNullableJson(message.usage) : null,
+          'turnId' in message ? message.turnId ?? null : null,
+          'eventType' in message ? message.eventType ?? null : null,
+        )
+      })
 
-    if (!result) {
-      throw new Error('创建消息失败')
+      const result = createMessage()
+      if (!result) {
+        throw new Error('创建消息失败')
+      }
+
+      return mapMessageRow(result)
     }
-
-    return mapMessageRow(result)
+    catch (error) {
+      cleanupWrittenFiles(writtenFiles)
+      throw error
+    }
   }
 
   async createAssistant(conversationId: string, modelInfo: AIMessage['modelInfo'], turnId?: string): Promise<IMessage> {
@@ -126,10 +137,9 @@ export class SqliteMessageRepository implements MessageRepository {
       fields.push('role = ?')
       params.push(message.role)
     }
-    if (message.content !== undefined) {
+    const writtenFiles: string[] = []
+    if (message.content !== undefined)
       fields.push('content = ?')
-      params.push(stringifyJson(this.persistAttachmentData(message.content)))
-    }
     if (message.status !== undefined) {
       fields.push('status = ?')
       params.push(message.status)
@@ -160,12 +170,17 @@ export class SqliteMessageRepository implements MessageRepository {
     }
 
     const updateMessage = this.db.transaction(() => {
+      const transactionParams = [...params]
+      if (message.content !== undefined) {
+        transactionParams.splice(fields.findIndex(field => field === 'content = ?'), 0, stringifyJson(this.persistAttachmentData(message.content, writtenFiles)))
+      }
+
       const result = this.db.prepare<unknown[], MessageRow>(`
         UPDATE messages
         SET ${fields.join(', ')}
         WHERE id = ?
         RETURNING ${MESSAGE_COLUMNS}
-      `).get(...params, message.id)
+      `).get(...transactionParams, message.id)
 
       if (!result) {
         throw new Error('消息未找到')
@@ -180,40 +195,68 @@ export class SqliteMessageRepository implements MessageRepository {
       return result
     })
 
-    return mapMessageRow(updateMessage())
+    try {
+      return mapMessageRow(updateMessage())
+    }
+    catch (error) {
+      cleanupWrittenFiles(writtenFiles)
+      throw error
+    }
   }
 
   async delete(id: string): Promise<boolean> {
-    this.db.prepare('DELETE FROM messages WHERE id = ?').run(id)
+    const fileIds = this.getMessageAttachmentFileIds([id])
+    const deleteMessage = this.db.transaction(() => {
+      this.db.prepare('DELETE FROM messages WHERE id = ?').run(id)
+      this.deleteAttachmentRows(fileIds)
+    })
+
+    deleteMessage()
+    this.removeAttachmentFiles(fileIds)
     return true
   }
 
   async batchDelete(ids: string[]): Promise<boolean> {
+    const fileIds = this.getMessageAttachmentFileIds(ids)
     const deleteMessages = this.db.transaction((messageIds: string[]) => {
       const statement = this.db.prepare('DELETE FROM messages WHERE id = ?')
       for (const id of messageIds) {
         statement.run(id)
       }
+      this.deleteAttachmentRows(fileIds)
     })
 
     deleteMessages(ids)
+    this.removeAttachmentFiles(fileIds)
     return true
   }
 
   async loadAttachmentData(fileId: string): Promise<string | null> {
-    const filePath = this.getAttachmentFilePath(fileId)
-    try {
-      return readFileSync(filePath).toString('base64')
-    }
-    catch (error) {
-      if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
-        return null
+    for (const filePath of this.getAttachmentFileCandidates(fileId)) {
+      try {
+        return readFileSync(filePath).toString('base64')
       }
-      throw error
+      catch (error) {
+        if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+          continue
+        }
+        throw error
+      }
     }
+    return null
   }
 
-  private persistAttachmentData(content: MessageContent): MessageContent {
+  prepareConversationAttachmentCleanup(conversationId: string): () => void {
+    const ids = this.db.prepare<unknown[], { id: string }>(`
+      SELECT id FROM messages WHERE conv_id = ?
+    `).all(conversationId).map(row => row.id)
+    const fileIds = this.getMessageAttachmentFileIds(ids)
+
+    this.deleteAttachmentRows(fileIds)
+    return () => this.removeAttachmentFiles(fileIds)
+  }
+
+  private persistAttachmentData(content: MessageContent, writtenFiles: string[]): MessageContent {
     return content.map((block) => {
       if (
         block.type !== 'image-block'
@@ -231,10 +274,11 @@ export class SqliteMessageRepository implements MessageRepository {
         throw new Error('Attachment content with inline data must use file_id source')
       }
 
-      const filePath = this.getAttachmentFilePath(block.source.file_id)
+      const filePath = getAttachmentFilePath(this.requireAttachmentsRoot(), block.source.file_id)
       mkdirSync(path.dirname(filePath), { recursive: true })
       const bytes = decodeAttachmentData(block.data)
       writeFileSync(filePath, bytes)
+      writtenFiles.push(filePath)
 
       this.db.prepare(`
         INSERT OR REPLACE INTO attachments (id, name, media_type, size, created_at)
@@ -252,15 +296,60 @@ export class SqliteMessageRepository implements MessageRepository {
     })
   }
 
-  private getAttachmentFilePath(fileId: string): string {
+  private getMessageAttachmentFileIds(messageIds: string[]): string[] {
+    if (messageIds.length === 0) {
+      return []
+    }
+
+    const placeholders = messageIds.map(() => '?').join(', ')
+    const rows = this.db.prepare<unknown[], { content: string }>(`
+      SELECT content FROM messages WHERE id IN (${placeholders})
+    `).all(...messageIds)
+    const ids = new Set<string>()
+    for (const row of rows) {
+      for (const block of parseMessageContent(row.content)) {
+        if (
+          (block.type === 'image-block' || block.type === 'document' || block.type === 'file')
+          && block.source.type === 'file_id'
+        ) {
+          ids.add(block.source.file_id)
+        }
+      }
+    }
+
+    return [...ids]
+  }
+
+  private deleteAttachmentRows(fileIds: string[]): void {
+    const statement = this.db.prepare('DELETE FROM attachments WHERE id = ?')
+    for (const fileId of fileIds) {
+      statement.run(fileId)
+    }
+  }
+
+  private removeAttachmentFiles(fileIds: string[]): void {
+    for (const fileId of fileIds) {
+      for (const filePath of this.getAttachmentFileCandidates(fileId)) {
+        rmSync(filePath, { force: true })
+      }
+    }
+  }
+
+  private getAttachmentFileCandidates(fileId: string): string[] {
+    return getAttachmentFileCandidates(this.requireAttachmentsRoot(), fileId)
+  }
+
+  private requireAttachmentsRoot(): string {
     if (!this.options.attachmentsRoot) {
       throw new Error('attachmentsRoot is required for attachment file storage')
     }
-    if (!/^[\w-]+$/.test(fileId)) {
-      throw new Error(`Invalid attachment file id: ${fileId}`)
-    }
+    return this.options.attachmentsRoot
+  }
+}
 
-    return path.join(this.options.attachmentsRoot, fileId)
+function cleanupWrittenFiles(filePaths: string[]): void {
+  for (const filePath of filePaths) {
+    rmSync(filePath, { force: true })
   }
 }
 

--- a/packages/app-data/src/sqlite/repositories/sqliteMessageRepository.ts
+++ b/packages/app-data/src/sqlite/repositories/sqliteMessageRepository.ts
@@ -1,10 +1,17 @@
-import type { AddMessage, AIMessage, IMessage, UpdateMessageSchema } from '@ant-chat/shared'
+import type { AddMessage, AIMessage, IMessage, MessageContent, UpdateMessageSchema } from '@ant-chat/shared'
 import type { MessageRepository } from '../../repositories'
 import type { MessageRow } from '../rows'
 import type { AppDataDatabase } from '../types'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
 import { nanoid } from 'nanoid'
+import { decodeAttachmentData } from '../migrations/migrateAttachments'
 import { mapMessageRow, stringifyJson } from '../rows'
 import { SqliteConversationRepository } from './sqliteConversationRepository'
+
+interface SqliteMessageRepositoryOptions {
+  attachmentsRoot?: string
+}
 
 const MESSAGE_COLUMNS = `
   id,
@@ -23,7 +30,10 @@ const MESSAGE_COLUMNS = `
 export class SqliteMessageRepository implements MessageRepository {
   private readonly conversations: SqliteConversationRepository
 
-  constructor(private readonly db: AppDataDatabase) {
+  constructor(
+    private readonly db: AppDataDatabase,
+    private readonly options: SqliteMessageRepositoryOptions = {},
+  ) {
     this.conversations = new SqliteConversationRepository(db)
   }
 
@@ -54,6 +64,7 @@ export class SqliteMessageRepository implements MessageRepository {
     await this.conversations.getById(message.convId)
 
     const id = `msg-${nanoid()}`
+    const content = this.persistAttachmentData(message.content)
     const result = this.db.prepare<unknown[], MessageRow>(`
       INSERT INTO messages (
         id,
@@ -74,7 +85,7 @@ export class SqliteMessageRepository implements MessageRepository {
       id,
       message.convId,
       message.role,
-      stringifyJson(message.content),
+      stringifyJson(content),
       Date.now(),
       message.status,
       'reasoningContent' in message ? message.reasoningContent ?? null : null,
@@ -117,7 +128,7 @@ export class SqliteMessageRepository implements MessageRepository {
     }
     if (message.content !== undefined) {
       fields.push('content = ?')
-      params.push(stringifyJson(message.content))
+      params.push(stringifyJson(this.persistAttachmentData(message.content)))
     }
     if (message.status !== undefined) {
       fields.push('status = ?')
@@ -187,6 +198,69 @@ export class SqliteMessageRepository implements MessageRepository {
 
     deleteMessages(ids)
     return true
+  }
+
+  async loadAttachmentData(fileId: string): Promise<string | null> {
+    const filePath = this.getAttachmentFilePath(fileId)
+    try {
+      return readFileSync(filePath).toString('base64')
+    }
+    catch (error) {
+      if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+        return null
+      }
+      throw error
+    }
+  }
+
+  private persistAttachmentData(content: MessageContent): MessageContent {
+    return content.map((block) => {
+      if (
+        block.type !== 'image-block'
+        && block.type !== 'document'
+        && block.type !== 'file'
+      ) {
+        return block
+      }
+
+      if (!block.data) {
+        return block
+      }
+
+      if (block.source.type !== 'file_id') {
+        throw new Error('Attachment content with inline data must use file_id source')
+      }
+
+      const filePath = this.getAttachmentFilePath(block.source.file_id)
+      mkdirSync(path.dirname(filePath), { recursive: true })
+      const bytes = decodeAttachmentData(block.data)
+      writeFileSync(filePath, bytes)
+
+      this.db.prepare(`
+        INSERT OR REPLACE INTO attachments (id, name, media_type, size, created_at)
+        VALUES (?, ?, ?, ?, ?)
+      `).run(
+        block.source.file_id,
+        block.type === 'file' ? block.filename ?? block.name ?? 'file' : block.name ?? block.type,
+        block.media_type ?? 'application/octet-stream',
+        block.size ?? bytes.byteLength,
+        Date.now(),
+      )
+
+      const { data: _data, ...persistedBlock } = block
+      return persistedBlock
+    })
+  }
+
+  private getAttachmentFilePath(fileId: string): string {
+    if (!this.options.attachmentsRoot) {
+      throw new Error('attachmentsRoot is required for attachment file storage')
+    }
+    if (!/^[\w-]+$/.test(fileId)) {
+      throw new Error(`Invalid attachment file id: ${fileId}`)
+    }
+
+    return path.join(this.options.attachmentsRoot, fileId)
   }
 }
 

--- a/packages/app-data/src/sqlite/repositories/sqliteMessageRepository.ts
+++ b/packages/app-data/src/sqlite/repositories/sqliteMessageRepository.ts
@@ -129,14 +129,6 @@ export class SqliteMessageRepository implements MessageRepository {
       fields.push('status = ?')
       params.push(message.status)
     }
-    if (message.images !== undefined) {
-      fields.push('images = ?')
-      params.push(stringifyJson(message.images))
-    }
-    if (message.attachments !== undefined) {
-      fields.push('attachments = ?')
-      params.push(stringifyJson(message.attachments))
-    }
     if (message.reasoningContent !== undefined) {
       fields.push('reasoning_content = ?')
       params.push(message.reasoningContent)

--- a/packages/app-data/src/sqlite/rows.ts
+++ b/packages/app-data/src/sqlite/rows.ts
@@ -1,5 +1,4 @@
 import type {
-  AttachmentSchema,
   ConversationsSettingsSchema,
   IConversations,
   IMessage,
@@ -8,13 +7,11 @@ import type {
   ModelInfo,
 } from '@ant-chat/shared'
 import {
-  AttachmentSchema as AttachmentInput,
   ConversationsSettingsSchema as ConversationSettingsInput,
   LanguageModelUsageSchema,
   MessageContentSchema,
   ModelInfoSchema,
 } from '@ant-chat/shared'
-import { z } from 'zod'
 
 export interface ConversationRow {
   id: string
@@ -32,16 +29,12 @@ export interface MessageRow {
   content: string
   created_at: number
   status: string
-  images: string | null
-  attachments: string | null
   reasoning_content: string | null
   model_info: string | null
   usage: string | null
   turn_id: string | null
   event_type: string | null
 }
-
-const AttachmentListInput = z.array(AttachmentInput)
 
 export function mapConversationRow(row: ConversationRow): IConversations {
   return {
@@ -62,8 +55,6 @@ export function mapMessageRow(row: MessageRow): IMessage {
     content: parseMessageContent(row.content),
     createdAt: row.created_at,
     status: row.status as IMessage['status'],
-    images: parseAttachmentList(row.images ?? '[]'),
-    attachments: parseAttachmentList(row.attachments ?? '[]'),
     reasoningContent: row.reasoning_content ?? undefined,
     modelInfo: parseNullableModelInfo(row.model_info),
     usage: parseNullableUsage(row.usage),
@@ -82,10 +73,6 @@ function parseConversationSettings(value: string): ConversationsSettingsSchema {
 
 export function parseMessageContent(value: string): MessageContent {
   return MessageContentSchema.parse(JSON.parse(value))
-}
-
-function parseAttachmentList(value: string): AttachmentSchema[] {
-  return AttachmentListInput.parse(JSON.parse(value))
 }
 
 function parseNullableModelInfo(value: string | null): ModelInfo | undefined {

--- a/packages/app-data/src/sqlite/schema.ts
+++ b/packages/app-data/src/sqlite/schema.ts
@@ -34,5 +34,13 @@ export function initializeAppDataSchema(db: AppDataDatabase): void {
       turn_id text DEFAULT NULL,
       event_type text DEFAULT NULL
     );
+
+    CREATE TABLE IF NOT EXISTS attachments (
+      id text PRIMARY KEY NOT NULL,
+      name text NOT NULL,
+      media_type text NOT NULL,
+      size integer NOT NULL,
+      created_at integer NOT NULL
+    );
   `)
 }

--- a/packages/app-data/src/sqlite/schema.ts
+++ b/packages/app-data/src/sqlite/schema.ts
@@ -26,8 +26,6 @@ export function initializeAppDataSchema(db: AppDataDatabase): void {
       content text NOT NULL,
       created_at integer NOT NULL,
       status text NOT NULL,
-      images text DEFAULT '[]',
-      attachments text DEFAULT '[]',
       reasoning_content text,
       model_info text DEFAULT NULL,
       usage text DEFAULT NULL,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -2,6 +2,7 @@ export * from './appPaths'
 export * from './interfaces'
 export * from './ipc-events'
 export * from './schemas'
+export * from './utils'
 
 /**
  * 默认的MCP工具名称分隔符

--- a/packages/shared/src/interfaces/agent-runtime-electron.ts
+++ b/packages/shared/src/interfaces/agent-runtime-electron.ts
@@ -1,5 +1,5 @@
 import type { AgentMode } from './agent-runtime'
-import type { ChatFeatures, IAttachment, IConversations } from './db-types'
+import type { ChatFeatures, IConversations, IMessageContent } from './db-types'
 import type { ChatSettings } from './model-service'
 
 /**
@@ -8,8 +8,7 @@ import type { ChatSettings } from './model-service'
 export interface StartAgentTurnOptions {
   conversationId?: string
   prompt: string
-  images?: IAttachment[]
-  attachments?: IAttachment[]
+  content?: IMessageContent
   referencedFiles?: string[]
   selectedSkill?: string
   workspacePath?: string

--- a/packages/shared/src/interfaces/agent-runtime-interfaces.ts
+++ b/packages/shared/src/interfaces/agent-runtime-interfaces.ts
@@ -214,6 +214,8 @@ export interface AgentRuntimeHost {
   memoryReader?: AgentMemoryReader
   skillReader?: SkillReader
   mcpClientHub?: RuntimeMcpClientHub
+  /** 加载附件文件数据（用于将 file_id 转换为 base64 数据） */
+  loadFileData?: (fileId: string) => Promise<string | null>
   getToolApprovalWhitelistEntries?: () => ToolApprovalWhitelistEntry[]
 }
 

--- a/packages/shared/src/interfaces/agent-runtime-interfaces.ts
+++ b/packages/shared/src/interfaces/agent-runtime-interfaces.ts
@@ -2,7 +2,7 @@ import type { AddConversationsSchema, AddMessage, ModelInfo, ProviderConfigSchem
 import type { AgentMemoryReader } from './agent-memory'
 import type { AgentMode, AgentPendingAction, AgentTaskSnapshot, ToolApprovalWhitelistEntry } from './agent-runtime'
 import type { AgentTool } from './agent-tools'
-import type { IAttachment, IConversations, IMessage } from './db-types'
+import type { IConversations, IMessage, IMessageContent } from './db-types'
 import type { McpServer, McpToolCallResponse } from './mcp'
 import type { ImportSkillFromGithubOptions, SkillManifest } from './skill'
 
@@ -252,8 +252,7 @@ export interface AgentRuntimeStartTaskOptions {
   modelId: string
   workspacePath: string
   mode?: AgentMode
-  images?: IAttachment[]
-  attachments?: IAttachment[]
+  content?: IMessageContent
   referencedFiles?: string[]
   selectedSkill?: string
   chatSettings?: {

--- a/packages/shared/src/interfaces/agent-runtime-interfaces.ts
+++ b/packages/shared/src/interfaces/agent-runtime-interfaces.ts
@@ -244,6 +244,8 @@ export interface AgentRuntimeConfig extends AgentRuntimeOverrides {
   getToolApprovalWhitelistEntries?: () => ToolApprovalWhitelistEntry[]
   skillReader?: SkillReader
   mcpClientHub?: RuntimeMcpClientHub
+  /** 加载附件文件数据（用于将 file_id 转换为 base64 数据） */
+  loadFileData?: (fileId: string) => Promise<string | null>
 }
 
 export interface AgentRuntimeStartTaskOptions {

--- a/packages/shared/src/interfaces/db-types.ts
+++ b/packages/shared/src/interfaces/db-types.ts
@@ -44,8 +44,6 @@ export interface IMessageBase {
 export interface IMessageUser extends IMessageBase {
   role: 'user'
   content: IMessageContent
-  images: IAttachment[]
-  attachments: IAttachment[]
   status: 'success'
 }
 
@@ -84,8 +82,6 @@ export interface IMessage {
   content: IMessageContent
   reasoningContent?: string
   status: 'success' | 'error' | 'loading' | 'typing' | 'cancel'
-  images?: IAttachment[]
-  attachments?: IAttachment[]
   /** 生成当前消息的模型信息 */
   modelInfo?: IModelInfo
   /** token usage for this message */

--- a/packages/shared/src/schemas/messages.ts
+++ b/packages/shared/src/schemas/messages.ts
@@ -48,6 +48,70 @@ export const ToolResultContentSchema = z.object({
 
 export type ToolResultContent = z.infer<typeof ToolResultContentSchema>
 
+// ============================ 新增：文件引用类型 ============================
+
+// 文件 ID 来源（本地存储）
+export const FileIdSourceSchema = z.object({
+  type: z.literal('file_id'),
+  file_id: z.string(),
+})
+
+export type FileIdSource = z.infer<typeof FileIdSourceSchema>
+
+// URL 来源（远程图片）
+export const UrlSourceSchema = z.object({
+  type: z.literal('url'),
+  url: z.string(),
+})
+
+export type UrlSource = z.infer<typeof UrlSourceSchema>
+
+// 内容来源联合类型
+export const ContentSourceSchema = z.union([
+  FileIdSourceSchema,
+  UrlSourceSchema,
+])
+
+export type ContentSource = z.infer<typeof ContentSourceSchema>
+
+// 图片内容块（通过 file_id 引用本地文件）
+export const ImageBlockSchema = z.object({
+  type: z.literal('image-block'),
+  source: ContentSourceSchema,
+  name: z.string().optional(),
+  media_type: z.string().optional(),
+  size: z.number().optional(),
+})
+
+export type ImageBlock = z.infer<typeof ImageBlockSchema>
+
+// 文档内容块（通过 file_id 引用本地文件）
+export const DocumentBlockSchema = z.object({
+  type: z.literal('document'),
+  source: ContentSourceSchema,
+  title: z.string().optional(),
+  context: z.string().optional(),
+  name: z.string().optional(),
+  media_type: z.string().optional(),
+  size: z.number().optional(),
+})
+
+export type DocumentBlock = z.infer<typeof DocumentBlockSchema>
+
+// 文件内容块（通用类型，用于非图片非文档的文件）
+export const FileBlockSchema = z.object({
+  type: z.literal('file'),
+  source: ContentSourceSchema,
+  filename: z.string().optional(),
+  name: z.string().optional(),
+  media_type: z.string().optional(),
+  size: z.number().optional(),
+})
+
+export type FileBlock = z.infer<typeof FileBlockSchema>
+
+// ============================ 消息内容 Schema ============================
+
 // 消息内容
 export const MessageContentSchema = z.array(z.union([
   TextContentSchema,
@@ -55,6 +119,9 @@ export const MessageContentSchema = z.array(z.union([
   ErrorContentSchema,
   ToolCallContentSchema,
   ToolResultContentSchema,
+  ImageBlockSchema,
+  DocumentBlockSchema,
+  FileBlockSchema,
 ]))
 
 export type MessageContent = z.infer<typeof MessageContentSchema>
@@ -125,8 +192,9 @@ const BaseMessage = z.object({
 
 export const UserMessage = BaseMessage.extend({
   role: z.literal('user'),
-  images: z.array(AttachmentSchema),
-  attachments: z.array(AttachmentSchema),
+  // 移除独立的 images 和 attachments 字段，合并到 content 中
+  // images: z.array(AttachmentSchema),
+  // attachments: z.array(AttachmentSchema),
   status: z.literal('success'),
 })
 
@@ -175,7 +243,8 @@ export const UpdateMessageSchema = BaseMessage.extend({
   role: z.enum(['assistant', 'user', 'tool', 'event']),
   eventType: z.string().optional(),
   ...(AIMessage.pick({ modelInfo: true, reasoningContent: true, usage: true }).shape),
-  ...(UserMessage.pick({ images: true, attachments: true }).shape),
+  // 移除 images 和 attachments 字段
+  // ...(UserMessage.pick({ images: true, attachments: true }).shape),
 }).partial().extend({ id: z.string() })
 
 export type UpdateMessageSchema = z.infer<typeof UpdateMessageSchema>

--- a/packages/shared/src/schemas/messages.ts
+++ b/packages/shared/src/schemas/messages.ts
@@ -81,6 +81,7 @@ export const ImageBlockSchema = z.object({
   name: z.string().optional(),
   media_type: z.string().optional(),
   size: z.number().optional(),
+  data: z.string().optional(),
 })
 
 export type ImageBlock = z.infer<typeof ImageBlockSchema>
@@ -94,6 +95,7 @@ export const DocumentBlockSchema = z.object({
   name: z.string().optional(),
   media_type: z.string().optional(),
   size: z.number().optional(),
+  data: z.string().optional(),
 })
 
 export type DocumentBlock = z.infer<typeof DocumentBlockSchema>
@@ -106,6 +108,7 @@ export const FileBlockSchema = z.object({
   name: z.string().optional(),
   media_type: z.string().optional(),
   size: z.number().optional(),
+  data: z.string().optional(),
 })
 
 export type FileBlock = z.infer<typeof FileBlockSchema>

--- a/packages/shared/src/schemas/messages.ts
+++ b/packages/shared/src/schemas/messages.ts
@@ -81,6 +81,7 @@ export const ImageBlockSchema = z.object({
   name: z.string().optional(),
   media_type: z.string().optional(),
   size: z.number().optional(),
+  // Transport-only payload. App data strips it before persisting message content.
   data: z.string().optional(),
 })
 
@@ -95,6 +96,7 @@ export const DocumentBlockSchema = z.object({
   name: z.string().optional(),
   media_type: z.string().optional(),
   size: z.number().optional(),
+  // Transport-only payload. App data strips it before persisting message content.
   data: z.string().optional(),
 })
 
@@ -108,6 +110,7 @@ export const FileBlockSchema = z.object({
   name: z.string().optional(),
   media_type: z.string().optional(),
   size: z.number().optional(),
+  // Transport-only payload. App data strips it before persisting message content.
   data: z.string().optional(),
 })
 
@@ -195,9 +198,6 @@ const BaseMessage = z.object({
 
 export const UserMessage = BaseMessage.extend({
   role: z.literal('user'),
-  // 移除独立的 images 和 attachments 字段，合并到 content 中
-  // images: z.array(AttachmentSchema),
-  // attachments: z.array(AttachmentSchema),
   status: z.literal('success'),
 })
 
@@ -246,8 +246,6 @@ export const UpdateMessageSchema = BaseMessage.extend({
   role: z.enum(['assistant', 'user', 'tool', 'event']),
   eventType: z.string().optional(),
   ...(AIMessage.pick({ modelInfo: true, reasoningContent: true, usage: true }).shape),
-  // 移除 images 和 attachments 字段
-  // ...(UserMessage.pick({ images: true, attachments: true }).shape),
 }).partial().extend({ id: z.string() })
 
 export type UpdateMessageSchema = z.infer<typeof UpdateMessageSchema>

--- a/packages/shared/src/utils/fileClassification.ts
+++ b/packages/shared/src/utils/fileClassification.ts
@@ -1,0 +1,116 @@
+/**
+ * 文件分类工具函数
+ * 根据 MIME 类型判断文件属于 image、document 还是 file
+ */
+
+export type FileCategory = 'image' | 'document' | 'file'
+
+/**
+ * 加载文件数据的回调函数类型
+ * 用于将 file_id 转换为 base64 数据
+ */
+export type LoadFileDataFn = (fileId: string) => Promise<string | null>
+
+/**
+ * 根据 MIME 类型判断文件分类
+ * @param mimeType 文件的 MIME 类型
+ * @returns 文件分类：'image' | 'document' | 'file'
+ */
+export function classifyFileByMimeType(mimeType: string): FileCategory {
+  if (mimeType.startsWith('image/')) {
+    return 'image'
+  }
+
+  const isDocument = mimeType.startsWith('text/')
+    || mimeType.includes('pdf')
+    || mimeType.includes('document')
+    || mimeType.includes('spreadsheet')
+    || mimeType.includes('presentation')
+    || mimeType.includes('msword')
+    || mimeType.includes('ms-excel')
+    || mimeType.includes('ms-powerpoint')
+    || mimeType.includes('opendocument')
+    || mimeType.includes('openxmlformats')
+
+  if (isDocument) {
+    return 'document'
+  }
+
+  return 'file'
+}
+
+/**
+ * 根据文件名和 MIME 类型判断文件分类
+ * @param fileName 文件名
+ * @param mimeType 文件的 MIME 类型
+ * @returns 文件分类：'image' | 'document' | 'file'
+ */
+export function classifyFile(fileName: string, mimeType: string): FileCategory {
+  // 优先根据 MIME 类型判断
+  const category = classifyFileByMimeType(mimeType)
+  if (category !== 'file') {
+    return category
+  }
+
+  // 如果 MIME 类型判断为 file，再根据文件扩展名判断
+  const ext = fileName.includes('.') ? `.${fileName.split('.').pop()!.toLowerCase()}` : ''
+  const documentExtensions = new Set([
+    '.txt',
+    '.md',
+    '.markdown',
+    '.rst',
+    '.org',
+    '.pdf',
+    '.doc',
+    '.docx',
+    '.xls',
+    '.xlsx',
+    '.ppt',
+    '.pptx',
+    '.odt',
+    '.ods',
+    '.odp',
+    '.rtf',
+    '.csv',
+    '.tsv',
+    '.json',
+    '.xml',
+    '.yaml',
+    '.yml',
+    '.toml',
+    '.html',
+    '.htm',
+    '.css',
+    '.scss',
+    '.less',
+    '.js',
+    '.jsx',
+    '.ts',
+    '.tsx',
+    '.mjs',
+    '.cjs',
+    '.py',
+    '.rb',
+    '.go',
+    '.rs',
+    '.java',
+    '.kt',
+    '.swift',
+    '.c',
+    '.cpp',
+    '.h',
+    '.hpp',
+    '.sh',
+    '.bash',
+    '.zsh',
+    '.sql',
+    '.graphql',
+    '.proto',
+  ])
+
+  if (documentExtensions.has(ext)) {
+    return 'document'
+  }
+
+  return 'file'
+}

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './fileClassification'


### PR DESCRIPTION
## 概述

这个 PR 将消息的 `images` 和 `attachments` 字段合并到 `content` 字段中，使用统一的 content block 格式。

## 主要变更

### 1. 类型系统扩展
- 新增 `ImageBlock`、`DocumentBlock`、`FileBlock` 类型
- 使用 `source` 对象模式（`file_id`/`url`）统一数据来源
- 参考主流 LLM 服务商 API 设计（Anthropic、OpenAI、Google）

### 2. 附件存储系统
- 创建 `AttachmentStorage` 类（文件读写）
- 创建 `AttachmentService` 类（业务逻辑）
- 文件存储在 `.ant-chat/attachments/` 目录

### 3. 数据库迁移
- 添加 `attachments` 表（存储元数据）
- 创建迁移脚本（将旧数据迁移到新格式）
- 重建 `messages` 表（移除旧列）

### 4. 前端 UI 适配
- 创建 `ContentBlockRenderer` 组件（统一渲染）
- 更新 `MessageBubble`、`Sender`、`Chat` 组件
- 更新消息转换和搜索功能

## 技术决策

1. **采用 Anthropic 的 source 对象模式** - 统一数据来源，兼容 LLM 服务商 API
2. **区分 image、document、file 类型** - 语义清晰，便于后续扩展
3. **使用 file_id 引用** - content 字段保持轻量，文件数据按需加载
4. **本地文件存储** - 适合桌面应用，文件系统更适合大文件
5. **attachments 表存储元数据** - 便于查询和管理附件

## 优势

1. **消除数据冗余** - 图片和附件数据不再重复存储
2. **简化数据流** - 消除转换层，存储格式与 LLM 协议一致
3. **性能优化** - content 字段保持轻量，文件按需加载
4. **扩展性好** - 新增 content block 类型时扩展自然

## 数据存储结构

### 数据库

```sql
-- attachments 表
CREATE TABLE attachments (
  id text PRIMARY KEY NOT NULL,
  name text NOT NULL,
  media_type text NOT NULL,
  size integer NOT NULL,
  created_at integer NOT NULL
);

-- messages 表（移除 images 和 attachments 列）
CREATE TABLE messages (
  id text PRIMARY KEY NOT NULL,
  conv_id text NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
  role text NOT NULL,
  content text NOT NULL,  -- JSON 格式的 content blocks
  created_at integer NOT NULL,
  status text NOT NULL,
  reasoning_content text,
  model_info text DEFAULT NULL,
  usage text DEFAULT NULL,
  turn_id text DEFAULT NULL,
  event_type text DEFAULT NULL
);
```

### Content Block 格式

```typescript
// 图片内容块
{
  type: 'image-block',
  source: {
    type: 'file_id',
    file_id: 'abc123'
  },
  name: 'photo.jpg',
  media_type: 'image/jpeg',
  size: 1024000
}

// 文档内容块
{
  type: 'document',
  source: {
    type: 'file_id',
    file_id: 'def456'
  },
  name: 'report.pdf',
  media_type: 'application/pdf',
  size: 2048000
}

// 文件内容块
{
  type: 'file',
  source: {
    type: 'file_id',
    file_id: 'ghi789'
  },
  filename: 'data.csv',
  name: 'data.csv',
  media_type: 'text/csv',
  size: 512000
}
```

## 测试

- ✅ TypeScript 类型检查通过
- ✅ Lint 检查通过（0 errors, 17 warnings）
- ✅ 所有测试通过（272 tests）

## 关键文件

| 文件 | 说明 |
|------|------|
| `packages/shared/src/schemas/messages.ts` | 类型定义 |
| `packages/agent-runtime/src/storage/attachmentStorage.ts` | 文件存储 |
| `packages/agent-runtime/src/services/attachmentService.ts` | 业务逻辑 |
| `apps/web/src/components/Chat/ContentBlockRenderer.tsx` | UI 渲染 |
| `packages/app-data/src/sqlite/migrations/migrateAttachments.ts` | 数据迁移 |

## 下一步

1. **运行应用测试** - 测试完整的提交-存储-渲染流程
2. **创建附件加载 API** - 用于图片显示
3. **样式优化** - 优化 ContentBlockRenderer 的样式
4. **清理策略** - 设计附件清理机制