### PR TITLE
fix(agent-runtime): fallback to SKILL.md frontmatter when manifest.json is missing in rebuildIndex

### DIFF
--- a/packages/agent-runtime/src/skills/skillManagementService.ts
+++ b/packages/agent-runtime/src/skills/skillManagementService.ts
@@ -142,7 +142,29 @@ export class SkillManagementService {
         }
         skills.push(manifest)
       }
-      catch {}
+      catch {
+        // Fallback: if manifest.json is missing, build one from SKILL.md frontmatter
+        try {
+          const skillPath = path.join(this.skillsRoot, entry.name)
+          const skillFile = path.join(skillPath, 'SKILL.md')
+          if (fs.existsSync(skillFile)) {
+            const metadata = await readSkillMetadata(skillPath)
+            const now = Date.now()
+            const manifest: SkillManifest = {
+              name: metadata.name || entry.name,
+              version: metadata.version,
+              description: metadata.description,
+              source: 'zip',
+              enabled: true,
+              installedAt: now,
+              updatedAt: now,
+            }
+            await this.writeManifest(skillPath, manifest)
+            skills.push(manifest)
+          }
+        }
+        catch {}
+      }
     }
     skills.sort((a, b) => a.name.localeCompare(b.name, 'en'))
     await fs.promises.writeFile(path.join(this.skillsRoot, INDEX_FILE), JSON.stringify(skills, null, 2), 'utf8')


### PR DESCRIPTION
## 问题

`rebuildIndex()` 只通过 `readManifest()` 读取 `manifest.json`，如果 skill 目录下缺少 `manifest.json`，空 `catch {}` 会静默跳过该 skill，使其无法进入索引。例如 `frontend-design` skill 只有 `SKILL.md` 没有 `manifest.json`，导致索引构建时被遗漏。

## 修复

在 `rebuildIndex()` 中增加回退逻辑：当 `manifest.json` 缺失时，解析 `SKILL.md` 的 YAML frontmatter 提取元数据，并自动生成 `manifest.json`。这与 `importFromDirectory` 所使用的 `readSkillMetadata()` 函数行为一致。

## 验证

- 所有已有测试通过（4 suites, 9 tests）
- 修复后 `rebuildIndex()` 能正确处理仅有 `SKILL.md` 的 skill 目录