### PR TITLE
[codex] Integrate LXGW WenKai Lite font

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -37,6 +37,7 @@
     "embla-carousel-react": "^8.6.0",
     "js-base64": "^3.7.7",
     "lucide-react": "catalog:",
+    "lxgw-wenkai-lite-webfont": "^1.7.0",
     "media-chrome": "^4.19.0",
     "motion": "^12.34.3",
     "nanoid": "^5.1.6",

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -1,6 +1,9 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 @import 'shadcn/tailwind.css';
+@import 'lxgw-wenkai-lite-webfont/lxgwwenkailite-light.css';
+@import 'lxgw-wenkai-lite-webfont/lxgwwenkailite-regular.css';
+@import 'lxgw-wenkai-lite-webfont/lxgwwenkailite-bold.css';
 @import '@fontsource-variable/jetbrains-mono';
 @import 'streamdown/styles.css';
 
@@ -14,7 +17,7 @@
 @plugin "@iconify/tailwind4";
 
 @theme inline {
-  --font-sans: 'Nunito Sans', Inter, ui-sans-serif, system-ui, sans-serif;
+  --font-sans: 'LXGW WenKai Lite', 'Nunito Sans', Inter, ui-sans-serif, system-ui, sans-serif;
   --font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace, SFMono-Regular, monospace;
   --font-serif: 'Merriweather', Georgia, Cambria, 'Times New Roman', serif;
   --font-heading: var(--font-sans);
@@ -118,7 +121,7 @@
   --chart-5: oklch(70% 0.11 330);
   --radius: 0.8rem;
   --letter-spacing: 0em;
-  --font-sans: 'Nunito Sans', Inter, ui-sans-serif, system-ui, sans-serif;
+  --font-sans: 'LXGW WenKai Lite', 'Nunito Sans', Inter, ui-sans-serif, system-ui, sans-serif;
   --font-serif: 'Merriweather', Georgia, Cambria, 'Times New Roman', serif;
   --font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace, SFMono-Regular, monospace;
   --radius-sm: 0.1875rem;
@@ -186,7 +189,7 @@
   --chart-5: oklch(76% 0.08 320);
   --radius: 0.8rem;
   --letter-spacing: 0em;
-  --font-sans: 'Nunito Sans', Inter, ui-sans-serif, system-ui, sans-serif;
+  --font-sans: 'LXGW WenKai Lite', 'Nunito Sans', Inter, ui-sans-serif, system-ui, sans-serif;
   --font-serif: 'Merriweather', Georgia, Cambria, 'Times New Roman', serif;
   --font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace, SFMono-Regular, monospace;
   --radius-sm: 0.1875rem;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -554,6 +554,9 @@ importers:
       lucide-react:
         specifier: 'catalog:'
         version: 1.11.0(react@19.2.4)
+      lxgw-wenkai-lite-webfont:
+        specifier: ^1.7.0
+        version: 1.7.0
       media-chrome:
         specifier: ^4.19.0
         version: 4.19.0(react@19.2.4)
@@ -6556,6 +6559,9 @@ packages:
     resolution: {integrity: sha512-UOhjdztXCgdBReRcIhsvz2siIBogfv/lhJEIViCpLt924dO+GDms9T7DNoucI23s6kEPpe988m5N0D2ajnzb2g==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lxgw-wenkai-lite-webfont@1.7.0:
+    resolution: {integrity: sha512-VcQYNRpdXAxaZsJ18rfT1mmAreGqkIFNZ/9pdVLbT2Tkb+2lLWJDXq4zYxMEk9AcecSnxO31R2LHh5ieLlxjRg==}
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -15309,6 +15315,8 @@ snapshots:
   lucide-react@1.11.0(react@19.2.4):
     dependencies:
       react: 19.2.4
+
+  lxgw-wenkai-lite-webfont@1.7.0: {}
 
   lz-string@1.5.0: {}
 


### PR DESCRIPTION
## Summary

- Integrates LXGW WenKai Lite as the default sans-serif font in the shared UI styles.
- Adds the font package to `packages/ui` and updates the lockfile.

## Validation

- `pnpm check`
- Result: passed. ESLint reported 20 warnings and 0 errors.
