### PR TITLE
[codex] Switch message font package

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -37,6 +37,7 @@
     "embla-carousel-react": "^8.6.0",
     "js-base64": "^3.7.7",
     "lucide-react": "catalog:",
+    "lxgw-wenkai-mono-gb-screen-webfont": "^1.0.1",
     "media-chrome": "^4.19.0",
     "motion": "^12.34.3",
     "nanoid": "^5.1.6",

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -1,6 +1,7 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 @import 'shadcn/tailwind.css';
+@import 'lxgw-wenkai-mono-gb-screen-webfont/fonts/style.css';
 @import '@fontsource-variable/jetbrains-mono';
 @import 'streamdown/styles.css';
 
@@ -18,6 +19,7 @@
   --font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace, SFMono-Regular, monospace;
   --font-serif: 'Merriweather', Georgia, Cambria, 'Times New Roman', serif;
   --font-heading: var(--font-sans);
+  --font-message: 'LXGW WenKai Mono GB Screen', 'Nunito Sans', Inter, ui-sans-serif, system-ui, sans-serif;
 
   --radius-sm: 0.1875rem;
   --radius-md: 0.375rem;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -554,6 +554,9 @@ importers:
       lucide-react:
         specifier: 'catalog:'
         version: 1.11.0(react@19.2.4)
+      lxgw-wenkai-mono-gb-screen-webfont:
+        specifier: ^1.0.1
+        version: 1.0.1
       media-chrome:
         specifier: ^4.19.0
         version: 4.19.0(react@19.2.4)
@@ -6556,6 +6559,9 @@ packages:
     resolution: {integrity: sha512-UOhjdztXCgdBReRcIhsvz2siIBogfv/lhJEIViCpLt924dO+GDms9T7DNoucI23s6kEPpe988m5N0D2ajnzb2g==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lxgw-wenkai-mono-gb-screen-webfont@1.0.1:
+    resolution: {integrity: sha512-GuJbWOsusYJjPifhhIVH25WEADKnaRPrbSLlhjDN/FtFOwa8sCj7s/FAYOGkzbM/7jEAFp7DM+6ImEQuXSSzxg==, tarball: https://r.cnpmjs.org/lxgw-wenkai-mono-gb-screen-webfont/-/lxgw-wenkai-mono-gb-screen-webfont-1.0.1.tgz}
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -15309,6 +15315,8 @@ snapshots:
   lucide-react@1.11.0(react@19.2.4):
     dependencies:
       react: 19.2.4
+
+  lxgw-wenkai-mono-gb-screen-webfont@1.0.1: {}
 
   lz-string@1.5.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,8 +1,17 @@
+allowBuilds:
+  better-sqlite3: true
+  electron: true
+  electron-winstaller: true
+  esbuild: true
+  msw: true
+  protobufjs: true
+  simple-git-hooks: true
+minimumReleaseAgeExclude:
+  - lxgw-wenkai-mono-gb-screen-webfont@1.0.1
 shellEmulator: true
 packages:
   - packages/*
   - apps/*
-
 catalog:
   '@eslint/js': ^9.39.2
   '@tailwindcss/vite': ^4.1.18
@@ -25,11 +34,3 @@ onlyBuiltDependencies:
   - esbuild
   - msw
   - protobufjs
-allowBuilds:
-  better-sqlite3: true
-  electron: true
-  electron-winstaller: true
-  esbuild: true
-  msw: true
-  protobufjs: true
-  simple-git-hooks: true


### PR DESCRIPTION
## Summary

- Switches the message font package to `lxgw-wenkai-mono-gb-screen-webfont`.
- Imports the Mono GB Screen font and exposes it as `--font-message`.
- Adds the package release-age exclusion required for install resolution.

## Source Commit

- Based on `b261448 chore(ui): switch message font package`.
- Re-applied onto `main` as a single equivalent commit because `b261448` was originally based on the feature branch history.

## Validation

- `pnpm check`
- Result: passed. ESLint reported 20 warnings and 0 errors.
