### PR TITLE
refactor: redesign assistant message trace with collapsible steps

### DIFF
--- a/apps/web/src/components/Chat/AssistantTrace.tsx
+++ b/apps/web/src/components/Chat/AssistantTrace.tsx
@@ -16,7 +16,7 @@ import {
   WrenchIcon,
   XCircleIcon,
 } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 
 // ---- step types ----
 
@@ -142,44 +142,31 @@ function useTraceAutoExpand(steps: ContentStep[]) {
     return null
   }, [traceSteps])
 
-  const userToggledRef = useRef<Set<string>>(new Set())
-  const prevActiveRef = useRef<string | null>(null)
-  const [openState, setOpenState] = useState<Record<string, boolean>>({})
+  // User overrides: explicit open/close toggles that trump auto-behavior
+  const [userOverrides, setUserOverrides] = useState<Record<string, boolean>>({})
+  const openStateRef = useRef<Record<string, boolean>>({})
 
-  // Sync open state with steps and activeStepId
-  useEffect(() => {
-    setOpenState((prev) => {
-      const next: Record<string, boolean> = {}
-      let changed = false
-      for (const step of traceSteps) {
-        if (userToggledRef.current.has(step.id)) {
-          next[step.id] = prev[step.id] ?? computeDefaultOpen(step)
-        }
-        else if (step.id === activeStepId) {
-          next[step.id] = true
-        }
-        else {
-          next[step.id] = computeDefaultOpen(step)
-        }
-        if (next[step.id] !== prev[step.id])
-          changed = true
+  // Compute open state during render — no useEffect needed
+  const openState = useMemo(() => {
+    const next: Record<string, boolean> = {}
+    for (const step of traceSteps) {
+      if (step.id in userOverrides) {
+        next[step.id] = userOverrides[step.id]
       }
-      return changed ? next : prev
-    })
-  }, [traceSteps, activeStepId])
-
-  // Auto-close previous active when active changes
-  useEffect(() => {
-    const prev = prevActiveRef.current
-    if (prev && prev !== activeStepId && !userToggledRef.current.has(prev)) {
-      setOpenState(s => (s[prev] === true ? { ...s, [prev]: false } : s))
+      else if (step.id === activeStepId) {
+        next[step.id] = true
+      }
+      else {
+        next[step.id] = computeDefaultOpen(step)
+      }
     }
-    prevActiveRef.current = activeStepId
-  }, [activeStepId])
+    openStateRef.current = next
+    return next
+  }, [traceSteps, activeStepId, userOverrides])
 
   const handleToggle = useCallback((stepId: string) => {
-    userToggledRef.current.add(stepId)
-    setOpenState(s => ({ ...s, [stepId]: !s[stepId] }))
+    const currentOpen = openStateRef.current[stepId] ?? false
+    setUserOverrides(prev => ({ ...prev, [stepId]: !currentOpen }))
   }, [])
 
   return { openState, handleToggle, traceSteps, activeStepId }

--- a/apps/web/src/components/Chat/AssistantTrace.tsx
+++ b/apps/web/src/components/Chat/AssistantTrace.tsx
@@ -1,0 +1,551 @@
+import type { IMessage, ToolCallContent, ToolResultContent } from '@ant-chat/shared'
+import { CodeBlock } from '@workspace/ui/components/ai-elements/code-block'
+import { MessageResponse } from '@workspace/ui/components/ai-elements/message'
+import { Alert, AlertDescription, AlertTitle } from '@workspace/ui/components/alert'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@workspace/ui/components/collapsible'
+import { cn } from '@workspace/ui/lib/utils'
+import {
+  BrainIcon,
+  CheckCircleIcon,
+  ChevronDownIcon,
+  Loader2Icon,
+  WrenchIcon,
+  XCircleIcon,
+} from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+// ---- step types ----
+
+interface ToolStepData {
+  id: string
+  toolCall: ToolCallContent
+  toolResult?: ToolResultContent
+  isExecuting: boolean
+}
+
+type ContentStep
+  = | { type: 'reasoning', id: string, content: string, isStreaming: boolean }
+    | { type: 'tool', id: string, toolCall: ToolCallContent, toolResult?: ToolResultContent, isExecuting: boolean }
+    | { type: 'tool-group', id: string, tools: ToolStepData[], isExecuting: boolean }
+    | { type: 'text', id: string, text: string }
+    | { type: 'error-block', id: string, error: string }
+
+type TraceStep = Extract<ContentStep, { type: 'reasoning' | 'tool' | 'tool-group' }>
+
+// ---- build steps ----
+
+const TOOL_GROUP_THRESHOLD = 2
+
+function buildContentSteps(
+  message: IMessage,
+  toolResultMap: Map<string, IMessage>,
+  showReasoning: boolean,
+): ContentStep[] {
+  const steps: ContentStep[] = []
+
+  // Reasoning always first, before any content block
+  if (showReasoning && message.reasoningContent) {
+    const isStreaming = message.status === 'loading' || message.status === 'typing'
+    steps.push({
+      type: 'reasoning',
+      id: `${message.id}:reasoning`,
+      content: message.reasoningContent,
+      isStreaming,
+    })
+  }
+
+  // Content blocks in original order; consecutive tool-calls grouped
+  if (Array.isArray(message.content)) {
+    let textIndex = 0
+    let errorIndex = 0
+    const pendingTools: ToolStepData[] = []
+
+    function flushToolGroup() {
+      if (pendingTools.length === 0)
+        return
+      if (pendingTools.length < TOOL_GROUP_THRESHOLD) {
+        const t = pendingTools[0]
+        steps.push({ type: 'tool', id: t.id, toolCall: t.toolCall, toolResult: t.toolResult, isExecuting: t.isExecuting })
+      }
+      else {
+        const first = pendingTools[0]
+        steps.push({
+          type: 'tool-group',
+          id: `tool-group:${first.id}`,
+          tools: [...pendingTools],
+          isExecuting: pendingTools.some(t => t.isExecuting),
+        })
+      }
+      pendingTools.length = 0
+    }
+
+    for (const block of message.content) {
+      if (block.type === 'tool-call') {
+        const resultMsg = toolResultMap.get(block.toolCallId)
+        const resultBlock = resultMsg?.content.find(
+          (b): b is typeof b & { type: 'tool-result' } => b.type === 'tool-result',
+        )
+        pendingTools.push({
+          id: block.toolCallId,
+          toolCall: block,
+          toolResult: resultBlock as ToolResultContent | undefined,
+          isExecuting: !resultBlock,
+        })
+      }
+      else {
+        flushToolGroup()
+        if (block.type === 'text') {
+          steps.push({
+            type: 'text',
+            id: `${message.id}:text:${textIndex++}`,
+            text: block.text,
+          })
+        }
+        else if (block.type === 'error') {
+          steps.push({
+            type: 'error-block',
+            id: `${message.id}:error:${errorIndex++}`,
+            error: block.error,
+          })
+        }
+      }
+    }
+    flushToolGroup()
+  }
+
+  return steps
+}
+
+function isTraceStep(step: ContentStep): step is TraceStep {
+  return step.type === 'reasoning' || step.type === 'tool' || step.type === 'tool-group'
+}
+
+// ---- auto-expand/collapse ----
+
+function useTraceAutoExpand(steps: ContentStep[]) {
+  const traceSteps = useMemo(() => steps.filter(isTraceStep), [steps])
+
+  const activeStepId = useMemo(() => {
+    for (let i = traceSteps.length - 1; i >= 0; i--) {
+      const step = traceSteps[i]
+      if (step.type === 'reasoning' && step.isStreaming)
+        return step.id
+      if (step.type === 'tool' && step.isExecuting)
+        return step.id
+      if (step.type === 'tool-group' && step.isExecuting)
+        return step.id
+    }
+    return null
+  }, [traceSteps])
+
+  const userToggledRef = useRef<Set<string>>(new Set())
+  const prevActiveRef = useRef<string | null>(null)
+  const [openState, setOpenState] = useState<Record<string, boolean>>({})
+
+  // Sync open state with steps and activeStepId
+  useEffect(() => {
+    setOpenState((prev) => {
+      const next: Record<string, boolean> = {}
+      let changed = false
+      for (const step of traceSteps) {
+        if (userToggledRef.current.has(step.id)) {
+          next[step.id] = prev[step.id] ?? computeDefaultOpen(step)
+        }
+        else if (step.id === activeStepId) {
+          next[step.id] = true
+        }
+        else {
+          next[step.id] = computeDefaultOpen(step)
+        }
+        if (next[step.id] !== prev[step.id])
+          changed = true
+      }
+      return changed ? next : prev
+    })
+  }, [traceSteps, activeStepId])
+
+  // Auto-close previous active when active changes
+  useEffect(() => {
+    const prev = prevActiveRef.current
+    if (prev && prev !== activeStepId && !userToggledRef.current.has(prev)) {
+      setOpenState(s => (s[prev] === true ? { ...s, [prev]: false } : s))
+    }
+    prevActiveRef.current = activeStepId
+  }, [activeStepId])
+
+  const handleToggle = useCallback((stepId: string) => {
+    userToggledRef.current.add(stepId)
+    setOpenState(s => ({ ...s, [stepId]: !s[stepId] }))
+  }, [])
+
+  return { openState, handleToggle, traceSteps, activeStepId }
+}
+
+function computeDefaultOpen(step: TraceStep): boolean {
+  if (step.type === 'reasoning')
+    return step.isStreaming
+  if (step.type === 'tool')
+    return step.isExecuting
+  return step.isExecuting
+}
+
+// ---- sub-components ----
+
+function CollapseChevron({ open }: { open: boolean }) {
+  return (
+    <ChevronDownIcon
+      className={cn(
+        'size-3.5 ml-auto shrink-0 opacity-0 transition-all',
+        'group-hover:opacity-100',
+        open && 'rotate-180 opacity-100',
+      )}
+    />
+  )
+}
+
+function ReasoningStepItem({
+  step,
+  open,
+  onToggle,
+}: {
+  step: Extract<ContentStep, { type: 'reasoning' }>
+  open: boolean
+  onToggle: (id: string) => void
+}) {
+  return (
+    <Collapsible open={open} onOpenChange={() => onToggle(step.id)}>
+      <CollapsibleTrigger
+        className={cn(
+          'flex w-full items-center gap-1.5 py-1 text-sm transition-colors group',
+          'text-muted-foreground hover:text-foreground',
+        )}
+      >
+        <BrainIcon className="size-3 shrink-0" />
+        <span className="text-xs">
+          {step.isStreaming ? 'Thinking...' : 'Thought complete'}
+        </span>
+        {step.isStreaming && <Loader2Icon className="size-3 animate-spin" />}
+        <CollapseChevron open={open} />
+      </CollapsibleTrigger>
+      <CollapsibleContent
+        className={cn(
+          'ml-4 pl-2',
+          'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-1',
+          'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-top-1',
+        )}
+      >
+        <div className="py-1 text-xs text-muted-foreground whitespace-pre-wrap">
+          {step.content}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}
+
+// ---- tool parameter extraction ----
+
+/** Extract the most relevant inline parameter for the tool header. */
+function getInlineParam(toolCall: ToolCallContent): string | null {
+  const args = toolCall.args as Record<string, unknown> | undefined
+  if (!args || typeof args !== 'object')
+    return null
+
+  switch (toolCall.toolName) {
+    case 'read_file':
+    case 'write_to_file':
+    case 'replace_in_file':
+      return typeof args.filePath === 'string'
+        ? args.filePath
+        : typeof args.path === 'string'
+          ? args.path
+          : null
+    case 'search_content':
+    case 'search_file':
+      return typeof args.pattern === 'string'
+        ? args.pattern
+        : typeof args.regex === 'string'
+          ? args.regex
+          : null
+    case 'bash':
+      return typeof args.command === 'string' ? args.command : null
+    default:
+      return null
+  }
+}
+
+// ---- compact tool header icon ----
+
+function ToolStatusIcon({ state }: { state: 'input-available' | 'output-available' | 'output-error' }) {
+  if (state === 'output-error') {
+    return <XCircleIcon className="size-3 shrink-0 text-destructive" />
+  }
+  if (state === 'output-available') {
+    return <CheckCircleIcon className="size-3 shrink-0 text-green-600" />
+  }
+  return <Loader2Icon className="size-3 shrink-0 animate-spin text-muted-foreground" />
+}
+
+function CompactToolItem({
+  tool,
+  open,
+  onToggle,
+}: {
+  tool: ToolStepData
+  open: boolean
+  onToggle: (id: string) => void
+}) {
+  const hasResult = !!tool.toolResult
+  const state = hasResult
+    ? (tool.toolResult!.isError ? 'output-error' as const : 'output-available' as const)
+    : 'input-available' as const
+  const inlineParam = getInlineParam(tool.toolCall)
+
+  return (
+    <Collapsible open={open} onOpenChange={() => onToggle(tool.id)}>
+      <CollapsibleTrigger
+        className={cn(
+          'flex w-full min-w-0 items-center gap-1.5 py-1 text-sm transition-colors group',
+          'text-muted-foreground hover:text-foreground',
+        )}
+      >
+        <ToolStatusIcon state={state} />
+        <span className="font-medium text-xs shrink-0">{tool.toolCall.toolName}</span>
+        {inlineParam && (
+          <span className="text-xs text-muted-foreground/60 truncate min-w-0">
+            {inlineParam}
+          </span>
+        )}
+        <CollapseChevron open={open} />
+      </CollapsibleTrigger>
+      <CollapsibleContent
+        className={cn(
+          'ml-4 pl-2 space-y-2',
+          'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-1',
+          'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-top-1',
+        )}
+      >
+        {tool.toolResult && (
+          <div
+            className={cn(
+              'rounded text-xs overflow-y-auto',
+              '[&_pre]:text-xs! [&_code]:text-xs!',
+              tool.toolResult.isError
+                ? 'text-destructive'
+                : 'bg-muted/50 text-foreground',
+            )}
+          >
+            <CodeBlock code={String(tool.toolResult.result)} language="json" className="max-h-40 overflow-y-auto mb-1" />
+
+          </div>
+        )}
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}
+
+function ToolGroupItem({
+  group,
+  open,
+  onToggle,
+}: {
+  group: Extract<ContentStep, { type: 'tool-group' }>
+  open: boolean
+  onToggle: (id: string) => void
+}) {
+  const toolCount = group.tools.length
+
+  return (
+    <Collapsible open={open} onOpenChange={() => onToggle(group.id)}>
+      <CollapsibleTrigger
+        className={cn(
+          'flex w-full items-center gap-1.5 py-1 text-sm transition-colors group',
+          'text-muted-foreground hover:text-foreground',
+        )}
+      >
+        {group.isExecuting
+          ? <Loader2Icon className="size-3 shrink-0 animate-spin text-muted-foreground" />
+          : <WrenchIcon className="size-3 shrink-0 text-muted-foreground" />}
+        <span className="text-xs">
+          View
+          {' '}
+          {toolCount}
+          {' '}
+          steps
+        </span>
+        <CollapseChevron open={open} />
+      </CollapsibleTrigger>
+      <CollapsibleContent
+        className={cn(
+          'ml-4 pl-2 space-y-1',
+          'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-1',
+          'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-top-1',
+        )}
+      >
+        {group.tools.map(tool => (
+          <CompactToolItem
+            key={tool.id}
+            tool={tool}
+            open={!tool.toolResult}
+            onToggle={onToggle}
+          />
+        ))}
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}
+
+function TraceStepItem({
+  step,
+  open,
+  onToggle,
+}: {
+  step: TraceStep
+  open: boolean
+  onToggle: (stepId: string) => void
+}) {
+  if (step.type === 'reasoning') {
+    return <ReasoningStepItem step={step} open={open} onToggle={onToggle} />
+  }
+  if (step.type === 'tool-group') {
+    return <ToolGroupItem group={step} open={open} onToggle={onToggle} />
+  }
+  return (
+    <CompactToolItem
+      tool={{ id: step.id, toolCall: step.toolCall, toolResult: step.toolResult, isExecuting: step.isExecuting }}
+      open={open}
+      onToggle={onToggle}
+    />
+  )
+}
+
+// ---- helpers ----
+
+function isNetworkError(text: string): boolean {
+  if (!text)
+    return false
+  const patterns = /network|connection|fetch|abort|timeout|econnrefused|enotfound|socket|disconnected|econnreset|etimedout/i
+  return patterns.test(text)
+}
+
+function getErrorText(message: IMessage): string {
+  return message.content
+    .filter(b => b.type === 'error')
+    .map(b => b.error)
+    .join('\n')
+}
+
+function hasTextContent(message: IMessage): boolean {
+  return message.content.some(b => b.type === 'text' && b.text.length > 0)
+}
+
+// ---- public component ----
+
+interface AssistantTraceProps {
+  message: IMessage
+  toolResultMap: Map<string, IMessage>
+  /** Whether to show reasoning step. False for visible messages whose reasoning was extracted to the fold. */
+  showReasoning?: boolean
+}
+
+/**
+ * Renders assistant message content in order.
+ * Consecutive trace steps (reasoning / tool / tool-group) share one
+ * continuous left border. Text and error blocks break the border.
+ */
+export function AssistantTrace({ message, toolResultMap, showReasoning = true }: AssistantTraceProps) {
+  const steps = useMemo(
+    () => buildContentSteps(message, toolResultMap, showReasoning),
+    [message, toolResultMap, showReasoning],
+  )
+
+  const { openState, handleToggle } = useTraceAutoExpand(steps)
+  const isStreaming = message.status === 'loading' || message.status === 'typing'
+
+  // Group consecutive same-kind steps so trace items share a single left border
+  const renderGroups = useMemo(() => {
+    const groups: Array<{ steps: ContentStep[], isTrace: boolean }> = []
+    for (const step of steps) {
+      const currentIsTrace = isTraceStep(step)
+      const last = groups[groups.length - 1]
+      if (last && last.isTrace === currentIsTrace) {
+        last.steps.push(step)
+      }
+      else {
+        groups.push({ steps: [step], isTrace: currentIsTrace })
+      }
+    }
+    return groups
+  }, [steps])
+
+  return (
+    <div className="space-y-3">
+      {renderGroups.map((group) => {
+        // Consecutive trace steps: single bordered wrapper
+        if (group.isTrace) {
+          return (
+            <div
+              key={group.steps[0].id}
+              className="ml-3 border-l-2 border-muted/60 pl-4 space-y-0.5"
+            >
+              {group.steps.map(step => (
+                <TraceStepItem
+                  key={step.id}
+                  step={step as TraceStep}
+                  open={openState[step.id] ?? false}
+                  onToggle={handleToggle}
+                />
+              ))}
+            </div>
+          )
+        }
+
+        // Non-trace steps: render inline without border
+        return group.steps.map((step) => {
+          if (step.type === 'text') {
+            return (
+              <MessageResponse key={step.id} isAnimating={isStreaming}>
+                {step.text}
+              </MessageResponse>
+            )
+          }
+          if (step.type === 'error-block') {
+            return (
+              <p key={step.id} className="text-destructive whitespace-pre-wrap text-sm">
+                {step.error}
+              </p>
+            )
+          }
+          return null
+        })
+      })}
+
+      {/* Status alerts */}
+      {message.status === 'error' && (
+        <Alert variant="destructive">
+          <XCircleIcon className="size-4" />
+          <AlertTitle>
+            {isNetworkError(getErrorText(message)) ? 'Connection interrupted' : 'Request failed'}
+          </AlertTitle>
+          <AlertDescription>
+            <p className="whitespace-pre-wrap">
+              {getErrorText(message) || '请求失败。请检查配置并重试。'}
+            </p>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {message.status === 'cancel' && (
+        <Alert variant="default">
+          <AlertTitle>Cancelled</AlertTitle>
+          <AlertDescription>
+            {hasTextContent(message) ? null : <p>Task cancelled.</p>}
+          </AlertDescription>
+        </Alert>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/Chat/AssistantTrace.tsx
+++ b/apps/web/src/components/Chat/AssistantTrace.tsx
@@ -17,6 +17,7 @@ import {
   XCircleIcon,
 } from 'lucide-react'
 import { useCallback, useMemo, useRef, useState } from 'react'
+import { isNetworkError } from '@/utils/networkError'
 
 // ---- step types ----
 
@@ -129,7 +130,25 @@ function isTraceStep(step: ContentStep): step is TraceStep {
 function useTraceAutoExpand(steps: ContentStep[]) {
   const traceSteps = useMemo(() => steps.filter(isTraceStep), [steps])
 
+  // Collect child-tool ids so they have entries in openState
+  const childToolEntries = useMemo(() => {
+    const entries: { id: string, isExecuting: boolean }[] = []
+    for (const step of traceSteps) {
+      if (step.type === 'tool-group') {
+        for (const tool of step.tools) {
+          entries.push({ id: tool.id, isExecuting: tool.isExecuting })
+        }
+      }
+    }
+    return entries
+  }, [traceSteps])
+
   const activeStepId = useMemo(() => {
+    // Check child tools first (most granular), then groups, then top-level steps
+    for (const e of childToolEntries) {
+      if (e.isExecuting)
+        return e.id
+    }
     for (let i = traceSteps.length - 1; i >= 0; i--) {
       const step = traceSteps[i]
       if (step.type === 'reasoning' && step.isStreaming)
@@ -140,7 +159,7 @@ function useTraceAutoExpand(steps: ContentStep[]) {
         return step.id
     }
     return null
-  }, [traceSteps])
+  }, [traceSteps, childToolEntries])
 
   // User overrides: explicit open/close toggles that trump auto-behavior
   const [userOverrides, setUserOverrides] = useState<Record<string, boolean>>({})
@@ -149,20 +168,38 @@ function useTraceAutoExpand(steps: ContentStep[]) {
   // Compute open state during render — no useEffect needed
   const openState = useMemo(() => {
     const next: Record<string, boolean> = {}
-    for (const step of traceSteps) {
-      if (step.id in userOverrides) {
-        next[step.id] = userOverrides[step.id]
+
+    function setOpen(id: string, defaultOpen: boolean) {
+      if (id in userOverrides) {
+        next[id] = userOverrides[id]
       }
-      else if (step.id === activeStepId) {
-        next[step.id] = true
+      else if (id === activeStepId) {
+        next[id] = true
       }
       else {
-        next[step.id] = computeDefaultOpen(step)
+        next[id] = defaultOpen
       }
     }
+
+    for (const step of traceSteps) {
+      if (step.type === 'tool-group') {
+        setOpen(step.id, step.isExecuting)
+        for (const tool of step.tools) {
+          setOpen(tool.id, tool.isExecuting)
+        }
+      }
+      else if (step.type === 'reasoning') {
+        setOpen(step.id, step.isStreaming)
+      }
+      else {
+        // single tool
+        setOpen(step.id, step.isExecuting)
+      }
+    }
+
     openStateRef.current = next
     return next
-  }, [traceSteps, activeStepId, userOverrides])
+  }, [traceSteps, activeStepId, userOverrides, childToolEntries])
 
   const handleToggle = useCallback((stepId: string) => {
     const currentOpen = openStateRef.current[stepId] ?? false
@@ -170,14 +207,6 @@ function useTraceAutoExpand(steps: ContentStep[]) {
   }, [])
 
   return { openState, handleToggle, traceSteps, activeStepId }
-}
-
-function computeDefaultOpen(step: TraceStep): boolean {
-  if (step.type === 'reasoning')
-    return step.isStreaming
-  if (step.type === 'tool')
-    return step.isExecuting
-  return step.isExecuting
 }
 
 // ---- sub-components ----
@@ -338,10 +367,12 @@ function ToolGroupItem({
   group,
   open,
   onToggle,
+  openState,
 }: {
   group: Extract<ContentStep, { type: 'tool-group' }>
   open: boolean
   onToggle: (id: string) => void
+  openState: Record<string, boolean>
 }) {
   const toolCount = group.tools.length
 
@@ -376,7 +407,7 @@ function ToolGroupItem({
           <CompactToolItem
             key={tool.id}
             tool={tool}
-            open={!tool.toolResult}
+            open={openState[tool.id] ?? !tool.toolResult}
             onToggle={onToggle}
           />
         ))}
@@ -389,16 +420,18 @@ function TraceStepItem({
   step,
   open,
   onToggle,
+  openState,
 }: {
   step: TraceStep
   open: boolean
   onToggle: (stepId: string) => void
+  openState: Record<string, boolean>
 }) {
   if (step.type === 'reasoning') {
     return <ReasoningStepItem step={step} open={open} onToggle={onToggle} />
   }
   if (step.type === 'tool-group') {
-    return <ToolGroupItem group={step} open={open} onToggle={onToggle} />
+    return <ToolGroupItem group={step} open={open} onToggle={onToggle} openState={openState} />
   }
   return (
     <CompactToolItem
@@ -410,13 +443,6 @@ function TraceStepItem({
 }
 
 // ---- helpers ----
-
-function isNetworkError(text: string): boolean {
-  if (!text)
-    return false
-  const patterns = /network|connection|fetch|abort|timeout|econnrefused|enotfound|socket|disconnected|econnreset|etimedout/i
-  return patterns.test(text)
-}
 
 function getErrorText(message: IMessage): string {
   return message.content
@@ -484,6 +510,7 @@ export function AssistantTrace({ message, toolResultMap, showReasoning = true }:
                   step={step as TraceStep}
                   open={openState[step.id] ?? false}
                   onToggle={handleToggle}
+                  openState={openState}
                 />
               ))}
             </div>

--- a/apps/web/src/components/Chat/MessageBubble.tsx
+++ b/apps/web/src/components/Chat/MessageBubble.tsx
@@ -104,33 +104,7 @@ export function MessageBubble({ messages, collapseIntermediate, onCopyMessage }:
   if (nonToolMessages.length === 0)
     return null
 
-  // Split messages into process (fold) and visible:
-  // - Messages without text → always in fold
-  // - Messages with tool calls → always in fold
-  // - The last message stays visible (its text is the final answer),
-  //   but its reasoning is extracted into a virtual message in the fold
-  const processIds = new Set<string>()
-  const processMessages: IMessage[] = []
-
-  for (const m of nonToolMessages) {
-    if (!messageHasTextContent(m) || messageHasToolCalls(m)) {
-      processMessages.push(m)
-      processIds.add(m.id)
-    }
-  }
-
-  // Extract reasoning from the last message into the fold
-  const lastNonToolMsg = nonToolMessages[nonToolMessages.length - 1]
-  if (lastNonToolMsg?.reasoningContent && !processIds.has(lastNonToolMsg.id)) {
-    processMessages.push({
-      ...lastNonToolMsg,
-      id: `${lastNonToolMsg.id}:reasoning-fold`,
-      content: [],
-    })
-  }
-
-  const visibleMessages = nonToolMessages.filter(m => !processIds.has(m.id))
-
+  const { processMessages, visibleMessages } = splitProcessMessages(nonToolMessages)
   const shouldCollapseProcess = isAI && collapseIntermediate && processMessages.length > 0
 
   return (
@@ -249,6 +223,44 @@ function messageHasTextContent(msg: IMessage): boolean {
 
 function messageHasToolCalls(msg: IMessage): boolean {
   return Array.isArray(msg.content) && msg.content.some(b => b.type === 'tool-call')
+}
+
+interface ProcessSplit {
+  processMessages: IMessage[]
+  visibleMessages: IMessage[]
+}
+
+/**
+ * Split non-tool messages into process (fold) and visible:
+ * - Messages without text → fold
+ * - Messages with tool calls → fold
+ * - The last message stays visible (its text is the final answer);
+ *   its reasoning is extracted into a virtual message in the fold.
+ */
+function splitProcessMessages(messages: IMessage[]): ProcessSplit {
+  const processIds = new Set<string>()
+  const processMessages: IMessage[] = []
+
+  for (const m of messages) {
+    if (!messageHasTextContent(m) || messageHasToolCalls(m)) {
+      processMessages.push(m)
+      processIds.add(m.id)
+    }
+  }
+
+  // Extract reasoning from the last message into the fold
+  const lastMsg = messages[messages.length - 1]
+  if (lastMsg?.reasoningContent && !processIds.has(lastMsg.id)) {
+    processMessages.push({
+      ...lastMsg,
+      id: `${lastMsg.id}:reasoning-fold`,
+      content: [],
+    })
+  }
+
+  const visibleMessages = messages.filter(m => !processIds.has(m.id))
+
+  return { processMessages, visibleMessages }
 }
 
 function hasToolCallBlocks(msgs: IMessage[]): boolean {

--- a/apps/web/src/components/Chat/MessageBubble.tsx
+++ b/apps/web/src/components/Chat/MessageBubble.tsx
@@ -1,5 +1,4 @@
 import type { IMessage } from '@ant-chat/shared'
-import type { BubbleContent } from '@/types/global'
 import {
   MessageContent as AiMessageContent,
   Message,
@@ -10,14 +9,14 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@workspace/ui/components/collapsible'
+import { Separator } from '@workspace/ui/components/separator'
 import { cn } from '@workspace/ui/lib/utils'
-import { pick } from 'lodash-es'
 import { ChevronRightIcon, ShrinkIcon } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Role } from '@/constants'
 import { transformMessageContent } from '@/utils/messageTransform'
+import { AssistantTrace } from './AssistantTrace'
 import BubbleFooter from './BubbleFooter'
-import { McpToolCallPanel } from './McpToolCallPanel'
 import MessageContent from './MessageContent'
 
 interface MessageBubbleProps {
@@ -33,7 +32,7 @@ export function MessageBubble({ messages, collapseIntermediate, onCopyMessage }:
   const isAI = message.role === Role.AI
   const isEvent = message.role === Role.EVENT
 
-  // 建立 toolCallId → tool-result 消息的索引
+  // Build toolCallId → tool-result message index
   const toolResultMap = useMemo(() => {
     const map = new Map<string, IMessage>()
     for (const m of messages) {
@@ -48,7 +47,20 @@ export function MessageBubble({ messages, collapseIntermediate, onCopyMessage }:
     return map
   }, [messages])
 
-  // 事件消息：渲染为可折叠分隔线
+  // Determine if the last assistant message has reasoning / is running (for fold decisions).
+  // Must be computed before early returns to keep hook order stable.
+  const nonToolForFold = messages.filter(m => m.role !== 'tool')
+  const lastNonTool = nonToolForFold[nonToolForFold.length - 1]
+  const isRunning = lastNonTool?.status === 'loading' || lastNonTool?.status === 'typing'
+
+  // Auto-open fold only while the conversation is streaming
+  useEffect(() => {
+    if (collapseIntermediate && isRunning && nonToolForFold.length > 1) {
+      setIsProcessOpen(true)
+    }
+  }, [collapseIntermediate, isRunning, nonToolForFold.length])
+
+  // Event messages: render as collapsible divider
   if (isEvent) {
     const eventLabel = message.eventType === 'compaction' ? '上下文压缩' : message.eventType
     const eventText = typeof message.content === 'string'
@@ -86,14 +98,40 @@ export function MessageBubble({ messages, collapseIntermediate, onCopyMessage }:
     )
   }
 
-  // 只展示 non-tool 消息（assistant + user）
-  const nonToolMessages = messages.filter(m => m.role !== 'tool')
+  // Show only non-tool messages (assistant + user)
+  const nonToolMessages = nonToolForFold
+
   if (nonToolMessages.length === 0)
     return null
 
-  const shouldCollapseProcess = isAI && collapseIntermediate && nonToolMessages.length > 1
-  const processMessages = shouldCollapseProcess ? nonToolMessages.slice(0, -1) : []
-  const visibleMessages = shouldCollapseProcess ? nonToolMessages.slice(-1) : nonToolMessages
+  // Split messages into process (fold) and visible:
+  // - Messages without text → always in fold
+  // - Messages with tool calls → always in fold
+  // - The last message stays visible (its text is the final answer),
+  //   but its reasoning is extracted into a virtual message in the fold
+  const processIds = new Set<string>()
+  const processMessages: IMessage[] = []
+
+  for (const m of nonToolMessages) {
+    if (!messageHasTextContent(m) || messageHasToolCalls(m)) {
+      processMessages.push(m)
+      processIds.add(m.id)
+    }
+  }
+
+  // Extract reasoning from the last message into the fold
+  const lastNonToolMsg = nonToolMessages[nonToolMessages.length - 1]
+  if (lastNonToolMsg?.reasoningContent && !processIds.has(lastNonToolMsg.id)) {
+    processMessages.push({
+      ...lastNonToolMsg,
+      id: `${lastNonToolMsg.id}:reasoning-fold`,
+      content: [],
+    })
+  }
+
+  const visibleMessages = nonToolMessages.filter(m => !processIds.has(m.id))
+
+  const shouldCollapseProcess = isAI && collapseIntermediate && processMessages.length > 0
 
   return (
     <Message
@@ -137,9 +175,8 @@ export function MessageBubble({ messages, collapseIntermediate, onCopyMessage }:
                         key={item.id}
                         data-message-id={item.id}
                       >
-                        <MessageContentRenderer
+                        <AssistantMessageContent
                           item={item}
-                          content={transformMessageContent(item)}
                           toolResultMap={toolResultMap}
                         />
                       </div>
@@ -151,18 +188,17 @@ export function MessageBubble({ messages, collapseIntermediate, onCopyMessage }:
               {visibleMessages.map((item, index) => (
                 <div
                   key={item.id}
-                  className={cn(
-                    (index > 0 || shouldCollapseProcess) && `
-                      border-t border-gray-200 pt-5
-                      dark:border-gray-800
-                    `,
-                  )}
                   data-message-id={item.id}
                 >
-                  <MessageContentRenderer
+                  {
+                    (index > 0 || shouldCollapseProcess) && (
+                      <Separator className="my-3" />
+                    )
+                  }
+                  <AssistantMessageContent
                     item={item}
-                    content={transformMessageContent(item)}
                     toolResultMap={toolResultMap}
+                    showReasoning={false}
                   />
                 </div>
               ))}
@@ -181,84 +217,38 @@ export function MessageBubble({ messages, collapseIntermediate, onCopyMessage }:
   )
 }
 
-type RenderSegment
-  = | { kind: 'text', text: string, isFirst: boolean }
-    | { kind: 'tool-call', block: IMessage['content'][number] & { type: 'tool-call' } }
+// ---- per-message content renderer ----
 
-function buildRenderSegments(item: IMessage): RenderSegment[] {
-  if (typeof item.content === 'string')
-    return [{ kind: 'text', text: item.content, isFirst: true }]
-
-  const segments: RenderSegment[] = []
-  let isFirstText = true
-
-  for (const block of item.content) {
-    if (block.type === 'text') {
-      segments.push({ kind: 'text', text: block.text, isFirst: isFirstText })
-      isFirstText = false
-    }
-    else if (block.type === 'error') {
-      segments.push({ kind: 'text', text: `${block.error}`, isFirst: isFirstText })
-      isFirstText = false
-    }
-    else if (block.type === 'tool-call') {
-      segments.push({ kind: 'tool-call', block })
-    }
-  }
-
-  return segments
-}
-
-function MessageContentRenderer({
+function AssistantMessageContent({
   item,
-  content,
   toolResultMap,
+  showReasoning = true,
 }: {
   item: IMessage
-  content: string
   toolResultMap: Map<string, IMessage>
+  showReasoning?: boolean
 }) {
-  const itemIsUser = item.role === Role.USER
-  const itemIsAI = item.role === Role.AI
-
-  if (!itemIsAI) {
-    const messageContentProps: Partial<BubbleContent> = {
-      ...pick(item, ['status']),
-      content,
-    }
-    return <MessageContent {...messageContentProps} enableReferenceTokens={itemIsUser} />
+  if (item.role !== Role.AI) {
+    return (
+      <MessageContent
+        content={transformMessageContent(item)}
+        status={item.status as 'success' | 'cancel'}
+        enableReferenceTokens
+      />
+    )
   }
 
-  const segments = buildRenderSegments(item)
+  return <AssistantTrace message={item} toolResultMap={toolResultMap} showReasoning={showReasoning} />
+}
 
-  return (
-    <>
-      {segments.map((seg, i) => {
-        if (seg.kind === 'tool-call') {
-          const resultMsg = toolResultMap.get(seg.block.toolCallId)
-          const resultBlock = resultMsg?.content.find(
-            (b): b is typeof b & { type: 'tool-result' } => b.type === 'tool-result',
-          )
-          return (
-            <div key={seg.block.toolCallId || i} className="my-2">
-              <McpToolCallPanel
-                toolCall={seg.block}
-                toolResult={resultBlock}
-              />
-            </div>
-          )
-        }
-        return (
-          <MessageContent
-            key={i}
-            content={seg.text}
-            reasoningContent={seg.isFirst ? item.reasoningContent : undefined}
-            status={item.status}
-          />
-        )
-      })}
-    </>
-  )
+// ---- helpers ----
+
+function messageHasTextContent(msg: IMessage): boolean {
+  return Array.isArray(msg.content) && msg.content.some(b => b.type === 'text' && b.text.length > 0)
+}
+
+function messageHasToolCalls(msg: IMessage): boolean {
+  return Array.isArray(msg.content) && msg.content.some(b => b.type === 'tool-call')
 }
 
 function hasToolCallBlocks(msgs: IMessage[]): boolean {

--- a/apps/web/src/components/Chat/MessageContent.tsx
+++ b/apps/web/src/components/Chat/MessageContent.tsx
@@ -10,14 +10,9 @@ import {
   Attachments,
 } from '@workspace/ui/components/ai-elements/attachments'
 import { MessageResponse } from '@workspace/ui/components/ai-elements/message'
-import {
-  Reasoning,
-  ReasoningContent,
-  ReasoningTrigger,
-} from '@workspace/ui/components/ai-elements/reasoning'
-import { Alert, AlertDescription } from '@workspace/ui/components/alert'
+import { Alert, AlertDescription, AlertTitle } from '@workspace/ui/components/alert'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@workspace/ui/components/tooltip'
-import { FileIcon, Loader2Icon, SparklesIcon } from 'lucide-react'
+import { FileIcon, SparklesIcon, XCircleIcon } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { skillApi } from '@/api/skillApi'
 import { tokenizeMessageReferences } from './messageReferenceTokens'
@@ -43,10 +38,16 @@ function getAttachmentUrl(item: AttachmentData): string {
 const EMPTY_IMAGES: NonNullable<BubbleContent['images']> = []
 const EMPTY_ATTACHMENTS: NonNullable<BubbleContent['attachments']> = []
 
-export default function MessageContent({ content = '', images = EMPTY_IMAGES, attachments = EMPTY_ATTACHMENTS, reasoningContent = '', status, enableReferenceTokens = false }: Partial<BubbleContent> & { enableReferenceTokens?: boolean }) {
+export default function MessageContent({ content = '', images = EMPTY_IMAGES, attachments = EMPTY_ATTACHMENTS, status, enableReferenceTokens = false }: Partial<BubbleContent> & { enableReferenceTokens?: boolean }) {
   if (status === 'error') {
+    const title = isNetworkError(content)
+      ? 'Connection interrupted'
+      : 'Request failed'
+
     return (
       <Alert variant="destructive">
+        <XCircleIcon className="size-4" />
+        <AlertTitle>{title}</AlertTitle>
         <AlertDescription>
           {content
             ? <p className="whitespace-pre-wrap">{content}</p>
@@ -59,8 +60,11 @@ export default function MessageContent({ content = '', images = EMPTY_IMAGES, at
   if (status === 'cancel') {
     return (
       <Alert variant="default">
+        <AlertTitle>Cancelled</AlertTitle>
         <AlertDescription>
-          {content && <p className="whitespace-pre-wrap">{content}</p>}
+          {content
+            ? <p className="whitespace-pre-wrap">{content}</p>
+            : <p>Task cancelled.</p>}
         </AlertDescription>
       </Alert>
     )
@@ -72,20 +76,6 @@ export default function MessageContent({ content = '', images = EMPTY_IMAGES, at
 
   return (
     <div className="space-y-3">
-      {reasoningContent && (
-        <Reasoning isStreaming={isStreaming}>
-          <ReasoningTrigger
-            getThinkingMessage={streaming => (
-              <span className="inline-flex items-center gap-1">
-                {streaming ? 'Thinking' : 'Thought complete'}
-                {streaming && <Loader2Icon className="size-3 animate-spin" />}
-              </span>
-            )}
-          />
-          <ReasoningContent>{reasoningContent}</ReasoningContent>
-        </Reasoning>
-      )}
-
       {content && (
         enableReferenceTokens
           ? <ReferenceTokenMessage content={content} />
@@ -125,6 +115,13 @@ export default function MessageContent({ content = '', images = EMPTY_IMAGES, at
       )}
     </div>
   )
+}
+
+function isNetworkError(text: string): boolean {
+  if (!text)
+    return false
+  const patterns = /network|connection|fetch|abort|timeout|econnrefused|enotfound|socket|disconnected|econnreset|etimedout/i
+  return patterns.test(text)
 }
 
 function ReferenceTokenMessage({ content }: { content: string }) {

--- a/apps/web/src/components/Chat/MessageContent.tsx
+++ b/apps/web/src/components/Chat/MessageContent.tsx
@@ -15,6 +15,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@workspace/ui/component
 import { FileIcon, SparklesIcon, XCircleIcon } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { skillApi } from '@/api/skillApi'
+import { isNetworkError } from '@/utils/networkError'
 import { tokenizeMessageReferences } from './messageReferenceTokens'
 
 function toAttachmentData(item: NonNullable<BubbleContent['attachments']>[number]): AttachmentData {
@@ -115,13 +116,6 @@ export default function MessageContent({ content = '', images = EMPTY_IMAGES, at
       )}
     </div>
   )
-}
-
-function isNetworkError(text: string): boolean {
-  if (!text)
-    return false
-  const patterns = /network|connection|fetch|abort|timeout|econnrefused|enotfound|socket|disconnected|econnreset|etimedout/i
-  return patterns.test(text)
 }
 
 function ReferenceTokenMessage({ content }: { content: string }) {

--- a/apps/web/src/utils/networkError.ts
+++ b/apps/web/src/utils/networkError.ts
@@ -1,0 +1,11 @@
+const NETWORK_ERROR_PATTERNS = /network|connection|fetch|abort|timeout|econnrefused|enotfound|socket|disconnected|econnreset|etimedout/i
+
+/**
+ * Lightweight UI-layer check: does the error text indicate a network / connectivity problem?
+ * No schema changes required; pure string matching.
+ */
+export function isNetworkError(text: string): boolean {
+  if (!text)
+    return false
+  return NETWORK_ERROR_PATTERNS.test(text)
+}


### PR DESCRIPTION
## Summary

Redesign assistant message bubble to show reasoning and tool calls as a unified, indented trace area with auto-expand/collapse behavior.

### Key Changes

**New: `AssistantTrace` component**
- Builds `ContentStep[]` from message content blocks, preserving original order
- Reasoning and tool-call steps render as compact collapsible rows with left-border indentation
- Consecutive tool calls (≥2) grouped into "View N steps" fold
- Auto-expand: current streaming/executing step opens, previous step closes
- User manual toggles persist across streaming updates
- Compact tool header: status icon replaces wrench icon; key parameters (filePath/pattern/command) shown inline with truncation
- Open state computed in render via `useMemo`, no `setState` inside `useEffect`

**Refactored: `MessageBubble`**
- Assistant path now delegates to `AssistantTrace`
- `splitProcessMessages` pure function: messages without text or with tool-calls go into the execution-process fold; last message text stays visible, its reasoning extracted to a virtual fold entry
- Fold auto-opens only while conversation is streaming

**Enhanced: `MessageContent`**
- Error states: distinct titles for "Connection interrupted", "Request failed", "Cancelled"
- Reasoning rendering removed (moved to `AssistantTrace`)

**Extracted: `networkError.ts`**
- `isNetworkError` moved to shared helper, removes duplicate regex

### Files Changed
| File | Status |
|------|--------|
| `apps/web/src/components/Chat/AssistantTrace.tsx` | new |
| `apps/web/src/components/Chat/MessageBubble.tsx` | refactored |
| `apps/web/src/components/Chat/MessageContent.tsx` | enhanced |
| `apps/web/src/utils/networkError.ts` | new |

### Checks
`pnpm check` passes: type-check, lint (0 errors), 310+ tests