### PR TITLE
refactor: redesign assistant message trace with collapsible steps

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,8 +1,6 @@
 import { Toaster } from '@workspace/ui/components/sonner'
-import { useState } from 'react'
 import { Outlet } from 'react-router'
 import { AppProviders } from './AppProviders'
-import { SliderMenu } from './components/SiliderMenu'
 import { UpdateNotification } from './components/UpdateNotification'
 import { useAppEventListener } from './hooks/useAppEventListener'
 import { useUpdateNotification } from './hooks/useUpdateNotification'
@@ -19,44 +17,13 @@ function AppWrapper() {
 function AntChatApp() {
   useAppEventListener()
   const { updateInfo, showNotification, hideNotification } = useUpdateNotification()
-  const [showSliderMenu, setShowSliderMenu] = useState(true)
 
   return (
     <div className="flex h-dvh w-full overflow-hidden">
-      <div className="app-region-drag absolute top-0 left-0 z-9999 h-4 w-full"></div>
-      <div
-        role="button"
-        tabIndex={0}
-        className="absolute top-4 left-22.5 z-9990 cursor-pointer text-slate-600"
-        onClick={() => {
-          setShowSliderMenu(prev => !prev)
-        }}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault()
-            setShowSliderMenu(prev => !prev)
-          }
-        }}
-      >
-        <span
-          className={`
-            text-xl
-            ${showSliderMenu
-      ? 'icon-[fluent--panel-left-24-filled]'
-      : 'icon-[fluent--panel-left-24-regular]'}
-          `}
-        >
-        </span>
-      </div>
-      <div
-        className={`
-          overflow-hidden transition-[width,opacity] duration-300 ease-in-out
-          ${showSliderMenu ? 'w-74 opacity-100' : 'w-0 opacity-0'}
-        `}
-      >
-        <SliderMenu />
-      </div>
-      <div className="h-dvh min-w-0 flex-1">
+      {/* Window drag region (Electron) */}
+      <div className="app-region-drag absolute top-0 left-0 z-50 h-10 w-full md:h-4" />
+
+      <div className="min-w-0 flex-1">
         <Outlet />
       </div>
 

--- a/apps/web/src/components/Chat/AssistantTrace.tsx
+++ b/apps/web/src/components/Chat/AssistantTrace.tsx
@@ -16,7 +16,7 @@ import {
   WrenchIcon,
   XCircleIcon,
 } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 
 // ---- step types ----
 
@@ -142,44 +142,31 @@ function useTraceAutoExpand(steps: ContentStep[]) {
     return null
   }, [traceSteps])
 
-  const userToggledRef = useRef<Set<string>>(new Set())
-  const prevActiveRef = useRef<string | null>(null)
-  const [openState, setOpenState] = useState<Record<string, boolean>>({})
+  // User overrides: explicit open/close toggles that trump auto-behavior
+  const [userOverrides, setUserOverrides] = useState<Record<string, boolean>>({})
+  const openStateRef = useRef<Record<string, boolean>>({})
 
