### PR TITLE
feat(chat): add message jump rail for quick navigation between user messages

### DIFF
--- a/apps/web/src/components/Chat/BubbleList.tsx
+++ b/apps/web/src/components/Chat/BubbleList.tsx
@@ -115,7 +115,7 @@ function BubbleList({ messages, isAgentRunning }: Props) {
   )
 
   return (
-    <div className="relative h-full">
+    <>
       <InfiniteScroll
         ref={infiniteScrollRef}
         className="flex flex-col gap-6 px-4 py-6"
@@ -156,7 +156,7 @@ function BubbleList({ messages, isAgentRunning }: Props) {
         activeMessageId={activeMessageId}
         onJumpToMessage={handleJumpToMessage}
       />
-    </div>
+    </>
   )
 }
 

--- a/apps/web/src/components/Chat/BubbleList.tsx
+++ b/apps/web/src/components/Chat/BubbleList.tsx
@@ -99,9 +99,6 @@ function BubbleList({ messages, isAgentRunning }: Props) {
       // 关闭自动滚动，防止跳转后被拉回底部
       setAutoScrollToBottom(false)
 
-      infiniteScrollRef.current?.scrollToElement(`[data-message-id="${messageId}"]`)
-
-      // 短暂高亮目标消息（内层 bubble 容器）
       const container = infiniteScrollRef.current?.containerRef.current
       if (!container)
         return
@@ -112,11 +109,18 @@ function BubbleList({ messages, isAgentRunning }: Props) {
       // 即带背景色/圆角的实际气泡容器，而非外层 wrapper
       const bubble = messageEl.querySelector('.flex.w-fit.min-w-0.max-w-full') as HTMLElement | null
       const target: HTMLElement = bubble || (messageEl as HTMLElement)
+
+      // 设置 scroll-margin 留出顶部呼吸空间，再滚动
+      target.style.scrollMarginTop = '1.5rem'
+      target.scrollIntoView({ behavior: 'smooth', block: 'start' })
+
+      // 高亮效果
       target.style.transition = 'box-shadow 0.3s ease-in-out'
       target.style.boxShadow = '0 0 0 2px var(--ring)'
       target.style.borderRadius = 'var(--radius-lg)'
       setTimeout(() => {
         target.style.boxShadow = ''
+        target.style.scrollMarginTop = ''
       }, 1500)
     },
     [infiniteScrollRef, setAutoScrollToBottom],
@@ -126,7 +130,7 @@ function BubbleList({ messages, isAgentRunning }: Props) {
     <>
       <InfiniteScroll
         ref={infiniteScrollRef}
-        className="flex flex-col gap-6 px-4 py-6 scroll-pt-6"
+        className="flex flex-col gap-6 px-4 py-6"
         hasMore={false}
         loading={false}
         onLoadMore={async () => {}}

--- a/apps/web/src/components/Chat/BubbleList.tsx
+++ b/apps/web/src/components/Chat/BubbleList.tsx
@@ -122,7 +122,7 @@ function BubbleList({ messages, isAgentRunning }: Props) {
     <>
       <InfiniteScroll
         ref={infiniteScrollRef}
-        className="flex flex-col gap-6 px-4 py-6"
+        className="flex flex-col gap-6 px-4 py-6 scroll-pt-6"
         hasMore={false}
         loading={false}
         onLoadMore={async () => {}}

--- a/apps/web/src/components/Chat/BubbleList.tsx
+++ b/apps/web/src/components/Chat/BubbleList.tsx
@@ -115,46 +115,48 @@ function BubbleList({ messages, isAgentRunning }: Props) {
   )
 
   return (
-    <InfiniteScroll
-      ref={infiniteScrollRef}
-      className="relative flex flex-col gap-6 px-4 py-6"
-      hasMore={false}
-      loading={false}
-      onLoadMore={async () => {}}
-      direction="top"
-      onWheel={handleWheel}
-    >
-      {messageGroups.map(group => (
-        <MessageBubble
-          key={group.map(message => message.id).join(':')}
-          messages={group}
-          collapseIntermediate={!isAgentRunning}
-          onCopyMessage={copyMessage}
-        />
-      ))}
+    <div className="relative h-full">
+      <InfiniteScroll
+        ref={infiniteScrollRef}
+        className="flex flex-col gap-6 px-4 py-6"
+        hasMore={false}
+        loading={false}
+        onLoadMore={async () => {}}
+        direction="top"
+        onWheel={handleWheel}
+      >
+        {messageGroups.map(group => (
+          <MessageBubble
+            key={group.map(message => message.id).join(':')}
+            messages={group}
+            collapseIntermediate={!isAgentRunning}
+            onCopyMessage={copyMessage}
+          />
+        ))}
+
+        <Button
+          size="icon-sm"
+          variant="outline"
+          className={`
+            sticky bottom-8 left-1/2 z-10 -translate-x-1/2 rounded-full bg-background shadow-sm
+            transition-opacity duration-300
+            ${autoScrollToBottom
+      ? `opacity-0`
+      : `opacity-100`}
+          `}
+          type="button"
+          onClick={scrollToBottom}
+        >
+          <ArrowDownIcon className="size-4" />
+        </Button>
+      </InfiniteScroll>
 
       <MessageJumpRail
         userMessages={userMessages}
         activeMessageId={activeMessageId}
         onJumpToMessage={handleJumpToMessage}
       />
-
-      <Button
-        size="icon-sm"
-        variant="outline"
-        className={`
-          sticky bottom-8 left-1/2 z-10 -translate-x-1/2 rounded-full bg-background shadow-sm
-          transition-opacity duration-300
-          ${autoScrollToBottom
-      ? `opacity-0`
-      : `opacity-100`}
-        `}
-        type="button"
-        onClick={scrollToBottom}
-      >
-        <ArrowDownIcon className="size-4" />
-      </Button>
-    </InfiniteScroll>
+    </div>
   )
 }
 

--- a/apps/web/src/components/Chat/BubbleList.tsx
+++ b/apps/web/src/components/Chat/BubbleList.tsx
@@ -101,19 +101,23 @@ function BubbleList({ messages, isAgentRunning }: Props) {
 
       infiniteScrollRef.current?.scrollToElement(`[data-message-id="${messageId}"]`)
 
-      // 短暂高亮目标消息
+      // 短暂高亮目标消息（内层 bubble 容器）
       const container = infiniteScrollRef.current?.containerRef.current
       if (!container)
         return
-      const el = container.querySelector(`[data-message-id="${messageId}"]`) as HTMLElement | null
-      if (el) {
-        el.style.transition = 'box-shadow 0.3s ease-in-out'
-        el.style.boxShadow = '0 0 0 2px var(--ring)'
-        el.style.borderRadius = 'var(--radius-lg)'
-        setTimeout(() => {
-          el.style.boxShadow = ''
-        }, 1500)
-      }
+      const messageEl = container.querySelector(`[data-message-id="${messageId}"]`)
+      if (!messageEl)
+        return
+      // 选中 MessageContent 内层 div（ai-elements/message.tsx:58），
+      // 即带背景色/圆角的实际气泡容器，而非外层 wrapper
+      const bubble = messageEl.querySelector('.flex.w-fit.min-w-0.max-w-full') as HTMLElement | null
+      const target: HTMLElement = bubble || (messageEl as HTMLElement)
+      target.style.transition = 'box-shadow 0.3s ease-in-out'
+      target.style.boxShadow = '0 0 0 2px var(--ring)'
+      target.style.borderRadius = 'var(--radius-lg)'
+      setTimeout(() => {
+        target.style.boxShadow = ''
+      }, 1500)
     },
     [infiniteScrollRef, setAutoScrollToBottom],
   )

--- a/apps/web/src/components/Chat/BubbleList.tsx
+++ b/apps/web/src/components/Chat/BubbleList.tsx
@@ -17,6 +17,7 @@ interface Props {
 function BubbleList({ messages, isAgentRunning }: Props) {
   const {
     autoScrollToBottom,
+    setAutoScrollToBottom,
     infiniteScrollRef,
     handleWheel,
     scrollToBottom,
@@ -95,6 +96,9 @@ function BubbleList({ messages, isAgentRunning }: Props) {
 
   const handleJumpToMessage = useCallback(
     (messageId: string) => {
+      // 关闭自动滚动，防止跳转后被拉回底部
+      setAutoScrollToBottom(false)
+
       infiniteScrollRef.current?.scrollToElement(`[data-message-id="${messageId}"]`)
 
       // 短暂高亮目标消息
@@ -111,7 +115,7 @@ function BubbleList({ messages, isAgentRunning }: Props) {
         }, 1500)
       }
     },
-    [infiniteScrollRef],
+    [infiniteScrollRef, setAutoScrollToBottom],
   )
 
   return (

--- a/apps/web/src/components/Chat/BubbleList.tsx
+++ b/apps/web/src/components/Chat/BubbleList.tsx
@@ -1,10 +1,12 @@
 import type { IMessage } from '@ant-chat/shared'
 import { Button } from '@workspace/ui/components/button'
 import { ArrowDownIcon } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useAutoScroll } from '@/hooks/useAutoScroll'
 import { useMessageActions } from '@/hooks/useMessageActions'
 import { InfiniteScroll } from '../InfiniteScroll'
 import { MessageBubble } from './MessageBubble'
+import { MessageJumpRail } from './MessageJumpRail'
 
 interface Props {
   messages: IMessage[]
@@ -24,6 +26,94 @@ function BubbleList({ messages, isAgentRunning }: Props) {
 
   const messageGroups = groupMessages(messages)
 
+  // ---- 用户消息跳转导航 ----
+
+  const userMessages = useMemo(
+    () => messages.filter(m => m.role === 'user'),
+    [messages],
+  )
+
+  const [activeMessageId, setActiveMessageId] = useState<string | null>(null)
+  const visibilityMapRef = useRef<Map<string, number>>(new Map())
+
+  // 使用 IntersectionObserver 跟踪各用户消息的可见比例
+  useEffect(() => {
+    const container = infiniteScrollRef.current?.containerRef.current
+    if (!container || userMessages.length <= 1) {
+      setActiveMessageId(null)
+      return
+    }
+
+    const userMessageSelector = userMessages
+      .map(m => `[data-message-id="${m.id}"]`)
+      .join(',')
+
+    const elements = container.querySelectorAll(userMessageSelector)
+    if (elements.length === 0)
+      return
+
+    const map = visibilityMapRef.current
+    map.clear()
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          const id = (entry.target as HTMLElement).dataset.messageId
+          if (!id)
+            continue
+          if (entry.isIntersecting) {
+            map.set(id, entry.intersectionRatio)
+          }
+          else {
+            map.delete(id)
+          }
+        }
+
+        // 选 intersection ratio 最高的作为 active
+        let bestId: string | null = null
+        let bestRatio = 0
+        for (const [id, ratio] of map) {
+          if (ratio > bestRatio) {
+            bestRatio = ratio
+            bestId = id
+          }
+        }
+        setActiveMessageId(bestId)
+      },
+      {
+        root: container,
+        threshold: [0, 0.25, 0.5, 0.75, 1],
+      },
+    )
+
+    for (const el of elements) {
+      observer.observe(el)
+    }
+
+    return () => observer.disconnect()
+  }, [userMessages, infiniteScrollRef])
+
+  const handleJumpToMessage = useCallback(
+    (messageId: string) => {
+      infiniteScrollRef.current?.scrollToElement(`[data-message-id="${messageId}"]`)
+
+      // 短暂高亮目标消息
+      const container = infiniteScrollRef.current?.containerRef.current
+      if (!container)
+        return
+      const el = container.querySelector(`[data-message-id="${messageId}"]`) as HTMLElement | null
+      if (el) {
+        el.style.transition = 'box-shadow 0.3s ease-in-out'
+        el.style.boxShadow = '0 0 0 2px var(--ring)'
+        el.style.borderRadius = 'var(--radius-lg)'
+        setTimeout(() => {
+          el.style.boxShadow = ''
+        }, 1500)
+      }
+    },
+    [infiniteScrollRef],
+  )
+
   return (
     <InfiniteScroll
       ref={infiniteScrollRef}
@@ -42,6 +132,12 @@ function BubbleList({ messages, isAgentRunning }: Props) {
           onCopyMessage={copyMessage}
         />
       ))}
+
+      <MessageJumpRail
+        userMessages={userMessages}
+        activeMessageId={activeMessageId}
+        onJumpToMessage={handleJumpToMessage}
+      />
 
       <Button
         size="icon-sm"

--- a/apps/web/src/components/Chat/MessageJumpRail.tsx
+++ b/apps/web/src/components/Chat/MessageJumpRail.tsx
@@ -1,0 +1,145 @@
+import type { IMessage } from '@ant-chat/shared'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@workspace/ui/components/tooltip'
+import { cn } from '@workspace/ui/lib/utils'
+import { useMemo } from 'react'
+
+interface MessageJumpRailProps {
+  /** 所有用户消息（按原始顺序） */
+  userMessages: IMessage[]
+  /** 当前可见的用户消息 id */
+  activeMessageId: string | null
+  /** 点击节点时的回调，传入目标消息 id */
+  onJumpToMessage: (messageId: string) => void
+}
+
+/**
+ * 从消息内容中提取摘要文本。
+ * - 优先取第一个 text block 的文本
+ * - 空内容或只有附件时返回占位文本
+ */
+function extractSummary(message: IMessage): string {
+  if (Array.isArray(message.content)) {
+    const firstText = message.content.find(b => b.type === 'text')
+    if (firstText && 'text' in firstText && firstText.text.trim()) {
+      return firstText.text.trim()
+    }
+  }
+
+  return 'User message'
+}
+
+/**
+ * 截断文本到指定长度，超出部分用省略号
+ */
+function truncateText(text: string, maxLength = 80): string {
+  if (text.length <= maxLength)
+    return text
+  return `${text.slice(0, maxLength)}…`
+}
+
+export function MessageJumpRail({
+  userMessages,
+  activeMessageId,
+  onJumpToMessage,
+}: MessageJumpRailProps) {
+  const summaries = useMemo(
+    () => userMessages.map(m => truncateText(extractSummary(m))),
+    [userMessages],
+  )
+
+  if (userMessages.length <= 1)
+    return null
+
+  return (
+    <>
+      {/* 桌面：右侧垂直 rail */}
+      <nav
+        aria-label="Message navigation"
+        className={`
+          absolute right-3 top-1/2 z-20 -translate-y-1/2
+          hidden md:flex flex-col items-center gap-1.5
+          opacity-[0.42] transition-opacity duration-200
+          hover:opacity-100 focus-within:opacity-100
+        `}
+      >
+        {userMessages.map((message, index) => {
+          const isActive = message.id === activeMessageId
+
+          return (
+            <Tooltip key={message.id} delayDuration={300}>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label={`跳转到用户消息 ${index + 1}`}
+                  aria-current={isActive ? 'true' : undefined}
+                  className={cn(
+                    'block rounded-full border transition-all duration-200',
+                    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                    isActive
+                      ? 'size-2 border-primary bg-primary'
+                      : [
+                          'size-1.5',
+                          'border-muted-foreground/30 bg-background',
+                          'hover:size-2 hover:border-primary hover:ring-2 hover:ring-primary/20',
+                        ],
+                  )}
+                  onClick={() => onJumpToMessage(message.id)}
+                />
+              </TooltipTrigger>
+              <TooltipContent
+                side="left"
+                sideOffset={12}
+                className="border-border bg-card text-foreground shadow-none"
+              >
+                <p className="max-w-48 line-clamp-3 text-xs leading-relaxed whitespace-pre-wrap">
+                  {summaries[index]}
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          )
+        })}
+      </nav>
+
+      {/* 移动端：底部横向小圆点条（无 tooltip） */}
+      <nav
+        aria-label="Message navigation"
+        className={`
+          sticky bottom-0 left-0 right-0 z-20
+          flex md:hidden items-center justify-center gap-1.5
+          bg-background/80 backdrop-blur-sm py-1.5
+          opacity-[0.6] transition-opacity duration-200
+          hover:opacity-100 focus-within:opacity-100
+        `}
+      >
+        {userMessages.map((message, index) => {
+          const isActive = message.id === activeMessageId
+
+          return (
+            <button
+              key={message.id}
+              type="button"
+              aria-label={`跳转到用户消息 ${index + 1}`}
+              aria-current={isActive ? 'true' : undefined}
+              className={cn(
+                'block rounded-full border transition-all duration-200',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                isActive
+                  ? 'size-2 border-primary bg-primary'
+                  : [
+                      'size-1.5',
+                      'border-muted-foreground/30 bg-background',
+                      'hover:size-2 hover:border-primary hover:ring-2 hover:ring-primary/20',
+                    ],
+              )}
+              onClick={() => onJumpToMessage(message.id)}
+            />
+          )
+        })}
+      </nav>
+    </>
+  )
+}

--- a/apps/web/src/components/Chat/MessageJumpRail.tsx
+++ b/apps/web/src/components/Chat/MessageJumpRail.tsx
@@ -60,7 +60,7 @@ export function MessageJumpRail({
       <nav
         aria-label="Message navigation"
         className={`
-          absolute right-3 top-1/2 z-20 -translate-y-1/2
+          fixed right-3 top-1/2 z-20 -translate-y-1/2
           hidden md:flex flex-col items-center gap-1.5
           opacity-[0.42] transition-opacity duration-200
           hover:opacity-100 focus-within:opacity-100

--- a/apps/web/src/components/Chat/MessageJumpRail.tsx
+++ b/apps/web/src/components/Chat/MessageJumpRail.tsx
@@ -90,11 +90,7 @@ export function MessageJumpRail({
                   onClick={() => onJumpToMessage(message.id)}
                 />
               </TooltipTrigger>
-              <TooltipContent
-                side="left"
-                sideOffset={12}
-                className="border-border bg-card text-foreground shadow-none"
-              >
+              <TooltipContent side="left" sideOffset={12}>
                 <p className="max-w-48 line-clamp-3 text-xs leading-relaxed whitespace-pre-wrap">
                   {summaries[index]}
                 </p>

--- a/apps/web/src/components/Chat/__tests__/MessageJumpRail.spec.tsx
+++ b/apps/web/src/components/Chat/__tests__/MessageJumpRail.spec.tsx
@@ -1,0 +1,155 @@
+import type { IMessage, IMessageContent } from '@ant-chat/shared'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { TooltipProvider } from '@workspace/ui/components/tooltip'
+import { describe, expect, it, vi } from 'vitest'
+import { MessageJumpRail } from '../MessageJumpRail'
+
+function createUserMessage(id: string, content: IMessageContent): IMessage {
+  return {
+    id,
+    convId: 'conv-1',
+    role: 'user',
+    content,
+    status: 'success',
+    createdAt: 0,
+    turnId: id,
+  }
+}
+
+function renderRail(
+  userMessages: ReturnType<typeof createUserMessage>[],
+  activeMessageId: string | null = null,
+) {
+  const onJump = vi.fn()
+  render(
+    <TooltipProvider>
+      <MessageJumpRail
+        userMessages={userMessages}
+        activeMessageId={activeMessageId}
+        onJumpToMessage={onJump}
+      />
+    </TooltipProvider>,
+  )
+  return { onJump }
+}
+
+describe('messageJumpRail', () => {
+  describe('渲染条件', () => {
+    it('0 条用户消息时不应渲染', () => {
+      renderRail([])
+      expect(screen.queryByRole('navigation')).toBeNull()
+    })
+
+    it('1 条用户消息时不应渲染', () => {
+      const msg = createUserMessage('msg-1', [{ type: 'text', text: 'hello' }])
+      renderRail([msg])
+      expect(screen.queryByRole('navigation')).toBeNull()
+    })
+
+    it('2 条用户消息时应渲染', () => {
+      const msgs = [
+        createUserMessage('msg-1', [{ type: 'text', text: 'hello' }]),
+        createUserMessage('msg-2', [{ type: 'text', text: 'world' }]),
+      ]
+      renderRail(msgs)
+      // 桌面端和移动端各一个 nav
+      expect(screen.getAllByRole('navigation').length).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  describe('节点数量', () => {
+    it('节点数量只等于用户消息数量', () => {
+      const msgs = [
+        createUserMessage('msg-1', [{ type: 'text', text: 'first' }]),
+        createUserMessage('msg-2', [{ type: 'text', text: 'second' }]),
+        createUserMessage('msg-3', [{ type: 'text', text: 'third' }]),
+      ]
+      renderRail(msgs)
+      // 桌面端 nav 里的 buttons
+      const desktopNav = screen.getAllByRole('navigation')[0]
+      const buttons = desktopNav.querySelectorAll('button')
+      expect(buttons).toHaveLength(3)
+    })
+  })
+
+  describe('点击行为', () => {
+    it('点击节点应调用 onJumpToMessage，传入正确的 message id', () => {
+      const msgs = [
+        createUserMessage('msg-1', [{ type: 'text', text: 'first' }]),
+        createUserMessage('msg-2', [{ type: 'text', text: 'second' }]),
+      ]
+      const { onJump } = renderRail(msgs)
+
+      const desktopNav = screen.getAllByRole('navigation')[0]
+      const buttons = desktopNav.querySelectorAll('button')
+
+      fireEvent.click(buttons[0])
+      expect(onJump).toHaveBeenCalledWith('msg-1')
+
+      fireEvent.click(buttons[1])
+      expect(onJump).toHaveBeenCalledWith('msg-2')
+    })
+  })
+
+  describe('tooltip 内容', () => {
+    it('tooltip 应显示消息内容文本摘要', () => {
+      const msgs = [
+        createUserMessage('msg-1', [{ type: 'text', text: '帮我写一个 React 组件' }]),
+        createUserMessage('msg-2', [{ type: 'text', text: '这段代码有什么问题？' }]),
+      ]
+      renderRail(msgs)
+
+      // trigger buttons 上的 aria-label 包含消息编号
+      const desktopNav = screen.getAllByRole('navigation')[0]
+      const buttons = desktopNav.querySelectorAll('button')
+
+      expect(buttons[0]).toHaveAttribute('aria-label', '跳转到用户消息 1')
+      expect(buttons[1]).toHaveAttribute('aria-label', '跳转到用户消息 2')
+    })
+
+    it('用户消息内容为空时应使用占位文本', () => {
+      const msgs = [
+        createUserMessage('msg-1', [{ type: 'text', text: '' }]),
+        createUserMessage('msg-2', []),
+      ]
+      renderRail(msgs)
+
+      const desktopNav = screen.getAllByRole('navigation')[0]
+      const buttons = desktopNav.querySelectorAll('button')
+      // 即使内容为空也应渲染按钮
+      expect(buttons).toHaveLength(2)
+    })
+
+    it('tooltip 不应包含 Turn 序号标题', () => {
+      const msgs = [
+        createUserMessage('msg-1', [{ type: 'text', text: '普通文本消息' }]),
+        createUserMessage('msg-2', [{ type: 'text', text: '另一条消息' }]),
+      ]
+      renderRail(msgs)
+
+      // 按钮的 aria-label 只包含"跳转到用户消息 N"，不包含 Turn 等标题
+      const desktopNav = screen.getAllByRole('navigation')[0]
+      const buttons = desktopNav.querySelectorAll('button')
+
+      for (const btn of buttons) {
+        expect(btn.getAttribute('aria-label')).not.toMatch(/Turn|turn|第/)
+      }
+    })
+  })
+
+  describe('active 状态', () => {
+    it('active 节点应有 aria-current="true"', () => {
+      const msgs = [
+        createUserMessage('msg-1', [{ type: 'text', text: 'first' }]),
+        createUserMessage('msg-2', [{ type: 'text', text: 'second' }]),
+      ]
+      renderRail(msgs, 'msg-1')
+
+      const desktopNav = screen.getAllByRole('navigation')[0]
+      const buttons = desktopNav.querySelectorAll('button')
+
+      expect(buttons[0]).toHaveAttribute('aria-current', 'true')
+      expect(buttons[1]).not.toHaveAttribute('aria-current')
+    })
+  })
+})

--- a/apps/web/src/components/InfiniteScroll/index.tsx
+++ b/apps/web/src/components/InfiniteScroll/index.tsx
@@ -67,7 +67,7 @@ export const InfiniteScroll: React.FC<Props> = ({
       if (element) {
         element.scrollIntoView({
           behavior: 'smooth',
-          block: 'center',
+          block: 'start',
         })
       }
     }

--- a/apps/web/src/hooks/useAutoScroll.ts
+++ b/apps/web/src/hooks/useAutoScroll.ts
@@ -53,6 +53,7 @@ export function useAutoScroll() {
 
   return {
     autoScrollToBottom,
+    setAutoScrollToBottom,
     infiniteScrollRef,
     handleWheel,
     scrollToBottom,


### PR DESCRIPTION
## Summary

Add a message jump navigation rail to quickly navigate between user messages in long conversations.

### Changes

- **New**: `MessageJumpRail` component — vertical dot rail (desktop) / horizontal dots (mobile) with tooltips showing message summaries
- **Modified**: `BubbleList` — integrates rail with IntersectionObserver-based active message tracking and scroll-on-click

### Details

- Only renders when more than 1 user message exists
- Active dot: filled `primary` color, 8px
- Inactive dot: 5px, `muted-foreground` border, low opacity (0.42)
- Hover: enlarges to 8px with `primary` border + subtle ring
- Click: scrolls to target message + brief highlight animation (1.5s)
- Mobile: horizontal dot bar at bottom, no tooltips
- Tooltips use `card` background with message content excerpts

### Tests

- 9 unit tests covering rendering conditions, node count, click behavior, tooltip content, and active state
- All 58 existing tests continue to pass