-  // Sync open state with steps and activeStepId
-  useEffect(() => {
-    setOpenState((prev) => {
-      const next: Record<string, boolean> = {}
-      let changed = false
-      for (const step of traceSteps) {
-        if (userToggledRef.current.has(step.id)) {
-          next[step.id] = prev[step.id] ?? computeDefaultOpen(step)
-        }
-        else if (step.id === activeStepId) {
-          next[step.id] = true
-        }
-        else {
-          next[step.id] = computeDefaultOpen(step)
-        }
-        if (next[step.id] !== prev[step.id])
-          changed = true
+  // Compute open state during render — no useEffect needed
+  const openState = useMemo(() => {
+    const next: Record<string, boolean> = {}
+    for (const step of traceSteps) {
+      if (step.id in userOverrides) {
+        next[step.id] = userOverrides[step.id]
       }
-      return changed ? next : prev
-    })
-  }, [traceSteps, activeStepId])
-
-  // Auto-close previous active when active changes
-  useEffect(() => {
-    const prev = prevActiveRef.current
-    if (prev && prev !== activeStepId && !userToggledRef.current.has(prev)) {
-      setOpenState(s => (s[prev] === true ? { ...s, [prev]: false } : s))
+      else if (step.id === activeStepId) {
+        next[step.id] = true
+      }
+      else {
+        next[step.id] = computeDefaultOpen(step)
+      }
     }
-    prevActiveRef.current = activeStepId
-  }, [activeStepId])
+    openStateRef.current = next
+    return next
+  }, [traceSteps, activeStepId, userOverrides])
 
   const handleToggle = useCallback((stepId: string) => {
-    userToggledRef.current.add(stepId)
-    setOpenState(s => ({ ...s, [stepId]: !s[stepId] }))
+    const currentOpen = openStateRef.current[stepId] ?? false
+    setUserOverrides(prev => ({ ...prev, [stepId]: !currentOpen }))
   }, [])
 
   return { openState, handleToggle, traceSteps, activeStepId }

--- a/apps/web/src/components/Chat/AssistantTrace.tsx
+++ b/apps/web/src/components/Chat/AssistantTrace.tsx
@@ -1,0 +1,551 @@
+import type { IMessage, ToolCallContent, ToolResultContent } from '@ant-chat/shared'
+import { CodeBlock } from '@workspace/ui/components/ai-elements/code-block'
+import { MessageResponse } from '@workspace/ui/components/ai-elements/message'
+import { Alert, AlertDescription, AlertTitle } from '@workspace/ui/components/alert'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@workspace/ui/components/collapsible'
+import { cn } from '@workspace/ui/lib/utils'
+import {
+  BrainIcon,
+  CheckCircleIcon,
+  ChevronDownIcon,
+  Loader2Icon,
+  WrenchIcon,
+  XCircleIcon,
+} from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+// ---- step types ----
+
+interface ToolStepData {
+  id: string
+  toolCall: ToolCallContent
+  toolResult?: ToolResultContent
+  isExecuting: boolean
+}
+
+type ContentStep
+  = | { type: 'reasoning', id: string, content: string, isStreaming: boolean }
+    | { type: 'tool', id: string, toolCall: ToolCallContent, toolResult?: ToolResultContent, isExecuting: boolean }
+    | { type: 'tool-group', id: string, tools: ToolStepData[], isExecuting: boolean }
+    | { type: 'text', id: string, text: string }
+    | { type: 'error-block', id: string, error: string }
+
+type TraceStep = Extract<ContentStep, { type: 'reasoning' | 'tool' | 'tool-group' }>
+
+// ---- build steps ----
+
+const TOOL_GROUP_THRESHOLD = 2
+
+function buildContentSteps(
+  message: IMessage,
+  toolResultMap: Map<string, IMessage>,
+  showReasoning: boolean,
+): ContentStep[] {
+  const steps: ContentStep[] = []
+
+  // Reasoning always first, before any content block
+  if (showReasoning && message.reasoningContent) {
+    const isStreaming = message.status === 'loading' || message.status === 'typing'
+    steps.push({
+      type: 'reasoning',
+      id: `${message.id}:reasoning`,
+      content: message.reasoningContent,
+      isStreaming,
+    })
+  }
+
+  // Content blocks in original order; consecutive tool-calls grouped
+  if (Array.isArray(message.content)) {
+    let textIndex = 0
+    let errorIndex = 0
+    const pendingTools: ToolStepData[] = []
+
+    function flushToolGroup() {
+      if (pendingTools.length === 0)
+        return
+      if (pendingTools.length < TOOL_GROUP_THRESHOLD) {
+        const t = pendingTools[0]
+        steps.push({ type: 'tool', id: t.id, toolCall: t.toolCall, toolResult: t.toolResult, isExecuting: t.isExecuting })
+      }
+      else {
+        const first = pendingTools[0]
+        steps.push({
+          type: 'tool-group',
+          id: `tool-group:${first.id}`,
+          tools: [...pendingTools],
+          isExecuting: pendingTools.some(t => t.isExecuting),
+        })
+      }
+      pendingTools.length = 0
+    }
+
+    for (const block of message.content) {
+      if (block.type === 'tool-call') {
+        const resultMsg = toolResultMap.get(block.toolCallId)
+        const resultBlock = resultMsg?.content.find(
+          (b): b is typeof b & { type: 'tool-result' } => b.type === 'tool-result',
+        )
+        pendingTools.push({
+          id: block.toolCallId,
+          toolCall: block,
+          toolResult: resultBlock as ToolResultContent | undefined,
+          isExecuting: !resultBlock,
+        })
+      }
+      else {
+        flushToolGroup()
+        if (block.type === 'text') {
+          steps.push({
+            type: 'text',
+            id: `${message.id}:text:${textIndex++}`,
+            text: block.text,
+          })
+        }
+        else if (block.type === 'error') {
+          steps.push({
+            type: 'error-block',
+            id: `${message.id}:error:${errorIndex++}`,
+            error: block.error,
+          })
+        }
+      }
+    }
+    flushToolGroup()
+  }
+
+  return steps
+}
+
+function isTraceStep(step: ContentStep): step is TraceStep {
+  return step.type === 'reasoning' || step.type === 'tool' || step.type === 'tool-group'
+}
+
+// ---- auto-expand/collapse ----
+
+function useTraceAutoExpand(steps: ContentStep[]) {
+  const traceSteps = useMemo(() => steps.filter(isTraceStep), [steps])
+
+  const activeStepId = useMemo(() => {
+    for (let i = traceSteps.length - 1; i >= 0; i--) {
+      const step = traceSteps[i]
+      if (step.type === 'reasoning' && step.isStreaming)
+        return step.id
+      if (step.type === 'tool' && step.isExecuting)
+        return step.id
+      if (step.type === 'tool-group' && step.isExecuting)
+        return step.id
+    }
+    return null
+  }, [traceSteps])
+
+  const userToggledRef = useRef<Set<string>>(new Set())
+  const prevActiveRef = useRef<string | null>(null)
+  const [openState, setOpenState] = useState<Record<string, boolean>>({})
+
+  // Sync open state with steps and activeStepId
+  useEffect(() => {
+    setOpenState((prev) => {
+      const next: Record<string, boolean> = {}
+      let changed = false
+      for (const step of traceSteps) {
+        if (userToggledRef.current.has(step.id)) {
+          next[step.id] = prev[step.id] ?? computeDefaultOpen(step)
+        }
+        else if (step.id === activeStepId) {
+          next[step.id] = true
+        }
+        else {
+          next[step.id] = computeDefaultOpen(step)
+        }
+        if (next[step.id] !== prev[step.id])
+          changed = true
+      }
+      return changed ? next : prev
+    })
+  }, [traceSteps, activeStepId])
+
+  // Auto-close previous active when active changes
+  useEffect(() => {
+    const prev = prevActiveRef.current
+    if (prev && prev !== activeStepId && !userToggledRef.current.has(prev)) {
+      setOpenState(s => (s[prev] === true ? { ...s, [prev]: false } : s))
+    }
+    prevActiveRef.current = activeStepId
+  }, [activeStepId])
+
+  const handleToggle = useCallback((stepId: string) => {
+    userToggledRef.current.add(stepId)
+    setOpenState(s => ({ ...s, [stepId]: !s[stepId] }))
+  }, [])
+
+  return { openState, handleToggle, traceSteps, activeStepId }
+}
+
+function computeDefaultOpen(step: TraceStep): boolean {
+  if (step.type === 'reasoning')
+    return step.isStreaming
+  if (step.type === 'tool')
+    return step.isExecuting
+  return step.isExecuting
+}
+
+// ---- sub-components ----
+
+function CollapseChevron({ open }: { open: boolean }) {
+  return (
+    <ChevronDownIcon
+      className={cn(
+        'size-3.5 ml-auto shrink-0 opacity-0 transition-all',
+        'group-hover:opacity-100',
+        open && 'rotate-180 opacity-100',
+      )}
+    />
+  )
+}
+
+function ReasoningStepItem({
+  step,
+  open,
+  onToggle,
+}: {
+  step: Extract<ContentStep, { type: 'reasoning' }>
+  open: boolean
+  onToggle: (id: string) => void
+}) {
+  return (
+    <Collapsible open={open} onOpenChange={() => onToggle(step.id)}>
+      <CollapsibleTrigger
+        className={cn(
+          'flex w-full items-center gap-1.5 py-1 text-sm transition-colors group',
+          'text-muted-foreground hover:text-foreground',
+        )}
+      >
+        <BrainIcon className="size-3 shrink-0" />
+        <span className="text-xs">
+          {step.isStreaming ? 'Thinking...' : 'Thought complete'}
+        </span>
+        {step.isStreaming && <Loader2Icon className="size-3 animate-spin" />}
+        <CollapseChevron open={open} />
+      </CollapsibleTrigger>
+      <CollapsibleContent
+        className={cn(
+          'ml-4 pl-2',
+          'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-1',
+          'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-top-1',
+        )}
+      >
+        <div className="py-1 text-xs text-muted-foreground whitespace-pre-wrap">
+          {step.content}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}
+
+// ---- tool parameter extraction ----
+
+/** Extract the most relevant inline parameter for the tool header. */
+function getInlineParam(toolCall: ToolCallContent): string | null {
+  const args = toolCall.args as Record<string, unknown> | undefined
+  if (!args || typeof args !== 'object')
+    return null
+
+  switch (toolCall.toolName) {
+    case 'read_file':
+    case 'write_to_file':
+    case 'replace_in_file':
+      return typeof args.filePath === 'string'
+        ? args.filePath
+        : typeof args.path === 'string'
+          ? args.path
+          : null
+    case 'search_content':
+    case 'search_file':
+      return typeof args.pattern === 'string'
+        ? args.pattern
+        : typeof args.regex === 'string'
+          ? args.regex
+          : null
+    case 'bash':
+      return typeof args.command === 'string' ? args.command : null
+    default:
+      return null
+  }
+}
+
+// ---- compact tool header icon ----
+
+function ToolStatusIcon({ state }: { state: 'input-available' | 'output-available' | 'output-error' }) {
+  if (state === 'output-error') {
+    return <XCircleIcon className="size-3 shrink-0 text-destructive" />
+  }
+  if (state === 'output-available') {
+    return <CheckCircleIcon className="size-3 shrink-0 text-green-600" />
+  }
+  return <Loader2Icon className="size-3 shrink-0 animate-spin text-muted-foreground" />
+}
+
+function CompactToolItem({
+  tool,
+  open,
+  onToggle,
+}: {
+  tool: ToolStepData
+  open: boolean
+  onToggle: (id: string) => void
+}) {
+  const hasResult = !!tool.toolResult
+  const state = hasResult
+    ? (tool.toolResult!.isError ? 'output-error' as const : 'output-available' as const)
+    : 'input-available' as const
+  const inlineParam = getInlineParam(tool.toolCall)
+
+  return (
+    <Collapsible open={open} onOpenChange={() => onToggle(tool.id)}>
+      <CollapsibleTrigger
+        className={cn(
+          'flex w-full min-w-0 items-center gap-1.5 py-1 text-sm transition-colors group',
+          'text-muted-foreground hover:text-foreground',
+        )}
+      >
+        <ToolStatusIcon state={state} />
+        <span className="font-medium text-xs shrink-0">{tool.toolCall.toolName}</span>
+        {inlineParam && (
+          <span className="text-xs text-muted-foreground/60 truncate min-w-0">
+            {inlineParam}
+          </span>
+        )}
+        <CollapseChevron open={open} />
+      </CollapsibleTrigger>
+      <CollapsibleContent
+        className={cn(
+          'ml-4 pl-2 space-y-2',
+          'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-1',
+          'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-top-1',
+        )}
+      >
+        {tool.toolResult && (
+          <div
+            className={cn(
+              'rounded text-xs overflow-y-auto',
+              '[&_pre]:text-xs! [&_code]:text-xs!',
+              tool.toolResult.isError
+                ? 'text-destructive'
+                : 'bg-muted/50 text-foreground',
+            )}
+          >
+            <CodeBlock code={String(tool.toolResult.result)} language="json" className="max-h-40 overflow-y-auto mb-1" />
+
+          </div>
+        )}
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}
+
+function ToolGroupItem({
+  group,
+  open,
+  onToggle,
+}: {
+  group: Extract<ContentStep, { type: 'tool-group' }>
+  open: boolean
+  onToggle: (id: string) => void
+}) {
+  const toolCount = group.tools.length
+
+  return (
+    <Collapsible open={open} onOpenChange={() => onToggle(group.id)}>
+      <CollapsibleTrigger
+        className={cn(
+          'flex w-full items-center gap-1.5 py-1 text-sm transition-colors group',
+          'text-muted-foreground hover:text-foreground',
+        )}
+      >
+        {group.isExecuting
+          ? <Loader2Icon className="size-3 shrink-0 animate-spin text-muted-foreground" />
+          : <WrenchIcon className="size-3 shrink-0 text-muted-foreground" />}
+        <span className="text-xs">
+          View
+          {' '}
+          {toolCount}
+          {' '}
+          steps
+        </span>
+        <CollapseChevron open={open} />
+      </CollapsibleTrigger>
+      <CollapsibleContent
+        className={cn(
+          'ml-4 pl-2 space-y-1',
+          'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-1',
+          'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-top-1',
+        )}
+      >
+        {group.tools.map(tool => (
+          <CompactToolItem
+            key={tool.id}
+            tool={tool}
+            open={!tool.toolResult}
+            onToggle={onToggle}
+          />
+        ))}
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}
+
+function TraceStepItem({
+  step,
+  open,
+  onToggle,
+}: {
+  step: TraceStep
+  open: boolean
+  onToggle: (stepId: string) => void
+}) {
+  if (step.type === 'reasoning') {
+    return <ReasoningStepItem step={step} open={open} onToggle={onToggle} />
+  }
+  if (step.type === 'tool-group') {
+    return <ToolGroupItem group={step} open={open} onToggle={onToggle} />
+  }
+  return (
+    <CompactToolItem
+      tool={{ id: step.id, toolCall: step.toolCall, toolResult: step.toolResult, isExecuting: step.isExecuting }}
+      open={open}
+      onToggle={onToggle}
+    />
+  )
+}
+
+// ---- helpers ----
+
+function isNetworkError(text: string): boolean {
+  if (!text)
+    return false
+  const patterns = /network|connection|fetch|abort|timeout|econnrefused|enotfound|socket|disconnected|econnreset|etimedout/i
+  return patterns.test(text)
+}
+
+function getErrorText(message: IMessage): string {
+  return message.content
+    .filter(b => b.type === 'error')
+    .map(b => b.error)
+    .join('\n')
+}
+
+function hasTextContent(message: IMessage): boolean {
+  return message.content.some(b => b.type === 'text' && b.text.length > 0)
+}
+
+// ---- public component ----
+
+interface AssistantTraceProps {
+  message: IMessage
+  toolResultMap: Map<string, IMessage>
+  /** Whether to show reasoning step. False for visible messages whose reasoning was extracted to the fold. */
+  showReasoning?: boolean
+}
+
+/**
+ * Renders assistant message content in order.
+ * Consecutive trace steps (reasoning / tool / tool-group) share one
+ * continuous left border. Text and error blocks break the border.
+ */
+export function AssistantTrace({ message, toolResultMap, showReasoning = true }: AssistantTraceProps) {
+  const steps = useMemo(
+    () => buildContentSteps(message, toolResultMap, showReasoning),
+    [message, toolResultMap, showReasoning],
+  )
+
+  const { openState, handleToggle } = useTraceAutoExpand(steps)
+  const isStreaming = message.status === 'loading' || message.status === 'typing'
+
+  // Group consecutive same-kind steps so trace items share a single left border
+  const renderGroups = useMemo(() => {
+    const groups: Array<{ steps: ContentStep[], isTrace: boolean }> = []
+    for (const step of steps) {
+      const currentIsTrace = isTraceStep(step)
+      const last = groups[groups.length - 1]
+      if (last && last.isTrace === currentIsTrace) {
+        last.steps.push(step)
+      }
+      else {
+        groups.push({ steps: [step], isTrace: currentIsTrace })
+      }
+    }
+    return groups
+  }, [steps])
+
+  return (
+    <div className="space-y-3">
+      {renderGroups.map((group) => {
+        // Consecutive trace steps: single bordered wrapper
+        if (group.isTrace) {
+          return (
+            <div
+              key={group.steps[0].id}
+              className="ml-3 border-l-2 border-muted/60 pl-4 space-y-0.5"
+            >
+              {group.steps.map(step => (
+                <TraceStepItem
+                  key={step.id}
+                  step={step as TraceStep}
+                  open={openState[step.id] ?? false}
+                  onToggle={handleToggle}
+                />
+              ))}
+            </div>
+          )
+        }
+
+        // Non-trace steps: render inline without border
+        return group.steps.map((step) => {
+          if (step.type === 'text') {
+            return (
+              <MessageResponse key={step.id} isAnimating={isStreaming}>
+                {step.text}
+              </MessageResponse>
+            )
+          }
+          if (step.type === 'error-block') {
+            return (
+              <p key={step.id} className="text-destructive whitespace-pre-wrap text-sm">
+                {step.error}
+              </p>
+            )
+          }
+          return null
+        })
+      })}
+
+      {/* Status alerts */}
+      {message.status === 'error' && (
+        <Alert variant="destructive">
+          <XCircleIcon className="size-4" />
+          <AlertTitle>
+            {isNetworkError(getErrorText(message)) ? 'Connection interrupted' : 'Request failed'}
+          </AlertTitle>
+          <AlertDescription>
+            <p className="whitespace-pre-wrap">
+              {getErrorText(message) || '请求失败。请检查配置并重试。'}
+            </p>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {message.status === 'cancel' && (
+        <Alert variant="default">
+          <AlertTitle>Cancelled</AlertTitle>
+          <AlertDescription>
+            {hasTextContent(message) ? null : <p>Task cancelled.</p>}
+          </AlertDescription>
+        </Alert>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/Chat/AssistantTrace.tsx
+++ b/apps/web/src/components/Chat/AssistantTrace.tsx
@@ -17,6 +17,7 @@ import {
   XCircleIcon,
 } from 'lucide-react'
 import { useCallback, useMemo, useRef, useState } from 'react'
+import { isNetworkError } from '@/utils/networkError'
 
 // ---- step types ----
 
@@ -129,7 +130,25 @@ function isTraceStep(step: ContentStep): step is TraceStep {
 function useTraceAutoExpand(steps: ContentStep[]) {
   const traceSteps = useMemo(() => steps.filter(isTraceStep), [steps])
 
+  // Collect child-tool ids so they have entries in openState
+  const childToolEntries = useMemo(() => {
+    const entries: { id: string, isExecuting: boolean }[] = []
+    for (const step of traceSteps) {
+      if (step.type === 'tool-group') {
+        for (const tool of step.tools) {
+          entries.push({ id: tool.id, isExecuting: tool.isExecuting })
+        }
+      }
+    }
+    return entries
+  }, [traceSteps])
+
   const activeStepId = useMemo(() => {
+    // Check child tools first (most granular), then groups, then top-level steps
+    for (const e of childToolEntries) {
+      if (e.isExecuting)
+        return e.id
+    }
     for (let i = traceSteps.length - 1; i >= 0; i--) {
       const step = traceSteps[i]
       if (step.type === 'reasoning' && step.isStreaming)
@@ -140,7 +159,7 @@ function useTraceAutoExpand(steps: ContentStep[]) {
         return step.id
     }
     return null
-  }, [traceSteps])
+  }, [traceSteps, childToolEntries])
 
   // User overrides: explicit open/close toggles that trump auto-behavior
   const [userOverrides, setUserOverrides] = useState<Record<string, boolean>>({})
@@ -149,20 +168,38 @@ function useTraceAutoExpand(steps: ContentStep[]) {
   // Compute open state during render — no useEffect needed
   const openState = useMemo(() => {
     const next: Record<string, boolean> = {}
-    for (const step of traceSteps) {
-      if (step.id in userOverrides) {
-        next[step.id] = userOverrides[step.id]
+
+    function setOpen(id: string, defaultOpen: boolean) {
+      if (id in userOverrides) {
+        next[id] = userOverrides[id]
       }
-      else if (step.id === activeStepId) {
-        next[step.id] = true
+      else if (id === activeStepId) {
+        next[id] = true
       }
       else {
-        next[step.id] = computeDefaultOpen(step)
+        next[id] = defaultOpen
       }
     }
+
+    for (const step of traceSteps) {
+      if (step.type === 'tool-group') {
+        setOpen(step.id, step.isExecuting)
+        for (const tool of step.tools) {
+          setOpen(tool.id, tool.isExecuting)
+        }
+      }
+      else if (step.type === 'reasoning') {
+        setOpen(step.id, step.isStreaming)
+      }
+      else {
+        // single tool
+        setOpen(step.id, step.isExecuting)
+      }
+    }
+
     openStateRef.current = next
     return next
-  }, [traceSteps, activeStepId, userOverrides])
+  }, [traceSteps, activeStepId, userOverrides, childToolEntries])
 
   const handleToggle = useCallback((stepId: string) => {
     const currentOpen = openStateRef.current[stepId] ?? false
@@ -170,14 +207,6 @@ function useTraceAutoExpand(steps: ContentStep[]) {
   }, [])
 
   return { openState, handleToggle, traceSteps, activeStepId }
-}
-
-function computeDefaultOpen(step: TraceStep): boolean {
-  if (step.type === 'reasoning')
-    return step.isStreaming
-  if (step.type === 'tool')
-    return step.isExecuting
-  return step.isExecuting
 }
 
 // ---- sub-components ----
@@ -338,10 +367,12 @@ function ToolGroupItem({
   group,
   open,
   onToggle,
+  openState,
 }: {
   group: Extract<ContentStep, { type: 'tool-group' }>
   open: boolean
   onToggle: (id: string) => void
+  openState: Record<string, boolean>
 }) {
   const toolCount = group.tools.length
 
@@ -376,7 +407,7 @@ function ToolGroupItem({
           <CompactToolItem
             key={tool.id}
             tool={tool}
-            open={!tool.toolResult}
+            open={openState[tool.id] ?? !tool.toolResult}
             onToggle={onToggle}
           />
         ))}
@@ -389,16 +420,18 @@ function TraceStepItem({
   step,
   open,
   onToggle,
+  openState,
 }: {
   step: TraceStep
   open: boolean
   onToggle: (stepId: string) => void
+  openState: Record<string, boolean>
 }) {
   if (step.type === 'reasoning') {
     return <ReasoningStepItem step={step} open={open} onToggle={onToggle} />
   }
   if (step.type === 'tool-group') {
-    return <ToolGroupItem group={step} open={open} onToggle={onToggle} />
+    return <ToolGroupItem group={step} open={open} onToggle={onToggle} openState={openState} />
   }
   return (
     <CompactToolItem
@@ -410,13 +443,6 @@ function TraceStepItem({
 }
 
 // ---- helpers ----
-
-function isNetworkError(text: string): boolean {
-  if (!text)
-    return false
-  const patterns = /network|connection|fetch|abort|timeout|econnrefused|enotfound|socket|disconnected|econnreset|etimedout/i
-  return patterns.test(text)
-}
 
 function getErrorText(message: IMessage): string {
   return message.content
@@ -484,6 +510,7 @@ export function AssistantTrace({ message, toolResultMap, showReasoning = true }:
                   step={step as TraceStep}
                   open={openState[step.id] ?? false}
                   onToggle={handleToggle}
+                  openState={openState}
                 />
               ))}
             </div>

--- a/apps/web/src/components/Chat/Chat.tsx
+++ b/apps/web/src/components/Chat/Chat.tsx
@@ -77,7 +77,7 @@ export default function Chat() {
   return (
     <div
       key={currentConversations?.id}
-      className="relative mx-auto grid h-(--mainHeight) w-full grid-rows-[1fr_max-content]"
+      className="relative mx-auto grid h-full w-full grid-rows-[1fr_max-content]"
     >
 
       {
@@ -93,7 +93,7 @@ export default function Chat() {
             )
           : null
       }
-      <div className="px-2 pb-4">
+      <div className="px-3 pb-3 md:px-2 md:pb-4">
         {agentTask && pending
           ? (
               <AgentApprovalCard

--- a/apps/web/src/components/Chat/MessageBubble.tsx
+++ b/apps/web/src/components/Chat/MessageBubble.tsx
@@ -104,33 +104,7 @@ export function MessageBubble({ messages, collapseIntermediate, onCopyMessage }:
   if (nonToolMessages.length === 0)
     return null
 
-  // Split messages into process (fold) and visible:
-  // - Messages without text → always in fold
-  // - Messages with tool calls → always in fold
-  // - The last message stays visible (its text is the final answer),
-  //   but its reasoning is extracted into a virtual message in the fold
-  const processIds = new Set<string>()
-  const processMessages: IMessage[] = []
-
-  for (const m of nonToolMessages) {
-    if (!messageHasTextContent(m) || messageHasToolCalls(m)) {
-      processMessages.push(m)
-      processIds.add(m.id)
-    }
-  }
-
-  // Extract reasoning from the last message into the fold
-  const lastNonToolMsg = nonToolMessages[nonToolMessages.length - 1]
-  if (lastNonToolMsg?.reasoningContent && !processIds.has(lastNonToolMsg.id)) {
-    processMessages.push({
-      ...lastNonToolMsg,
-      id: `${lastNonToolMsg.id}:reasoning-fold`,
-      content: [],
-    })
-  }
-
-  const visibleMessages = nonToolMessages.filter(m => !processIds.has(m.id))
-
+  const { processMessages, visibleMessages } = splitProcessMessages(nonToolMessages)
   const shouldCollapseProcess = isAI && collapseIntermediate && processMessages.length > 0
 
   return (
@@ -249,6 +223,44 @@ function messageHasTextContent(msg: IMessage): boolean {
 
 function messageHasToolCalls(msg: IMessage): boolean {
   return Array.isArray(msg.content) && msg.content.some(b => b.type === 'tool-call')
+}
+
+interface ProcessSplit {
+  processMessages: IMessage[]
+  visibleMessages: IMessage[]
+}
+
+/**
+ * Split non-tool messages into process (fold) and visible:
+ * - Messages without text → fold
+ * - Messages with tool calls → fold
+ * - The last message stays visible (its text is the final answer);
+ *   its reasoning is extracted into a virtual message in the fold.
+ */
+function splitProcessMessages(messages: IMessage[]): ProcessSplit {
+  const processIds = new Set<string>()
+  const processMessages: IMessage[] = []
+
+  for (const m of messages) {
+    if (!messageHasTextContent(m) || messageHasToolCalls(m)) {
+      processMessages.push(m)
+      processIds.add(m.id)
+    }
+  }
+
+  // Extract reasoning from the last message into the fold
+  const lastMsg = messages[messages.length - 1]
+  if (lastMsg?.reasoningContent && !processIds.has(lastMsg.id)) {
+    processMessages.push({
+      ...lastMsg,
+      id: `${lastMsg.id}:reasoning-fold`,
+      content: [],
+    })
+  }
+
+  const visibleMessages = messages.filter(m => !processIds.has(m.id))
+
+  return { processMessages, visibleMessages }
 }
 
 function hasToolCallBlocks(msgs: IMessage[]): boolean {

--- a/apps/web/src/components/Chat/MessageBubble.tsx
+++ b/apps/web/src/components/Chat/MessageBubble.tsx
@@ -1,5 +1,4 @@
 import type { IMessage } from '@ant-chat/shared'
-import type { BubbleContent } from '@/types/global'
 import {
   MessageContent as AiMessageContent,
   Message,
@@ -10,14 +9,14 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@workspace/ui/components/collapsible'
+import { Separator } from '@workspace/ui/components/separator'
 import { cn } from '@workspace/ui/lib/utils'
-import { pick } from 'lodash-es'
 import { ChevronRightIcon, ShrinkIcon } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Role } from '@/constants'
 import { transformMessageContent } from '@/utils/messageTransform'
+import { AssistantTrace } from './AssistantTrace'
 import BubbleFooter from './BubbleFooter'
-import { McpToolCallPanel } from './McpToolCallPanel'
 import MessageContent from './MessageContent'
 
 interface MessageBubbleProps {
@@ -33,7 +32,7 @@ export function MessageBubble({ messages, collapseIntermediate, onCopyMessage }:
   const isAI = message.role === Role.AI
   const isEvent = message.role === Role.EVENT
 
-  // 建立 toolCallId → tool-result 消息的索引
+  // Build toolCallId → tool-result message index
   const toolResultMap = useMemo(() => {
     const map = new Map<string, IMessage>()
     for (const m of messages) {
@@ -48,7 +47,20 @@ export function MessageBubble({ messages, collapseIntermediate, onCopyMessage }:
     return map
   }, [messages])
 
-  // 事件消息：渲染为可折叠分隔线
+  // Determine if the last assistant message has reasoning / is running (for fold decisions).
+  // Must be computed before early returns to keep hook order stable.
+  const nonToolForFold = messages.filter(m => m.role !== 'tool')
+  const lastNonTool = nonToolForFold[nonToolForFold.length - 1]
+  const isRunning = lastNonTool?.status === 'loading' || lastNonTool?.status === 'typing'
+
+  // Auto-open fold only while the conversation is streaming
+  useEffect(() => {
+    if (collapseIntermediate && isRunning && nonToolForFold.length > 1) {
+      setIsProcessOpen(true)
+    }
+  }, [collapseIntermediate, isRunning, nonToolForFold.length])
+
+  // Event messages: render as collapsible divider
   if (isEvent) {
     const eventLabel = message.eventType === 'compaction' ? '上下文压缩' : message.eventType
     const eventText = typeof message.content === 'string'
@@ -86,14 +98,40 @@ export function MessageBubble({ messages, collapseIntermediate, onCopyMessage }:
     )
   }
 
-  // 只展示 non-tool 消息（assistant + user）
-  const nonToolMessages = messages.filter(m => m.role !== 'tool')
+  // Show only non-tool messages (assistant + user)
+  const nonToolMessages = nonToolForFold
+
   if (nonToolMessages.length === 0)
     return null
 
-  const shouldCollapseProcess = isAI && collapseIntermediate && nonToolMessages.length > 1
-  const processMessages = shouldCollapseProcess ? nonToolMessages.slice(0, -1) : []
-  const visibleMessages = shouldCollapseProcess ? nonToolMessages.slice(-1) : nonToolMessages
+  // Split messages into process (fold) and visible:
+  // - Messages without text → always in fold
+  // - Messages with tool calls → always in fold
+  // - The last message stays visible (its text is the final answer),
+  //   but its reasoning is extracted into a virtual message in the fold
+  const processIds = new Set<string>()
+  const processMessages: IMessage[] = []
+
+  for (const m of nonToolMessages) {
+    if (!messageHasTextContent(m) || messageHasToolCalls(m)) {
+      processMessages.push(m)
+      processIds.add(m.id)
+    }
+  }
+
+  // Extract reasoning from the last message into the fold
+  const lastNonToolMsg = nonToolMessages[nonToolMessages.length - 1]
+  if (lastNonToolMsg?.reasoningContent && !processIds.has(lastNonToolMsg.id)) {
+    processMessages.push({
+      ...lastNonToolMsg,
+      id: `${lastNonToolMsg.id}:reasoning-fold`,
+      content: [],
+    })
+  }
+
+  const visibleMessages = nonToolMessages.filter(m => !processIds.has(m.id))
+
+  const shouldCollapseProcess = isAI && collapseIntermediate && processMessages.length > 0
 
   return (
     <Message
@@ -137,9 +175,8 @@ export function MessageBubble({ messages, collapseIntermediate, onCopyMessage }:
                         key={item.id}
                         data-message-id={item.id}
                       >
-                        <MessageContentRenderer
+                        <AssistantMessageContent
                           item={item}
-                          content={transformMessageContent(item)}
                           toolResultMap={toolResultMap}
                         />
                       </div>
@@ -151,18 +188,17 @@ export function MessageBubble({ messages, collapseIntermediate, onCopyMessage }:
               {visibleMessages.map((item, index) => (
                 <div
                   key={item.id}
-                  className={cn(
-                    (index > 0 || shouldCollapseProcess) && `
-                      border-t border-gray-200 pt-5
-                      dark:border-gray-800
-                    `,
-                  )}
                   data-message-id={item.id}
                 >
-                  <MessageContentRenderer
+                  {
+                    (index > 0 || shouldCollapseProcess) && (
+                      <Separator className="my-3" />
+                    )
+                  }
+                  <AssistantMessageContent
                     item={item}
-                    content={transformMessageContent(item)}
                     toolResultMap={toolResultMap}
+                    showReasoning={false}
                   />
                 </div>
               ))}
@@ -181,84 +217,38 @@ export function MessageBubble({ messages, collapseIntermediate, onCopyMessage }:
   )
 }
 
-type RenderSegment
-  = | { kind: 'text', text: string, isFirst: boolean }
-    | { kind: 'tool-call', block: IMessage['content'][number] & { type: 'tool-call' } }
+// ---- per-message content renderer ----
 
-function buildRenderSegments(item: IMessage): RenderSegment[] {
-  if (typeof item.content === 'string')
-    return [{ kind: 'text', text: item.content, isFirst: true }]
-
-  const segments: RenderSegment[] = []
-  let isFirstText = true
-
-  for (const block of item.content) {
-    if (block.type === 'text') {
-      segments.push({ kind: 'text', text: block.text, isFirst: isFirstText })
-      isFirstText = false
-    }
-    else if (block.type === 'error') {
-      segments.push({ kind: 'text', text: `${block.error}`, isFirst: isFirstText })
-      isFirstText = false
-    }
-    else if (block.type === 'tool-call') {
-      segments.push({ kind: 'tool-call', block })
-    }
-  }
-
-  return segments
-}
-
-function MessageContentRenderer({
+function AssistantMessageContent({
   item,
-  content,
   toolResultMap,
+  showReasoning = true,
 }: {
   item: IMessage
-  content: string
   toolResultMap: Map<string, IMessage>
+  showReasoning?: boolean
 }) {
-  const itemIsUser = item.role === Role.USER
-  const itemIsAI = item.role === Role.AI
-
-  if (!itemIsAI) {
-    const messageContentProps: Partial<BubbleContent> = {
-      ...pick(item, ['status']),
-      content,
-    }
-    return <MessageContent {...messageContentProps} enableReferenceTokens={itemIsUser} />
+  if (item.role !== Role.AI) {
+    return (
+      <MessageContent
+        content={transformMessageContent(item)}
+        status={item.status as 'success' | 'cancel'}
+        enableReferenceTokens
+      />
+    )
   }
 
-  const segments = buildRenderSegments(item)
+  return <AssistantTrace message={item} toolResultMap={toolResultMap} showReasoning={showReasoning} />
+}
 
-  return (
-    <>
-      {segments.map((seg, i) => {
-        if (seg.kind === 'tool-call') {
-          const resultMsg = toolResultMap.get(seg.block.toolCallId)
-          const resultBlock = resultMsg?.content.find(
-            (b): b is typeof b & { type: 'tool-result' } => b.type === 'tool-result',
-          )
-          return (
-            <div key={seg.block.toolCallId || i} className="my-2">
-              <McpToolCallPanel
-                toolCall={seg.block}
-                toolResult={resultBlock}
-              />
-            </div>
-          )
-        }
-        return (
-          <MessageContent
-            key={i}
-            content={seg.text}
-            reasoningContent={seg.isFirst ? item.reasoningContent : undefined}
-            status={item.status}
-          />
-        )
-      })}
-    </>
-  )
+// ---- helpers ----
+
+function messageHasTextContent(msg: IMessage): boolean {
+  return Array.isArray(msg.content) && msg.content.some(b => b.type === 'text' && b.text.length > 0)
+}
+
+function messageHasToolCalls(msg: IMessage): boolean {
+  return Array.isArray(msg.content) && msg.content.some(b => b.type === 'tool-call')
 }
 
 function hasToolCallBlocks(msgs: IMessage[]): boolean {

--- a/apps/web/src/components/Chat/MessageContent.tsx
+++ b/apps/web/src/components/Chat/MessageContent.tsx
@@ -10,14 +10,9 @@ import {
   Attachments,
 } from '@workspace/ui/components/ai-elements/attachments'
 import { MessageResponse } from '@workspace/ui/components/ai-elements/message'
-import {
-  Reasoning,
-  ReasoningContent,
-  ReasoningTrigger,
-} from '@workspace/ui/components/ai-elements/reasoning'
-import { Alert, AlertDescription } from '@workspace/ui/components/alert'
+import { Alert, AlertDescription, AlertTitle } from '@workspace/ui/components/alert'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@workspace/ui/components/tooltip'
-import { FileIcon, Loader2Icon, SparklesIcon } from 'lucide-react'
+import { FileIcon, SparklesIcon, XCircleIcon } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { skillApi } from '@/api/skillApi'
 import { tokenizeMessageReferences } from './messageReferenceTokens'
@@ -43,10 +38,16 @@ function getAttachmentUrl(item: AttachmentData): string {
 const EMPTY_IMAGES: NonNullable<BubbleContent['images']> = []
 const EMPTY_ATTACHMENTS: NonNullable<BubbleContent['attachments']> = []
 
-export default function MessageContent({ content = '', images = EMPTY_IMAGES, attachments = EMPTY_ATTACHMENTS, reasoningContent = '', status, enableReferenceTokens = false }: Partial<BubbleContent> & { enableReferenceTokens?: boolean }) {
+export default function MessageContent({ content = '', images = EMPTY_IMAGES, attachments = EMPTY_ATTACHMENTS, status, enableReferenceTokens = false }: Partial<BubbleContent> & { enableReferenceTokens?: boolean }) {
   if (status === 'error') {
+    const title = isNetworkError(content)
+      ? 'Connection interrupted'
+      : 'Request failed'
+
     return (
       <Alert variant="destructive">
+        <XCircleIcon className="size-4" />
+        <AlertTitle>{title}</AlertTitle>
         <AlertDescription>
           {content
             ? <p className="whitespace-pre-wrap">{content}</p>
@@ -59,8 +60,11 @@ export default function MessageContent({ content = '', images = EMPTY_IMAGES, at
   if (status === 'cancel') {
     return (
       <Alert variant="default">
+        <AlertTitle>Cancelled</AlertTitle>
         <AlertDescription>
-          {content && <p className="whitespace-pre-wrap">{content}</p>}
+          {content
+            ? <p className="whitespace-pre-wrap">{content}</p>
+            : <p>Task cancelled.</p>}
         </AlertDescription>
       </Alert>
     )
@@ -72,20 +76,6 @@ export default function MessageContent({ content = '', images = EMPTY_IMAGES, at
 
   return (
     <div className="space-y-3">
-      {reasoningContent && (
-        <Reasoning isStreaming={isStreaming}>
-          <ReasoningTrigger
-            getThinkingMessage={streaming => (
-              <span className="inline-flex items-center gap-1">
-                {streaming ? 'Thinking' : 'Thought complete'}
-                {streaming && <Loader2Icon className="size-3 animate-spin" />}
-              </span>
-            )}
-          />
-          <ReasoningContent>{reasoningContent}</ReasoningContent>
-        </Reasoning>
-      )}
-
       {content && (
         enableReferenceTokens
           ? <ReferenceTokenMessage content={content} />
@@ -125,6 +115,13 @@ export default function MessageContent({ content = '', images = EMPTY_IMAGES, at
       )}
     </div>
   )
+}
+
+function isNetworkError(text: string): boolean {
+  if (!text)
+    return false
+  const patterns = /network|connection|fetch|abort|timeout|econnrefused|enotfound|socket|disconnected|econnreset|etimedout/i
+  return patterns.test(text)
 }
 
 function ReferenceTokenMessage({ content }: { content: string }) {

--- a/apps/web/src/components/Chat/MessageContent.tsx
+++ b/apps/web/src/components/Chat/MessageContent.tsx
@@ -15,6 +15,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@workspace/ui/component
 import { FileIcon, SparklesIcon, XCircleIcon } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { skillApi } from '@/api/skillApi'
+import { isNetworkError } from '@/utils/networkError'
 import { tokenizeMessageReferences } from './messageReferenceTokens'
 
 function toAttachmentData(item: NonNullable<BubbleContent['attachments']>[number]): AttachmentData {
@@ -115,13 +116,6 @@ export default function MessageContent({ content = '', images = EMPTY_IMAGES, at
       )}
     </div>
   )
-}
-
-function isNetworkError(text: string): boolean {
-  if (!text)
-    return false
-  const patterns = /network|connection|fetch|abort|timeout|econnrefused|enotfound|socket|disconnected|econnreset|etimedout/i
-  return patterns.test(text)
 }
 
 function ReferenceTokenMessage({ content }: { content: string }) {

--- a/apps/web/src/components/ProviderManage/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/ProviderManage/ProviderSettingsPanel.tsx
@@ -21,7 +21,7 @@ export function ProviderSettingsPanel({ item, onChange, onDelete }: ProviderSett
   const officialKeyUrl = getOfficialKeyUrl(item.id)
 
   return (
-    <div className="h-dvh flex-1 overflow-y-auto p-3">
+    <div className="h-full flex-1 overflow-y-auto p-3">
       {
         !item.isOfficial && (
           <div className="flex items-center justify-end">

--- a/apps/web/src/components/Sender/PickerModel.tsx
+++ b/apps/web/src/components/Sender/PickerModel.tsx
@@ -67,7 +67,7 @@ export function ModelControlPanel({ value, onChange }: ModelControlPanelProps) {
           `}
           >
             <ProviderLogoDisplay providerId={activeProviderServiceInfo?.id || ''} />
-            <div className="flex max-w-30 items-center truncate text-xs font-medium">
+            <div className="hidden max-w-30 items-center truncate text-xs font-medium md:flex">
               <span className="truncate">{currentModelInfo?.name}</span>
               <span className="px-2">›</span>
             </div>

--- a/apps/web/src/components/Sender/Sender.tsx
+++ b/apps/web/src/components/Sender/Sender.tsx
@@ -757,11 +757,11 @@ function Sender({ actions, ...props }: SenderProps) {
       ref={senderRef}
       className={`
         mx-auto max-w-(--chat-width)
-        ${!hasMessage ? 'absolute inset-x-3 top-[50%] translate-y-[-50%]' : ''}
+        ${!hasMessage ? 'absolute inset-x-4 top-[50%] translate-y-[-50%] md:inset-x-3' : ''}
       `}
     >
       {!hasMessage && (
-        <h1 className="mb-3 py-3 text-center text-4xl text-gray-500">
+        <h1 className="mb-3 py-3 text-center text-2xl text-gray-500 md:text-4xl">
           <TypingEffect text="有什么可以帮忙的？" />
         </h1>
       )}
@@ -836,8 +836,10 @@ function Sender({ actions, ...props }: SenderProps) {
                   data-testid="workspace-switcher"
                   disabled={workspaceLoading}
                   aria-disabled={workspaceSwitchDisabled}
+                  tooltip="切换工作区"
                   className={`
-                    h-8 max-w-52 justify-start border px-2
+                    h-8 justify-start border px-2
+                    md:max-w-52
                     ${workspaceSwitchDisabled
       ? `
         pointer-events-none opacity-100
@@ -847,7 +849,7 @@ function Sender({ actions, ...props }: SenderProps) {
                   `}
                 >
                   <FolderOpenIcon className="size-4 shrink-0" />
-                  <span className="truncate text-xs">{workspaceDisplayName}</span>
+                  <span className="hidden truncate text-xs md:inline">{workspaceDisplayName}</span>
                 </PromptInputButton>
               </PopoverTrigger>
               <PopoverContent align="start" className="w-64 p-1">
@@ -882,13 +884,14 @@ function Sender({ actions, ...props }: SenderProps) {
                   size="sm"
                   type="button"
                   variant="ghost"
+                  tooltip="权限模式"
                   className={`
                     ${agentMode === 'full_managed' ? 'text-orange-600' : ''}
                   `}
                 >
                   {currentAgentModeOption.icon}
-                  {currentAgentModeOption.label}
-                  <ChevronDownIcon className="size-3" />
+                  <span className="hidden md:inline">{currentAgentModeOption.label}</span>
+                  <ChevronDownIcon className="hidden size-3 md:inline" />
                 </PromptInputButton>
               </PopoverTrigger>
               <PopoverContent align="start" className="w-52 p-1">
@@ -919,12 +922,13 @@ function Sender({ actions, ...props }: SenderProps) {
                   size="sm"
                   type="button"
                   variant={mcpEnabled ? 'secondary' : 'ghost'}
+                  tooltip="MCP 工具"
                 >
                   <Cable className="size-3" />
-                  MCP
+                  <span className="hidden md:inline">MCP</span>
                 </PromptInputButton>
               </PopoverTrigger>
-              <PopoverContent align="start" className="w-[340px] p-0">
+              <PopoverContent align="start" className="w-85 p-0">
                 <MCPManagementPanel />
               </PopoverContent>
             </Popover>

--- a/apps/web/src/components/SiliderMenu/SiliderMenu.tsx
+++ b/apps/web/src/components/SiliderMenu/SiliderMenu.tsx
@@ -29,10 +29,7 @@ export function SliderMenu() {
   }
 
   return (
-    <aside className={`
-      flex h-full w-(--conversationWidth) shrink-0 flex-col p-2 text-sidebar-foreground
-    `}
-    >
+    <aside className="flex h-full w-full shrink-0 flex-col p-2 text-sidebar-foreground">
       <div className="flex min-h-0 flex-1 flex-col rounded-2xl bg-sidebar px-2 pt-8 pb-3">
         <div className="flex flex-col gap-1 py-2">
           <SidebarNavItem

--- a/apps/web/src/hooks/useIsMobile.ts
+++ b/apps/web/src/hooks/useIsMobile.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react'
+
+const MOBILE_BREAKPOINT = 768
+
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(() =>
+    window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`).matches,
+  )
+
+  useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    const onChange = (e: MediaQueryListEvent) => setIsMobile(e.matches)
+    mql.addEventListener('change', onChange)
+    return () => mql.removeEventListener('change', onChange)
+  }, [])
+
+  return isMobile
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -26,12 +26,15 @@
   --border-color: #424242;
 }
 
-@media (max-width: 768px) {
+/* 移动端：聊天区域全宽，标题区域缩小 */
+@media (max-width: 767px) {
   :root {
-    --chat-width: 100vw;
+    --chat-width: 100%;
+    --titleHeight: 40px;
   }
 }
 
+/* 超大屏：内容区域定宽居中 */
 @media (min-width: 1096px) {
   :root {
     --chat-width: 800px;

--- a/apps/web/src/pages/Chat.tsx
+++ b/apps/web/src/pages/Chat.tsx
@@ -1,16 +1,105 @@
+import { Menu, PanelLeftClose, PanelLeftOpen } from 'lucide-react'
+import { AnimatePresence, motion } from 'motion/react'
+import { useState } from 'react'
 import Chat from '@/components/Chat'
 import { SearchContainer } from '@/components/Search'
+import { SliderMenu } from '@/components/SiliderMenu'
 import { ChatSettingsProvider } from '@/contexts/chatSettings'
+import { useIsMobile } from '@/hooks/useIsMobile'
+import { isElectronRuntime } from '@/utils/ipc-bus'
 
 export function ChatPage() {
+  const isMobile = useIsMobile()
+  // Desktop: sidebar collapsed state
+  const [desktopCollapsed, setDesktopCollapsed] = useState(false)
+  // Mobile: drawer open state
+  const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false)
+
   return (
-    <div className="relative flex h-(--mainHeight) w-full transition-all">
-      <div className="relative flex h-full flex-1">
-        <ChatSettingsProvider>
-          <Chat />
-        </ChatSettingsProvider>
+    <div className="relative flex h-(--mainHeight) w-full">
+
+      {/* ── Mobile: hamburger button ── */}
+      <button
+        type="button"
+        className={`
+          app-region-no-drag absolute top-2 left-2 z-60 flex size-10 items-center justify-center
+          rounded-full text-foreground
+          hover:bg-black/5
+          md:hidden
+          dark:hover:bg-white/10
+        `}
+        onClick={() => setMobileDrawerOpen(prev => !prev)}
+      >
+        <Menu className="size-5" />
+      </button>
+
+      {/* ── Mobile: drawer backdrop ── */}
+      <AnimatePresence>
+        {mobileDrawerOpen && isMobile && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 z-90 bg-black/30 backdrop-blur-sm"
+            onClick={() => setMobileDrawerOpen(false)}
+          />
+        )}
+      </AnimatePresence>
+
+      {/* ── Mobile: drawer sidebar ── */}
+      <AnimatePresence>
+        {mobileDrawerOpen && isMobile && (
+          <motion.aside
+            initial={{ x: '-100%' }}
+            animate={{ x: 0 }}
+            exit={{ x: '-100%' }}
+            transition={{ type: 'tween', duration: 0.28 }}
+            className="fixed inset-y-0 left-0 z-100 w-(--conversationWidth) pt-10"
+            onClick={() => setMobileDrawerOpen(false)}
+          >
+            <SliderMenu />
+          </motion.aside>
+        )}
+      </AnimatePresence>
+
+      {/* ── Desktop: single toggle button (stays fixed, sidebar animates behind it) ── */}
+      <button
+        type="button"
+        className={`
+          ${isElectronRuntime() ? 'left-21' : 'left-3'}
+          app-region-no-drag absolute top-3 z-60 hidden size-7 items-center justify-center
+          rounded-md text-slate-500
+          hover:bg-black/5 hover:text-slate-700
+          md:flex
+          dark:text-slate-400 dark:hover:bg-white/10 dark:hover:text-slate-200
+        `}
+        onClick={() => setDesktopCollapsed(prev => !prev)}
+      >
+        {desktopCollapsed
+          ? <PanelLeftOpen className="size-4" />
+          : <PanelLeftClose className="size-4" />}
+      </button>
+
+      {/* ── Desktop: inline sidebar ── */}
+      <div
+        className={`
+          hidden h-full shrink-0 overflow-hidden transition-[width] duration-300 ease-in-out
+          md:block
+          ${desktopCollapsed ? 'w-0' : 'w-(--conversationWidth)'}
+        `}
+      >
+        <SliderMenu />
       </div>
-      <SearchContainer />
+
+      {/* ── Main content ── */}
+      <div className="relative flex h-full min-w-0 flex-1 pt-12 transition-all md:pt-0">
+        <div className="relative flex h-full flex-1">
+          <ChatSettingsProvider>
+            <Chat />
+          </ChatSettingsProvider>
+        </div>
+        <SearchContainer />
+      </div>
     </div>
   )
 }

--- a/apps/web/src/pages/Settings/ProviderManage.tsx
+++ b/apps/web/src/pages/Settings/ProviderManage.tsx
@@ -3,6 +3,7 @@ import { Button } from '@workspace/ui/components/button'
 import { EmptyState } from '@workspace/ui/components/empty-state'
 import { Switch } from '@workspace/ui/components/switch'
 import { useRequest } from 'ahooks'
+import { ArrowLeft } from 'lucide-react'
 import React from 'react'
 import { toast } from 'sonner'
 import { providerApi } from '@/api/providerApi'
@@ -12,11 +13,21 @@ import { ProviderSettingsPanel } from '@/components/ProviderManage/ProviderSetti
 
 export default function ProviderManage() {
   const [activeProvider, setActiveProvider] = React.useState<ProviderConfigSchema | null>(null)
+  const [mobileShowDetail, setMobileShowDetail] = React.useState(false)
   const { data, error, refresh, loading } = useRequest(providerApi.listProviders)
 
   const handleAddProvider = async (provider: Parameters<typeof providerApi.createProvider>[0]) => {
     await providerApi.createProvider(provider)
     refresh()
+  }
+
+  function handleSelectProvider(item: ProviderConfigSchema) {
+    setActiveProvider(item)
+    setMobileShowDetail(true)
+  }
+
+  function handleBack() {
+    setMobileShowDetail(false)
   }
 
   if (error) {
@@ -27,98 +38,127 @@ export default function ProviderManage() {
     )
   }
 
-  return (
-    <div className="flex h-full">
-      <div
-        className={`
-          flex h-dvh w-50 shrink-0 flex-col gap-2 overflow-y-auto border-r border-solid
-          border-(--border-color) p-2
-        `}
-      >
-        {
-          data?.map(item => (
-            <div
-              key={item.id}
-              role="button"
-              tabIndex={0}
-              className={`
-                ${activeProvider?.id === item.id ? 'bg-(--hover-bg-color)' : ''}
-                group flex cursor-pointer items-center justify-between gap-2 rounded-md p-2 px-3
-                select-none
-                hover:bg-(--hover-bg-color)
-              `}
-              onClick={() => {
-                setActiveProvider(item)
-              }}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault()
-                  setActiveProvider(item)
-                }
-              }}
+  // Provider list panel (shared between mobile and desktop)
+  const listPanel = (
+    <div
+      className={`
+        flex h-full w-full shrink-0 flex-col gap-2 overflow-y-auto border-r border-solid
+        border-(--border-color) p-2
+        md:w-50
+        ${mobileShowDetail ? 'hidden md:flex' : 'flex'}
+      `}
+    >
+      {data?.map(item => (
+        <div
+          key={item.id}
+          role="button"
+          tabIndex={0}
+          className={`
+            ${activeProvider?.id === item.id ? 'bg-(--hover-bg-color)' : ''}
+            group flex cursor-pointer items-center justify-between gap-2 rounded-md p-2 px-3
+            select-none
+            hover:bg-(--hover-bg-color)
+          `}
+          onClick={() => handleSelectProvider(item)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault()
+              handleSelectProvider(item)
+            }
+          }}
+        >
+          <div className="flex items-center gap-2">
+            <div className="
+              flex size-5 shrink-0 items-center justify-center overflow-hidden rounded-sm bg-white
+            "
             >
-              <div className="flex items-center gap-2">
-                <div className="
-                  flex size-5 shrink-0 items-center justify-center overflow-hidden rounded-sm bg-white
-                "
-                >
-                  {(() => {
-                    const content = (
-                      <ProviderLogo id={item.id} name={item.name} size={14} className="size-3.5" />
-                    )
-                    return content || <img src="/logo.svg" alt="" className="size-3.5" draggable={false} />
-                  })()}
-                </div>
-
-                <span className="text-sm font-medium">
-                  {item.name}
-                </span>
-              </div>
-              <Switch
-                checked={item.isEnabled}
-                onCheckedChange={async (e) => {
-                  await providerApi.updateProvider({ id: item.id, isEnabled: e })
-                  refresh()
-                }}
-                size="sm"
-              />
+              {(() => {
+                const content = (
+                  <ProviderLogo id={item.id} name={item.name} size={14} className="size-3.5" />
+                )
+                return content || <img src="/logo.svg" alt="" className="size-3.5" draggable={false} />
+              })()}
             </div>
-          ))
-        }
-        <div className="p-2">
-          <AddCustomProvider
-            onAdd={handleAddProvider}
-            existingProviderIds={data?.map(item => item.id)}
-            loading={loading}
-          />
-        </div>
-      </div>
-      {
-        activeProvider
-          ? (
-              <ProviderSettingsPanel
-                key={activeProvider?.id || ''}
-                item={activeProvider}
-                onChange={async (e) => {
-                  await providerApi.updateProvider(e)
-                  refresh()
-                }}
-                onDelete={async () => {
-                  try {
-                    await providerApi.deleteProvider(activeProvider.id)
-                  }
-                  catch (e) {
-                    toast.error((e as Error).message)
-                    return
-                  }
 
-                  setActiveProvider(null)
-                  refresh()
-                }}
-              />
-            )
-          : null
-      }
+            <span className="text-sm font-medium">
+              {item.name}
+            </span>
+          </div>
+          <div
+            role="button"
+            tabIndex={0}
+            onClick={e => e.stopPropagation()}
+          >
+            <Switch
+              checked={item.isEnabled}
+              onCheckedChange={async (e) => {
+                await providerApi.updateProvider({ id: item.id, isEnabled: e })
+                refresh()
+              }}
+              size="sm"
+            />
+          </div>
+        </div>
+      ))}
+      <div className="p-2">
+        <AddCustomProvider
+          onAdd={handleAddProvider}
+          existingProviderIds={data?.map(item => item.id)}
+          loading={loading}
+        />
+      </div>
+    </div>
+  )
+
+  // Detail panel (shared between mobile and desktop)
+  const detailPanel = activeProvider
+    ? (
+        <div className={`min-w-0 flex-1 ${mobileShowDetail ? 'flex flex-col' : 'hidden md:flex md:flex-col'}`}>
+          {/* Mobile back header */}
+          <div className="flex items-center gap-2 border-b border-(--border-color) px-3 py-2 md:hidden">
+            <button
+              type="button"
+              className="flex items-center gap-1 text-sm text-primary hover:opacity-70"
+              onClick={handleBack}
+            >
+              <ArrowLeft className="size-4" />
+              返回列表
+            </button>
+            <span className="truncate text-sm font-medium">
+              {activeProvider.name}
+            </span>
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            <ProviderSettingsPanel
+              key={activeProvider.id}
+              item={activeProvider}
+              onChange={async (e) => {
+                await providerApi.updateProvider(e)
+                refresh()
+              }}
+              onDelete={async () => {
+                try {
+                  await providerApi.deleteProvider(activeProvider.id)
+                }
+                catch (e) {
+                  toast.error((e as Error).message)
+                  return
+                }
+
+                setActiveProvider(null)
+                setMobileShowDetail(false)
+                refresh()
+              }}
+            />
+          </div>
+        </div>
+      )
+    : null
+
+  return (
+    <div className="flex h-full flex-col md:flex-row">
+      {listPanel}
+      {detailPanel}
     </div>
   )
 }

--- a/apps/web/src/pages/Settings/Settings.tsx
+++ b/apps/web/src/pages/Settings/Settings.tsx
@@ -1,60 +1,125 @@
-import { Cable, Crown, Info, NotebookTabsIcon, SettingsIcon, SparklesIcon } from 'lucide-react'
+import { ArrowLeft, Cable, Crown, Info, MessageSquare, NotebookTabsIcon, SettingsIcon, SparklesIcon } from 'lucide-react'
+import { useState } from 'react'
 import { Outlet, useLocation, useNavigate } from 'react-router'
+import { isElectronRuntime } from '@/utils/ipc-bus'
+
+const menus = [
+  { id: 'general', name: '通用设置', icon: <SettingsIcon className="size-[1em]" /> },
+  { id: 'memory', name: '记忆', icon: <NotebookTabsIcon className="size-[1em]" /> },
+  { id: 'provider', name: 'AI服务商设置', icon: <Crown className="size-[1em]" /> },
+  { id: 'mcp', name: 'MCP设置', icon: <Cable className="size-[1em]" /> },
+  { id: 'skills', name: 'Skill设置', icon: <SparklesIcon className="size-[1em]" /> },
+  { id: 'about', name: '关于', icon: <Info className="size-[1em]" /> },
+]
+
+function SettingsNavMenu({
+  activeName,
+  onSelect,
+}: {
+  activeName: string
+  onSelect: (id: string) => void
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      {menus.map(item => (
+        <div
+          key={item.id}
+          role="button"
+          tabIndex={0}
+          data-testid={`settings-nav-${item.id}`}
+          className={`
+            flex h-10 cursor-pointer items-center gap-3 rounded-md px-4
+            hover:bg-(--hover-bg-color)
+            ${activeName === item.id ? 'bg-(--hover-bg-color)' : ''}
+          `}
+          onClick={() => onSelect(item.id)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault()
+              onSelect(item.id)
+            }
+          }}
+        >
+          <div>{item.icon}</div>
+          <div className="flex-1 text-sm">{item.name}</div>
+          <span className="text-xs text-gray-400 md:hidden">›</span>
+        </div>
+      ))}
+    </div>
+  )
+}
 
 export default function SettingsPage() {
-  const navigrate = useNavigate()
+  const navigate = useNavigate()
   const location = useLocation()
   const activeName = location.pathname.split('/').pop() || 'provider'
-  const menus = [
-    { id: 'general', name: '通用设置', icon: <SettingsIcon className="size-[1em]" /> },
-    { id: 'memory', name: '记忆', icon: <NotebookTabsIcon className="size-[1em]" /> },
-    { id: 'provider', name: 'AI服务商设置', icon: <Crown className="size-[1em]" /> },
-    { id: 'mcp', name: 'MCP设置', icon: <Cable className="size-[1em]" /> },
-    { id: 'skills', name: 'Skill设置', icon: <SparklesIcon className="size-[1em]" /> },
-    { id: 'about', name: '关于', icon: <Info className="size-[1em]" /> },
-  ]
+
+  // Mobile drill-down: true = show detail, false = show menu list
+  const [mobileShowDetail, setMobileShowDetail] = useState(false)
+
+  function handleSelect(id: string) {
+    navigate(`/settings/${id}`)
+    setMobileShowDetail(true)
+  }
+
+  function handleBack() {
+    setMobileShowDetail(false)
+  }
+
+  const isBrowser = !isElectronRuntime()
 
   return (
-    <div className="grid h-(--mainHeight) w-full grid-cols-[max-content_1fr]">
+    <div className="flex h-(--mainHeight) w-full flex-col md:flex-row">
+      {/* Sidebar: always in DOM, hidden on mobile when viewing detail */}
       <div
         data-testid="settings-nav"
-        className="h-full w-50 border-r border-(--border-color) px-2 pt-12 pb-4"
+        className={`
+          h-full w-full shrink-0 border-r border-(--border-color) px-2 pt-12 pb-4
+          md:w-50
+          ${mobileShowDetail ? 'hidden md:block' : 'block'}
+        `}
       >
-        <div className="flex flex-col gap-3">
-          {
-            menus.map(item => (
-              <div
-                key={item.id}
-                role="button"
-                tabIndex={0}
-                data-testid={`settings-nav-${item.id}`}
-                className={`
-                  flex h-10 cursor-pointer items-center gap-3 rounded-md px-4
-                  hover:bg-(--hover-bg-color)
-                  ${activeName === item.id ? 'bg-(--hover-bg-color)' : ''}
-                `}
-                onClick={() => {
-                  navigrate(`/settings/${item.id}`)
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault()
-                    navigrate(`/settings/${item.id}`)
-                  }
-                }}
-              >
-                <div>
-                  {item.icon}
-                </div>
-                <div className="text-sm">
-                  {item.name}
-                </div>
-              </div>
-            ))
-          }
-        </div>
+        {/* Back to chat button (browser mode only) */}
+        {isBrowser && (
+          <button
+            type="button"
+            className={`
+              mb-3 flex h-9 w-full items-center gap-2 rounded-md px-4 text-sm font-medium
+              text-primary
+              hover:bg-(--hover-bg-color)
+            `}
+            onClick={() => navigate('/chat')}
+          >
+            <MessageSquare className="size-4" />
+            返回对话
+          </button>
+        )}
+        <SettingsNavMenu activeName={activeName} onSelect={handleSelect} />
       </div>
-      <div className="overflow-y-auto">
+
+      {/* Content area */}
+      <div
+        className={`
+          min-w-0 flex-1
+          ${mobileShowDetail ? 'block' : 'hidden md:block'} overflow-y-auto
+        `}
+      >
+        {/* Mobile back header */}
+        <div className="border-b border-(--border-color) px-4 pt-10 pb-3 md:hidden">
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              className="flex items-center gap-1 text-sm text-primary hover:opacity-70"
+              onClick={handleBack}
+            >
+              <ArrowLeft className="size-4" />
+              返回
+            </button>
+            <span className="text-sm font-medium">
+              {menus.find(m => m.id === activeName)?.name}
+            </span>
+          </div>
+        </div>
         <Outlet />
       </div>
     </div>

--- a/apps/web/src/utils/networkError.ts
+++ b/apps/web/src/utils/networkError.ts
@@ -1,0 +1,11 @@
+const NETWORK_ERROR_PATTERNS = /network|connection|fetch|abort|timeout|econnrefused|enotfound|socket|disconnected|econnreset|etimedout/i
+
+/**
+ * Lightweight UI-layer check: does the error text indicate a network / connectivity problem?
+ * No schema changes required; pure string matching.
+ */
+export function isNetworkError(text: string): boolean {
+  if (!text)
+    return false
+  return NETWORK_ERROR_PATTERNS.test(text)
+}


### PR DESCRIPTION
## Summary

Redesign assistant message bubble to show reasoning and tool calls as a unified, indented trace area with auto-expand/collapse behavior.

### Key Changes

**New: `AssistantTrace` component** (`apps/web/src/components/Chat/AssistantTrace.tsx`)
- Builds `ContentStep[]` from message content blocks, preserving original order
- Reasoning and tool-call steps render as compact collapsible rows with left-border indentation
- Consecutive tool calls (≥2) grouped into "View N steps" fold
- Auto-expand: current streaming/executing step opens, previous step closes
- User manual toggles persist across streaming updates
- Compact tool header: status icon replaces wrench icon; key parameters (filePath/pattern/command) shown inline with truncation
- Open state computed in render via `useMemo` (no `setState` in `useEffect`)

**Refactored: `MessageBubble`** 
- Assistant path delegates to `AssistantTrace`
- `splitProcessMessages` pure function: messages without text or with tool-calls go into the execution-process fold; last message text stays visible, its reasoning extracted to a virtual fold entry
- Fold auto-opens only while conversation is streaming

**Enhanced: `MessageContent`**
- Error states: distinct titles for "Connection interrupted", "Request failed", "Cancelled"
- Reasoning rendering removed (now in `AssistantTrace`)

**Extracted: `networkError.ts`**
- `isNetworkError` regex moved to shared helper, used by both `AssistantTrace` and `MessageContent`

### Files Changed
- `apps/web/src/components/Chat/AssistantTrace.tsx` (new)
- `apps/web/src/components/Chat/MessageBubble.tsx` (refactored)
- `apps/web/src/components/Chat/MessageContent.tsx` (enhanced)
- `apps/web/src/utils/networkError.ts` (new)

### Checks
- `pnpm check` passes (type-check, lint, 310+ unit tests)