### PR TITLE
fix: harden builtin command system

### DIFF
--- a/apps/desktop/src/main/domains/commands/ipc.ts
+++ b/apps/desktop/src/main/domains/commands/ipc.ts
@@ -20,7 +20,7 @@ export class CommandsIpcService extends IpcService {
   @IpcMethod()
   async cancelCommand(conversationId: string): Promise<IpcResponse<null>> {
     try {
-      getAgentRuntimeEnvironment().commandController.cancelCommand(conversationId)
+      await getAgentRuntimeEnvironment().commandController.cancelCommand(conversationId)
       return createIpcResponse(true, null)
     }
     catch (error) {

--- a/apps/web/src/components/Chat/Chat.tsx
+++ b/apps/web/src/components/Chat/Chat.tsx
@@ -139,8 +139,8 @@ export default function Chat() {
             />
           )}
           onSubmit={onSubmit}
-          onCancel={() => {
-            cancelCommand()
+          onCancel={async () => {
+            await cancelCommand()
             void abortActiveRequest(activeConversationsId)
           }}
         />

--- a/apps/web/src/contexts/chatSettings/context.ts
+++ b/apps/web/src/contexts/chatSettings/context.ts
@@ -11,7 +11,7 @@ export const DEFAULT_SETTINGS: ConversationsSettingsSchema = {
     thresholdPercent: 70,
     keepRecentPairs: 3,
   },
-  lastCompactedAt: undefined,
+  lastCompactedMessageId: undefined,
 }
 
 export const ChatSettingsContext = createContext<{

--- a/apps/web/src/hooks/__tests__/useConversationSettings.spec.ts
+++ b/apps/web/src/hooks/__tests__/useConversationSettings.spec.ts
@@ -43,7 +43,7 @@ describe('useConversationSettings', () => {
       temperature: 0.7,
       maxTokens: 1000,
       compaction: defaultCompaction,
-      lastCompactedAt: undefined,
+      lastCompactedMessageId: undefined,
     })
   })
 
@@ -69,7 +69,7 @@ describe('useConversationSettings', () => {
       temperature: 0.5,
       maxTokens: 500,
       compaction: defaultCompaction,
-      lastCompactedAt: undefined,
+      lastCompactedMessageId: undefined,
     })
   })
 
@@ -146,7 +146,7 @@ describe('useConversationSettings', () => {
       temperature: 0.7,
       maxTokens: 1000,
       compaction: defaultCompaction,
-      lastCompactedAt: undefined,
+      lastCompactedMessageId: undefined,
     })
   })
 })

--- a/apps/web/src/hooks/useBuiltinCommandSubmit.ts
+++ b/apps/web/src/hooks/useBuiltinCommandSubmit.ts
@@ -52,7 +52,7 @@ export function useBuiltinCommandSubmit(options: UseBuiltinCommandSubmitOptions)
         workspacePath: options.currentWorkspacePath || '',
       })
 
-      if (result.conversation) {
+      if (result.status === 'success' && result.conversation) {
         upsertConversationAction(result.conversation)
         await setActiveConversationsId(result.conversation.id)
       }
@@ -85,9 +85,12 @@ export function useBuiltinCommandSubmit(options: UseBuiltinCommandSubmitOptions)
     }
   }, [activeConversationsId, options.settings, options.currentWorkspacePath])
 
-  const cancelCommand = useCallback(() => {
+  const cancelCommand = useCallback(async () => {
     if (activeConversationsId) {
-      commandsApi.cancelCommand(activeConversationsId)
+      await commandsApi.cancelCommand(activeConversationsId)
+      const updatedConv = await chatApi.getConversationById(activeConversationsId)
+      upsertConversationAction(updatedConv)
+      await setActiveConversationsId(activeConversationsId)
     }
   }, [activeConversationsId])
 

--- a/apps/web/src/hooks/useConversationSettings.ts
+++ b/apps/web/src/hooks/useConversationSettings.ts
@@ -43,8 +43,8 @@ export function useConversationSettings() {
     if (has(options, 'compaction')) {
       updatedSettings.compaction = options.compaction
     }
-    if (has(options, 'lastCompactedAt')) {
-      updatedSettings.lastCompactedAt = options.lastCompactedAt
+    if (has(options, 'lastCompactedMessageId')) {
+      updatedSettings.lastCompactedMessageId = options.lastCompactedMessageId
     }
 
     if (currentConversationsId) {
@@ -68,7 +68,7 @@ export function useConversationSettings() {
         draft.temperature = conversations.settings.temperature || 0.7
         draft.maxTokens = conversations.settings.maxTokens || 1000
         draft.compaction = conversations.settings.compaction || DEFAULT_COMPACTION
-        draft.lastCompactedAt = conversations.settings.lastCompactedAt
+        draft.lastCompactedMessageId = conversations.settings.lastCompactedMessageId
       }
       else {
         draft.modelId = ''
@@ -76,7 +76,7 @@ export function useConversationSettings() {
         draft.temperature = 0.7
         draft.maxTokens = 1000
         draft.compaction = DEFAULT_COMPACTION
-        draft.lastCompactedAt = undefined
+        draft.lastCompactedMessageId = undefined
       }
     })
   }, [currentConversationsId, _updateSettings, conversations?.settings])

--- a/packages/agent-core/src/compaction/__tests__/compaction.spec.ts
+++ b/packages/agent-core/src/compaction/__tests__/compaction.spec.ts
@@ -22,7 +22,7 @@ describe('estimateContextTokens', () => {
   it('estimates text messages by length / 4 + overhead', () => {
     const msg = makeTextMsg('user', 'Hello World') // 11 chars
     const tokens = estimateContextTokens([msg])
-    // 11/4 ≈ 3 + 4 overhead = 7
+    // 11/4 is about 3, plus 4 overhead equals 7.
     expect(tokens).toBeGreaterThan(0)
     expect(tokens).toBe(Math.ceil(11 / 4) + 4)
   })
@@ -47,6 +47,86 @@ describe('estimateContextTokens', () => {
     const total = estimateContextTokens(msgs)
     const single = estimateContextTokens([msgs[0]])
     expect(total).toBeGreaterThan(single)
+  })
+})
+
+describe('compactMessages force mode', () => {
+  const noopAiProvider = {} as IAIProvider
+
+  it('skips enabled and threshold checks when forced', async () => {
+    const summarize = vi.fn().mockResolvedValue('forced summary')
+    const messages = [
+      makeTextMsg('user', 'Q1'),
+      makeTextMsg('assistant', 'A1'),
+      makeTextMsg('user', 'Q2'),
+      makeTextMsg('assistant', 'A2'),
+    ]
+
+    const result = await compactMessages({
+      messages,
+      settings: { ...DEFAULT_COMPACTION_SETTINGS, enabled: false, thresholdPercent: 90 },
+      aiProvider: noopAiProvider,
+      model: 'test-model',
+      providerFormat: 'openai',
+      preEstimatedTokens: 1,
+      summarize,
+      force: true,
+    })
+
+    expect(result.compacted).toBe(true)
+    expect(result.summaryText).toBe('forced summary')
+    expect(result.summarizedCount).toBe(1)
+    expect(result.keptLength).toBe(3)
+    expect(summarize).toHaveBeenCalledOnce()
+  })
+
+  it('can summarize a single-message conversation when forced', async () => {
+    const messages = [makeTextMsg('user', 'Only message')]
+
+    const result = await compactMessages({
+      messages,
+      settings: DEFAULT_COMPACTION_SETTINGS,
+      aiProvider: noopAiProvider,
+      model: 'test-model',
+      providerFormat: 'openai',
+      summarize: async () => 'single summary',
+      force: true,
+    })
+
+    expect(result.compacted).toBe(true)
+    expect(result.summaryText).toBe('single summary')
+    expect(result.summarizedCount).toBe(1)
+    expect(result.keptLength).toBe(0)
+  })
+
+  it('returns summarizedCount matching the summarized prefix', async () => {
+    const messages = [
+      makeTextMsg('user', 'Q1'),
+      makeTextMsg('assistant', 'A1'),
+      makeTextMsg('user', 'Q2'),
+      makeTextMsg('assistant', 'A2'),
+      makeTextMsg('user', 'Q3'),
+      makeTextMsg('assistant', 'A3'),
+      makeTextMsg('user', 'Q4'),
+      makeTextMsg('assistant', 'A4'),
+      makeTextMsg('user', 'Q5'),
+      makeTextMsg('assistant', 'A5'),
+    ]
+
+    const result = await compactMessages({
+      messages,
+      settings: { ...DEFAULT_COMPACTION_SETTINGS, keepRecentPairs: 3 },
+      aiProvider: noopAiProvider,
+      model: 'test-model',
+      providerFormat: 'openai',
+      preEstimatedTokens: 100_000,
+      summarize: async () => 'summary',
+    })
+
+    expect(result.compacted).toBe(true)
+    expect(result.summarizedCount).toBe(4)
+    expect(result.keptLength).toBe(6)
+    expect(result.summarizedCount! + result.keptLength!).toBe(messages.length)
   })
 })
 
@@ -98,7 +178,7 @@ describe('compactMessages', () => {
     const summary = 'This is a summary of previous conversation.'
     const summarize = vi.fn().mockResolvedValue(summary)
 
-    // Need enough user messages: keepRecentPairs=3 → need >3 user messages for a cut point
+    // Need enough user messages: keepRecentPairs=3 requires more than 3 user messages for a cut point.
     // 4 user-assistant pairs = 8 messages, cutIndex will be at the 2nd message
     const messages = [
       makeTextMsg('user', 'Q1'),
@@ -137,7 +217,7 @@ describe('compactMessages', () => {
   it('keeps recent user-assistant pairs', async () => {
     const summarize = vi.fn().mockResolvedValue('summary')
 
-    // 5 pairs, keepRecentPairs=3 → keeps last 3 pairs (Q3-Q5 + their A's)
+    // 5 pairs, keepRecentPairs=3 keeps last 3 pairs (Q3-Q5 + their A's).
     const messages = [
       makeTextMsg('user', 'Q1'),
       makeTextMsg('assistant', 'A1'),

--- a/packages/agent-core/src/compaction/compaction.ts
+++ b/packages/agent-core/src/compaction/compaction.ts
@@ -53,7 +53,7 @@ function getContextWindow(providerFormat: string): number {
   return CONTEXT_WINDOWS[providerFormat] ?? DEFAULT_CONTEXT_WINDOW
 }
 
-function findCutPointByPairs(messages: LoopMessage[], keepRecentPairs: number): number {
+function findCutPointByPairs(messages: LoopMessage[], keepRecentPairs: number, force = false): number {
   let userCount = 0
 
   for (let i = messages.length - 1; i >= 0; i--) {
@@ -63,6 +63,10 @@ function findCutPointByPairs(messages: LoopMessage[], keepRecentPairs: number): 
         return i
       }
     }
+  }
+
+  if (force) {
+    return messages.length > 1 ? 1 : messages.length
   }
 
   return 0
@@ -115,6 +119,8 @@ export interface CompactionInput {
   preEstimatedTokens?: number
   /** Optional user instruction for what to preserve or ignore during compaction */
   instruction?: string
+  /** When true, skips enabled and threshold checks and forces a compaction attempt. */
+  force?: boolean
 }
 
 export interface CompactionResult {
@@ -125,26 +131,33 @@ export interface CompactionResult {
   keptLength?: number
   /** Error message when summarization fails. */
   summaryError?: string
+  /** Number of messages included in the summary. */
+  summarizedCount?: number
 }
 
 export async function compactMessages(input: CompactionInput): Promise<CompactionResult> {
-  const { messages, settings, aiProvider, model, providerFormat, abortSignal, logger: log = defaultLogger(), summarize, preEstimatedTokens, instruction } = input
+  const { messages, settings, aiProvider, model, providerFormat, abortSignal, logger: log = defaultLogger(), summarize, preEstimatedTokens, instruction, force = false } = input
 
-  if (!settings.enabled) {
+  if (!force && !settings.enabled) {
     return { messages, compacted: false }
   }
 
   const estimatedTokens = preEstimatedTokens ?? estimateContextTokens(messages)
   const contextWindow = getContextWindow(providerFormat)
-  const thresholdTokens = Math.floor(contextWindow * settings.thresholdPercent / 100)
 
-  log.info(`context check: estimated=${estimatedTokens}, window=${contextWindow}, threshold=${settings.thresholdPercent}% (${thresholdTokens} tokens)`)
+  if (!force) {
+    const thresholdTokens = Math.floor(contextWindow * settings.thresholdPercent / 100)
+    log.info(`context check: estimated=${estimatedTokens}, window=${contextWindow}, threshold=${settings.thresholdPercent}% (${thresholdTokens} tokens)`)
 
-  if (estimatedTokens <= thresholdTokens) {
-    return { messages, compacted: false }
+    if (estimatedTokens <= thresholdTokens) {
+      return { messages, compacted: false }
+    }
+  }
+  else {
+    log.info(`forced compaction: estimated=${estimatedTokens}, window=${contextWindow}, bypassing threshold`)
   }
 
-  const cutIndex = findCutPointByPairs(messages, settings.keepRecentPairs)
+  const cutIndex = findCutPointByPairs(messages, settings.keepRecentPairs, force)
   if (cutIndex <= 0) {
     log.warn('no safe cut point found, skipping compaction')
     return { messages, compacted: false }
@@ -171,7 +184,7 @@ export async function compactMessages(input: CompactionInput): Promise<Compactio
     role: 'user',
     content: [{
       type: 'text',
-      // 将压缩摘要注入为一条 user 消息，供模型后续对话参考
+      // Inject the summary as a user message so later turns can continue from it.
       text: [
         'Previous conversation history has been compressed into the following summary:',
         '<summary>',
@@ -192,6 +205,7 @@ export async function compactMessages(input: CompactionInput): Promise<Compactio
     summaryText: summary,
     summaryLength: summary.length,
     keptLength: toKeep.length,
+    summarizedCount: toSummarize.length,
   }
 }
 

--- a/packages/agent-core/src/loop/__tests__/loopContext.spec.ts
+++ b/packages/agent-core/src/loop/__tests__/loopContext.spec.ts
@@ -1,0 +1,70 @@
+import type { IMessage } from '@ant-chat/shared'
+import { describe, expect, it } from 'vitest'
+import { buildConversationContextMessages } from '../loopContext'
+
+function textMessage(id: string, role: 'user' | 'assistant', text: string): IMessage {
+  return {
+    id,
+    convId: 'conv-1',
+    createdAt: 1,
+    role,
+    status: 'success',
+    content: [{ type: 'text', text }],
+  }
+}
+
+describe('buildConversationContextMessages', () => {
+  it('replaces messages up to lastCompactedMessageId with the compaction summary', async () => {
+    const messages = [
+      textMessage('u1', 'user', 'old user'),
+      textMessage('a1', 'assistant', 'old assistant'),
+      {
+        id: 'evt-1',
+        convId: 'conv-1',
+        createdAt: 1,
+        role: 'event' as const,
+        status: 'success' as const,
+        eventType: 'compaction',
+        content: [{ type: 'text' as const, text: 'event summary' }],
+      },
+      textMessage('u2', 'user', 'kept user'),
+      textMessage('current', 'user', 'current prompt'),
+    ]
+
+    const result = await buildConversationContextMessages(
+      messages,
+      'current',
+      'a1',
+      'old summary',
+    )
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [{
+          type: 'text',
+          text: [
+            'Previous conversation history has been compressed into the following summary:',
+            '<summary>',
+            'old summary',
+            '</summary>',
+            'Continue the task based on the above summary and subsequent conversation.',
+          ].join('\n'),
+        }],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'kept user' }],
+      },
+    ])
+  })
+
+  it('rejects a missing compaction boundary id', async () => {
+    await expect(buildConversationContextMessages(
+      [textMessage('u1', 'user', 'old user')],
+      'current',
+      'missing-id',
+      'old summary',
+    )).rejects.toThrow('Compaction boundary message not found: missing-id')
+  })
+})

--- a/packages/agent-core/src/loop/loopContext.ts
+++ b/packages/agent-core/src/loop/loopContext.ts
@@ -83,19 +83,25 @@ export function createLoopSystemPrompt(workspacePath: string, customPrompt?: str
 export async function buildConversationContextMessages(
   messages: IMessage[],
   currentUserMessageId: string,
-  lastCompactedAt?: number,
+  lastCompactedMessageId?: string,
   lastCompactionSummary?: string,
   loadFileData?: LoadFileDataFn,
 ): Promise<LoopMessage[]> {
+  const lastCompactedIndex = lastCompactedMessageId
+    ? messages.findIndex(message => message.id === lastCompactedMessageId)
+    : -1
+  if (lastCompactedMessageId && lastCompactedIndex < 0) {
+    throw new Error(`Compaction boundary message not found: ${lastCompactedMessageId}`)
+  }
   const valid = messages
-    .filter((message): message is IMessage & { role: 'user' | 'assistant' | 'tool' } => {
+    .filter((message, index): message is IMessage & { role: 'user' | 'assistant' | 'tool' } => {
       if (message.id === currentUserMessageId)
         return false
       if (message.role === 'event')
         return false
       if (message.role !== 'user' && message.role !== 'assistant' && message.role !== 'tool')
         return false
-      if (lastCompactedAt && message.createdAt < lastCompactedAt)
+      if (lastCompactedIndex >= 0 && index <= lastCompactedIndex)
         return false
       if (message.role === 'user' || message.role === 'tool')
         return true
@@ -104,7 +110,7 @@ export async function buildConversationContextMessages(
 
   const result: LoopMessage[] = []
 
-  if (lastCompactionSummary && lastCompactedAt) {
+  if (lastCompactionSummary && lastCompactedIndex >= 0) {
     result.push({
       role: 'user',
       content: [{

--- a/packages/agent-core/src/session/SessionRuntime.ts
+++ b/packages/agent-core/src/session/SessionRuntime.ts
@@ -102,7 +102,7 @@ export class SessionRuntime {
     const contextMessages = await buildConversationContextMessages(
       historyMessages,
       userMessage.id,
-      currentConversation?.settings?.lastCompactedAt,
+      currentConversation?.settings?.lastCompactedMessageId,
       currentConversation?.settings?.lastCompactionSummary,
       loadFileData,
     )
@@ -113,10 +113,10 @@ export class SessionRuntime {
       selectedSkill: options.selectedSkill,
     })
 
-    // 构建用户内容
+    // Build user content.
     let userContent: LoopMessage['content']
     if (options.content && options.content.length > 0) {
-      // 使用新的 content 格式，将 enrichedPrompt 替换到第一个 text block
+      // Preserve content blocks while replacing the visible user prompt text.
       const contentWithEnrichedPrompt = options.content.map((block) => {
         if (block.type === 'text') {
           return { ...block, text: enrichedPrompt }

--- a/packages/agent-runtime/src/commands/__tests__/commandController.spec.ts
+++ b/packages/agent-runtime/src/commands/__tests__/commandController.spec.ts
@@ -11,6 +11,8 @@ function mockDeps(overrides: { activeTasks?: Array<{ status: string }> } = {}) {
     messageRepository: {
       listByConversation: vi.fn(),
       create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
     },
     modelCatalog: {
       getModelById: vi.fn(),
@@ -66,13 +68,17 @@ describe('commandController task guard', () => {
       modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0.7, maxTokens: 4096 },
       workspacePath: '/ws',
     })
+    expect(result.status).toBe('success')
+    if (result.status !== 'success') {
+      throw new Error('Expected /new to succeed')
+    }
     expect(result.conversationId).toBe('new-conv')
   })
 
   it('/compact ignores compaction.enabled flag (manual override)', async () => {
     const deps = mockDeps()
-    // enabled: false does NOT block manual /compact. With thresholdPercent forced
-    // to 0, any non-empty conversation triggers the compaction path → model lookup.
+    // enabled: false does NOT block manual /compact. force=true means any
+    // non-empty conversation triggers the compaction path and model lookup.
     deps.appDataContext.conversationRepository.getById.mockResolvedValue({
       id: 'conv-1',
       settings: { compaction: { enabled: false, thresholdPercent: 70, keepRecentPairs: 3 } },
@@ -83,14 +89,21 @@ describe('commandController task guard', () => {
     ])
     const cc = createCommandController(deps as any)
 
-    await expect(
-      cc.runBuiltinCommand({
-        id: 'compact',
-        conversationId: 'conv-1',
-        modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0, maxTokens: 0 },
-        workspacePath: '',
-      }),
-    ).rejects.toThrow('Model not found') // reaches model lookup, not blocked by enabled:false
+    deps.appDataContext.messageRepository.create.mockResolvedValue({ id: 'event-1' })
+    deps.appDataContext.modelCatalog.getModelById.mockResolvedValue(null)
+
+    const result = await cc.runBuiltinCommand({
+      id: 'compact',
+      conversationId: 'conv-1',
+      modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0, maxTokens: 0 },
+      workspacePath: '',
+    })
+
+    expect(result.status).toBe('error')
+    if (result.status !== 'error') {
+      throw new Error('Expected /compact to fail')
+    }
+    expect(result.errorMessage).toContain('Model not found')
   })
 
   it('rejects unknown command id', async () => {
@@ -106,28 +119,256 @@ describe('commandController task guard', () => {
   })
 })
 
-describe('fork toolCallId pairing', () => {
-  it('stable remap: same original toolCallId → same new id', () => {
-    const toolCallIdMap = new Map<string, string>()
+describe('commandController command concurrency', () => {
+  it('rejects second /compact on same conversation while first is running', async () => {
+    const deps = mockDeps()
+    deps.appDataContext.conversationRepository.getById.mockResolvedValue({
+      id: 'conv-1',
+      title: 'Test',
+      settings: {},
+    })
 
-    // Replicate the logic from remapToolRef for direct testing
-    function remapToolRef(originalId: string, map: Map<string, string>): string {
-      const existing = map.get(originalId)
-      if (existing)
-        return existing
-      const newId = `mapped-${originalId}`
-      map.set(originalId, newId)
-      return newId
+    let resolveFirst: (value: unknown) => void
+    const firstMessages = new Promise<unknown>((resolve) => {
+      resolveFirst = resolve
+    })
+    deps.appDataContext.messageRepository.listByConversation.mockReturnValue(firstMessages)
+
+    const cc = createCommandController(deps as any)
+    const firstPromise = cc.runBuiltinCommand({
+      id: 'compact',
+      conversationId: 'conv-1',
+      modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0, maxTokens: 0 },
+      workspacePath: '',
+    })
+
+    await new Promise(resolve => setTimeout(resolve, 10))
+
+    await expect(
+      cc.runBuiltinCommand({
+        id: 'compact',
+        conversationId: 'conv-1',
+        modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0, maxTokens: 0 },
+        workspacePath: '',
+      }),
+    ).rejects.toThrow('already running')
+
+    resolveFirst!([])
+    await firstPromise.catch(() => {})
+  })
+
+  it('allows /compact on different conversations concurrently', async () => {
+    const deps = mockDeps()
+    deps.appDataContext.conversationRepository.getById.mockResolvedValue({
+      id: 'conv-1',
+      title: 'Test',
+      settings: {},
+    })
+    deps.appDataContext.messageRepository.listByConversation.mockResolvedValue([])
+
+    const cc = createCommandController(deps as any)
+
+    const [r1, r2] = await Promise.all([
+      cc.runBuiltinCommand({
+        id: 'compact',
+        conversationId: 'conv-1',
+        modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0, maxTokens: 0 },
+        workspacePath: '',
+      }),
+      cc.runBuiltinCommand({
+        id: 'compact',
+        conversationId: 'conv-2',
+        modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0, maxTokens: 0 },
+        workspacePath: '',
+      }),
+    ])
+
+    expect(r1.status).toBe('success')
+    expect(r1.summaryText).toContain('No messages')
+    expect(r2.status).toBe('success')
+    expect(r2.summaryText).toContain('No messages')
+  })
+})
+
+describe('compact command error and cancellation', () => {
+  it('/compact returns error status when model is not found', async () => {
+    const deps = mockDeps()
+    deps.appDataContext.conversationRepository.getById.mockResolvedValue({
+      id: 'conv-1',
+      title: 'Test',
+      settings: {},
+    })
+    deps.appDataContext.messageRepository.listByConversation.mockResolvedValue([
+      { id: 'm1', role: 'user', content: [{ type: 'text', text: 'hello' }], createdAt: 1 },
+    ])
+    deps.appDataContext.messageRepository.create.mockResolvedValue({ id: 'event-1' })
+    deps.appDataContext.modelCatalog.getModelById.mockResolvedValue(null)
+
+    const cc = createCommandController(deps as any)
+    const result = await cc.runBuiltinCommand({
+      id: 'compact',
+      conversationId: 'conv-1',
+      modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0, maxTokens: 0 },
+      workspacePath: '',
+    })
+
+    expect(result.status).toBe('error')
+    if (result.status !== 'error') {
+      throw new Error('Expected /compact to fail')
     }
+    expect(result.errorMessage).toContain('Model not found')
+    expect(deps.appDataContext.messageRepository.update).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'event-1', status: 'error' }),
+    )
+  })
 
-    const originalId = 'tool-call-abc'
+  it('/compact with empty messages returns success without creating loading event', async () => {
+    const deps = mockDeps()
+    deps.appDataContext.conversationRepository.getById.mockResolvedValue({
+      id: 'conv-1',
+      title: 'Test',
+      settings: {},
+    })
+    deps.appDataContext.messageRepository.listByConversation.mockResolvedValue([])
 
-    const id1 = remapToolRef(originalId, toolCallIdMap)
-    const id2 = remapToolRef(originalId, toolCallIdMap)
-    const id3 = remapToolRef('other-id', toolCallIdMap)
+    const cc = createCommandController(deps as any)
+    const result = await cc.runBuiltinCommand({
+      id: 'compact',
+      conversationId: 'conv-1',
+      modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0, maxTokens: 0 },
+      workspacePath: '',
+    })
 
-    expect(id1).toBe(id2)
-    expect(id1).not.toBe(id3)
-    expect(toolCallIdMap.size).toBe(2)
+    expect(result.status).toBe('success')
+    expect(result.summaryText).toContain('No messages')
+    expect(deps.appDataContext.modelCatalog.getModelById).not.toHaveBeenCalled()
+    expect(deps.appDataContext.messageRepository.create).not.toHaveBeenCalled()
+  })
+
+  it('cancelCommand waits until the loading event is deleted', async () => {
+    const deps = mockDeps()
+    deps.appDataContext.conversationRepository.getById.mockResolvedValue({
+      id: 'conv-1',
+      title: 'Test',
+      settings: {},
+    })
+    deps.appDataContext.messageRepository.listByConversation.mockResolvedValue([
+      { id: 'm1', role: 'user', content: [{ type: 'text', text: 'hello' }], createdAt: 1 },
+    ])
+    deps.appDataContext.messageRepository.create.mockResolvedValue({ id: 'event-1' })
+
+    let rejectModelLookup: (reason?: unknown) => void
+    deps.appDataContext.modelCatalog.getModelById.mockReturnValue(new Promise((_, reject) => {
+      rejectModelLookup = reject
+    }))
+
+    const cc = createCommandController(deps as any)
+    const runPromise = cc.runBuiltinCommand({
+      id: 'compact',
+      conversationId: 'conv-1',
+      modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0, maxTokens: 0 },
+      workspacePath: '',
+    })
+
+    await new Promise(resolve => setTimeout(resolve, 10))
+
+    let cancelResolved = false
+    const cancelPromise = cc.cancelCommand('conv-1').then((result) => {
+      cancelResolved = true
+      return result
+    })
+
+    await Promise.resolve()
+    expect(cancelResolved).toBe(false)
+    expect(deps.appDataContext.messageRepository.delete).not.toHaveBeenCalled()
+
+    rejectModelLookup!(new Error('cancelled upstream request'))
+
+    const cancelResult = await cancelPromise
+    const runResult = await runPromise
+
+    expect(cancelResult?.status).toBe('cancelled')
+    expect(runResult.status).toBe('cancelled')
+    expect(deps.appDataContext.messageRepository.delete).toHaveBeenCalledWith('event-1')
+  })
+})
+
+describe('fork command', () => {
+  it('/fork preserves event message status from source', async () => {
+    const deps = mockDeps()
+    deps.appDataContext.conversationRepository.getById.mockResolvedValue({
+      id: 'conv-1',
+      title: 'Original',
+      settings: {},
+    })
+    deps.appDataContext.conversationRepository.create.mockResolvedValue({
+      id: 'fork-conv',
+      title: 'Original fork',
+      settings: {},
+    })
+    deps.appDataContext.messageRepository.listByConversation.mockResolvedValue([
+      { id: 'm1', role: 'user', content: [{ type: 'text', text: 'hello' }], createdAt: 1 },
+      { id: 'm2', role: 'event', status: 'error', eventType: 'compaction', content: [{ type: 'text', text: 'fail' }], createdAt: 2 },
+    ])
+    deps.appDataContext.messageRepository.create.mockResolvedValue({ id: 'new-id' })
+
+    const cc = createCommandController(deps as any)
+    const result = await cc.runBuiltinCommand({
+      id: 'fork',
+      conversationId: 'conv-1',
+      modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0, maxTokens: 0 },
+      workspacePath: '/ws',
+    })
+
+    expect(result.status).toBe('success')
+    if (result.status !== 'success') {
+      throw new Error('Expected /fork to succeed')
+    }
+    expect(result.conversationId).toBe('fork-conv')
+
+    const createCalls = deps.appDataContext.messageRepository.create.mock.calls
+    const eventCall = createCalls.find((call: unknown[]) => {
+      const arg = call[0] as Record<string, unknown>
+      return arg.role === 'event' && arg.eventType === 'compaction'
+    })
+    expect(eventCall).toBeDefined()
+    expect((eventCall![0] as Record<string, unknown>).status).toBe('error')
+  })
+
+  it('/fork is blocked by concurrency guard', async () => {
+    const deps = mockDeps()
+    deps.appDataContext.conversationRepository.getById.mockResolvedValue({
+      id: 'conv-1',
+      title: 'Original',
+      settings: {},
+    })
+
+    let resolveFirst: (value: unknown) => void
+    const firstMessages = new Promise<unknown>((resolve) => {
+      resolveFirst = resolve
+    })
+    deps.appDataContext.messageRepository.listByConversation.mockReturnValue(firstMessages)
+
+    const cc = createCommandController(deps as any)
+    const firstPromise = cc.runBuiltinCommand({
+      id: 'fork',
+      conversationId: 'conv-1',
+      modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0, maxTokens: 0 },
+      workspacePath: '/ws',
+    })
+
+    await new Promise(resolve => setTimeout(resolve, 10))
+
+    await expect(
+      cc.runBuiltinCommand({
+        id: 'fork',
+        conversationId: 'conv-1',
+        modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0, maxTokens: 0 },
+        workspacePath: '/ws',
+      }),
+    ).rejects.toThrow('already running')
+
+    resolveFirst!([])
+    await firstPromise.catch(() => {})
   })
 })

--- a/packages/agent-runtime/src/commands/commandController.ts
+++ b/packages/agent-runtime/src/commands/commandController.ts
@@ -13,16 +13,16 @@ export interface CommandControllerDeps {
 
 export interface CommandController {
   runBuiltinCommand: (params: RunBuiltinCommandParams) => Promise<RunBuiltinCommandResult>
-  cancelCommand: (conversationId: string) => void
+  cancelCommand: (conversationId: string) => Promise<RunBuiltinCommandResult | undefined>
 }
 
 export function createCommandController(deps: CommandControllerDeps): CommandController {
   const { appDataContext, logger, listActiveTasks } = deps
   const abortControllers = new Map<string, AbortController>()
+  const activeCommands = new Map<string, Promise<RunBuiltinCommandResult>>()
 
   function log(msg: string) {
     logger?.info(`[command-controller] ${msg}`)
-    console.log(`[command-controller] ${msg}`)
   }
 
   function guardConversationIdle(conversationId: string) {
@@ -32,12 +32,19 @@ export function createCommandController(deps: CommandControllerDeps): CommandCon
     }
   }
 
-  function cancelCommand(conversationId: string) {
+  function guardNoActiveCommand(conversationId: string) {
+    if (activeCommands.has(conversationId)) {
+      throw new Error('A command is already running for this conversation')
+    }
+  }
+
+  async function cancelCommand(conversationId: string): Promise<RunBuiltinCommandResult | undefined> {
     const ctrl = abortControllers.get(conversationId)
     if (ctrl) {
       log(`cancelling command for ${conversationId}`)
       ctrl.abort()
     }
+    return activeCommands.get(conversationId)
   }
 
   return {
@@ -50,21 +57,25 @@ export function createCommandController(deps: CommandControllerDeps): CommandCon
             throw new Error('/compact requires an active conversation')
           }
           guardConversationIdle(params.conversationId)
+          guardNoActiveCommand(params.conversationId)
 
           const ctrl = new AbortController()
           abortControllers.set(params.conversationId, ctrl)
+          const commandPromise = runCompact({
+            appDataContext,
+            conversationId: params.conversationId,
+            instruction: params.argument,
+            modelConfig: params.modelConfig,
+            logger,
+            abortSignal: ctrl.signal,
+          })
+          activeCommands.set(params.conversationId, commandPromise)
           try {
-            return await runCompact({
-              appDataContext,
-              conversationId: params.conversationId,
-              instruction: params.argument,
-              modelConfig: params.modelConfig,
-              logger,
-              abortSignal: ctrl.signal,
-            })
+            return await commandPromise
           }
           finally {
             abortControllers.delete(params.conversationId)
+            activeCommands.delete(params.conversationId)
           }
         }
 
@@ -77,7 +88,16 @@ export function createCommandController(deps: CommandControllerDeps): CommandCon
             throw new Error('/fork requires an active conversation')
           }
           guardConversationIdle(params.conversationId)
-          return runFork({ appDataContext, sourceConversationId: params.conversationId, workspacePath: params.workspacePath })
+          guardNoActiveCommand(params.conversationId)
+
+          const commandPromise = runFork({ appDataContext, sourceConversationId: params.conversationId, workspacePath: params.workspacePath })
+          activeCommands.set(params.conversationId, commandPromise)
+          try {
+            return await commandPromise
+          }
+          finally {
+            activeCommands.delete(params.conversationId)
+          }
         }
 
         default:

--- a/packages/agent-runtime/src/commands/compactCommand.ts
+++ b/packages/agent-runtime/src/commands/compactCommand.ts
@@ -1,6 +1,6 @@
 import type { AppDataContext } from '@ant-chat/app-data'
 import type { ILogger, RunBuiltinCommandResult } from '@ant-chat/shared'
-import { compactMessages, createCompactionStrategy, createProvider, DEFAULT_COMPACTION_SETTINGS, estimateContextTokens, getContextWindow } from '@ant-chat/agent-core'
+import { compactMessages, createCompactionStrategy, createProvider, DEFAULT_COMPACTION_SETTINGS, estimateContextTokens } from '@ant-chat/agent-core'
 import { messagesToLoopMessages } from './messageConversion'
 
 export async function runCompact(params: {
@@ -15,7 +15,6 @@ export async function runCompact(params: {
 
   function log(msg: string) {
     logger?.info(`[compact] ${msg}`)
-    console.log(`[compact] ${msg}`)
   }
 
   log(`start: convId=${conversationId}, modelId=${modelConfig.modelId}, hasInstruction=${!!instruction}`)
@@ -29,49 +28,20 @@ export async function runCompact(params: {
   const stored = conversation.settings?.compaction
   const compactionSettings = {
     ...DEFAULT_COMPACTION_SETTINGS,
-    thresholdPercent: 0,
     ...(stored ? { keepRecentPairs: stored.keepRecentPairs } : {}),
   }
-  log(`compactionSettings: thresholdPercent=0 (manual override), keepRecentPairs=${compactionSettings.keepRecentPairs}`)
+  log(`compactionSettings: force=true, keepRecentPairs=${compactionSettings.keepRecentPairs}`)
 
   const messages = await appDataContext.messageRepository.listByConversation(conversationId)
   log(`messages loaded: total=${messages.length}`)
   const loopMessages = messagesToLoopMessages(messages)
   log(`loopMessages converted: total=${loopMessages.length}`)
-
-  const modelInfo = await appDataContext.modelCatalog.getModelById(modelConfig.modelId)
-  if (!modelInfo) {
-    throw new Error(`Model not found: ${modelConfig.modelId}`)
+  if (loopMessages.length === 0) {
+    return { status: 'success', summaryText: 'No messages to compact.' }
   }
-  log(`model found: name=${modelInfo.model}, providerId=${modelInfo.providerId}`)
-
-  const provider = await appDataContext.modelCatalog.getProviderById(modelInfo.providerId)
-  if (!provider) {
-    throw new Error(`Provider not found: ${modelInfo.providerId}`)
-  }
-  log(`provider found: apiMode=${provider.apiMode || 'openai'}`)
-
-  const aiProvider = await createProvider(provider)
-  const apiMode = provider.apiMode || 'openai'
-  log(`aiProvider created`)
 
   const estimatedTokens = estimateContextTokens(loopMessages)
-  const contextWindow = getContextWindow(apiMode)
-  const thresholdTokens = Math.floor(contextWindow * compactionSettings.thresholdPercent / 100)
-
-  log(`context check: estimated=${estimatedTokens}, window=${contextWindow}, threshold=0% (${thresholdTokens} tokens)`)
-
-  if (estimatedTokens <= thresholdTokens) {
-    const msg = `Context is already compact enough (${estimatedTokens} tokens used, threshold is ${thresholdTokens}).`
-    await appDataContext.messageRepository.create({
-      convId: conversationId,
-      role: 'event',
-      status: 'success',
-      content: [{ type: 'text', text: msg }],
-      eventType: 'compaction',
-    })
-    return { summaryText: msg }
-  }
+  log(`context check: estimated=${estimatedTokens}, force=true`)
 
   log(`invoking LLM compaction...`)
 
@@ -90,6 +60,22 @@ export async function runCompact(params: {
 
   const compactionStrategy = createCompactionStrategy()
   try {
+    const modelInfo = await appDataContext.modelCatalog.getModelById(modelConfig.modelId)
+    if (!modelInfo) {
+      throw new Error(`Model not found: ${modelConfig.modelId}`)
+    }
+    log(`model found: name=${modelInfo.model}, providerId=${modelInfo.providerId}`)
+
+    const provider = await appDataContext.modelCatalog.getProviderById(modelInfo.providerId)
+    if (!provider) {
+      throw new Error(`Provider not found: ${modelInfo.providerId}`)
+    }
+    log(`provider found: apiMode=${provider.apiMode || 'openai'}`)
+
+    const aiProvider = await createProvider(provider)
+    const apiMode = provider.apiMode || 'openai'
+    log(`aiProvider created`)
+
     const compactResult = await compactMessages({
       messages: loopMessages,
       preEstimatedTokens: estimatedTokens,
@@ -101,11 +87,12 @@ export async function runCompact(params: {
       summarize: compactionStrategy.summarize,
       instruction,
       abortSignal,
+      force: true,
     })
 
     if (abortSignal?.aborted) {
       await appDataContext.messageRepository.delete(loadingEvent.id)
-      return { summaryText: '' }
+      return { status: 'cancelled', summaryText: '' }
     }
 
     if (!compactResult.compacted) {
@@ -119,36 +106,36 @@ export async function runCompact(params: {
     else {
       summaryText = compactResult.summaryText
 
-      // Determine cut-point for settings
-      const keptLength = compactResult.keptLength ?? 0
-      const summarizedCount = loopMessages.length - keptLength
+      const summarizedCount = compactResult.summarizedCount ?? 0
       const filteredIndices = messages
         .map((m, i) => (m.role === 'user' || m.role === 'assistant' || m.role === 'tool') ? i : -1)
         .filter(i => i >= 0)
-      const firstKeptIndex = summarizedCount > 0 && summarizedCount < filteredIndices.length
-        ? filteredIndices[summarizedCount]
-        : -1
-      const lastCompactedAt = firstKeptIndex >= 0
-        ? messages[firstKeptIndex].createdAt
-        : messages[messages.length - 1]?.createdAt ?? Date.now()
+      const lastCompactedMessage = summarizedCount > 0
+        ? messages[filteredIndices[summarizedCount - 1]]
+        : summarizedCount >= filteredIndices.length
+          ? messages[messages.length - 1]
+          : undefined
+      if (!lastCompactedMessage) {
+        throw new Error('Compaction did not identify a message boundary.')
+      }
 
       await appDataContext.conversationRepository.update({
         id: conversationId,
         settings: {
           ...conversation.settings,
-          lastCompactedAt,
+          lastCompactedMessageId: lastCompactedMessage.id,
           lastCompactionSummary: summaryText,
         },
       })
 
-      log(`compaction complete: summary=${compactResult.summaryLength} chars, kept=${compactResult.keptLength} msgs, cutAt=${lastCompactedAt}`)
+      log(`compaction complete: summary=${compactResult.summaryLength} chars, kept=${compactResult.keptLength} msgs, boundary=${lastCompactedMessage.id}`)
     }
   }
   catch (err) {
     if (abortSignal?.aborted) {
       log('compaction cancelled by user')
       await appDataContext.messageRepository.delete(loadingEvent.id)
-      return { summaryText: '' }
+      return { status: 'cancelled', summaryText: '' }
     }
     compactionFailed = true
     errorText = err instanceof Error ? err.message : String(err)
@@ -170,5 +157,9 @@ export async function runCompact(params: {
     })
   }
 
-  return { summaryText }
+  if (compactionFailed) {
+    return { status: 'error', errorMessage: errorText, summaryText: errorText }
+  }
+
+  return { status: 'success', summaryText }
 }

--- a/packages/agent-runtime/src/commands/conversationCommands.ts
+++ b/packages/agent-runtime/src/commands/conversationCommands.ts
@@ -23,5 +23,5 @@ export async function runNew(params: {
     updatedAt: Date.now(),
   })
 
-  return { conversation, conversationId: conversation.id }
+  return { status: 'success', conversation, conversationId: conversation.id }
 }

--- a/packages/agent-runtime/src/commands/messageFork.ts
+++ b/packages/agent-runtime/src/commands/messageFork.ts
@@ -15,7 +15,7 @@ export async function runFork(params: {
 
   const sourceMessages = await appDataContext.messageRepository.listByConversation(sourceConversationId)
 
-  // Create fork conversation with title "原标题 fork"
+  // Create fork conversation with title "<source title> fork".
   const forkTitle = `${sourceConversation.title} fork`
   const forkConversation = await appDataContext.conversationRepository.create({
     workspacePath,
@@ -37,7 +37,7 @@ export async function runFork(params: {
     eventType: 'fork',
   })
 
-  // Copy messages in order, tracking old→new ID mapping for turnId references
+  // Copy messages in order, tracking old-to-new ID mapping for turnId references.
   const idMap = new Map<string, string>()
   // Stable mapping for tool-call/tool-result IDs so pairs stay linked
   const toolCallIdMap = new Map<string, string>()
@@ -49,13 +49,13 @@ export async function runFork(params: {
     idMap.set(msg.id, created.id)
   }
 
-  return { conversation: forkConversation, conversationId: forkConversation.id }
+  return { status: 'success', conversation: forkConversation, conversationId: forkConversation.id }
 }
 
 /**
  * Convert a source message to an AddMessage shape for the fork conversation.
  * Remaps tool-call / tool-result IDs via a stable map so pairs stay linked,
- * and remaps turnId via the provided idMap (sourceId → forkId).
+ * and remaps turnId via the provided idMap (sourceId to forkId).
  */
 function messageToAddMessage(
   msg: IMessage,
@@ -108,10 +108,13 @@ function messageToAddMessage(
       }
 
     case 'event':
+      if (msg.status !== 'success' && msg.status !== 'loading' && msg.status !== 'error') {
+        throw new Error(`Invalid event message status: ${msg.status}`)
+      }
       return {
         ...base,
         role: 'event' as const,
-        status: 'success' as const,
+        status: msg.status,
         eventType: msg.eventType || 'unknown',
       }
 

--- a/packages/local-server/src/createServer.ts
+++ b/packages/local-server/src/createServer.ts
@@ -263,7 +263,7 @@ async function dispatchRpc(body: unknown, services: LocalServerServices): Promis
       const cc = services.commandController
       if (!cc)
         throw new Error('Command controller is not available in local web transport')
-      cc.cancelCommand(stringParam(params.conversationId))
+      await cc.cancelCommand(stringParam(params.conversationId))
       return null
     }
     default:

--- a/packages/shared/src/interfaces/builtin-command.ts
+++ b/packages/shared/src/interfaces/builtin-command.ts
@@ -60,11 +60,22 @@ export interface RunBuiltinCommandParams {
   workspacePath: string
 }
 
-export interface RunBuiltinCommandResult {
-  /** For /new and /fork: the created conversation */
-  conversation?: IConversations
-  /** For /new and /fork: the new conversation id */
-  conversationId?: string
-  /** For /compact: compaction summary text */
-  summaryText?: string
-}
+export type RunBuiltinCommandResult
+  = | {
+    status: 'success'
+    /** For /new and /fork: the created conversation. */
+    conversation?: IConversations
+    /** For /new and /fork: the new conversation id. */
+    conversationId?: string
+    /** For /compact: compaction summary text. */
+    summaryText?: string
+  }
+  | {
+    status: 'error'
+    errorMessage: string
+    summaryText?: string
+  }
+  | {
+    status: 'cancelled'
+    summaryText?: string
+  }

--- a/packages/shared/src/schemas/conversations.ts
+++ b/packages/shared/src/schemas/conversations.ts
@@ -10,28 +10,28 @@ export const ModelConfigSchema = z.object({
   temperature: z.number(),
 })
 
-// 上下文压缩设置
+// Context compaction settings
 export const CompactionSettingsSchema = z.object({
-  /** 是否启用上下文压缩 */
+  /** Whether context compaction is enabled. */
   enabled: z.boolean(),
-  /** 触发压缩的上下文使用率阈值（百分比 10-90） */
+  /** Context usage threshold percentage that triggers compaction. */
   thresholdPercent: z.number().min(10).max(90),
-  /** 保留的最近对话对数（1-10） */
+  /** Recent conversation pairs kept after compaction. */
   keepRecentPairs: z.number().min(1).max(10),
 })
 
 export type CompactionSettingsSchema = z.infer<typeof CompactionSettingsSchema>
 
-// 会话设置
+// Conversation settings
 export const ConversationsSettingsSchema = z.object({
   modelId: z.string(),
   systemPrompt: z.string(),
   temperature: z.number(),
   maxTokens: z.number(),
   compaction: CompactionSettingsSchema.optional(),
-  /** 上次压缩的时间戳。早于此时间的消息已被摘要替代 */
-  lastCompactedAt: z.number().optional(),
-  /** 上次压缩生成的摘要文本，上下文重建时注入，不显示在聊天中 */
+  /** Last message included in the compaction summary. Earlier messages are replaced by the summary. */
+  lastCompactedMessageId: z.string().optional(),
+  /** Last compaction summary injected when rebuilding context. It is not shown in chat. */
   lastCompactionSummary: z.string().optional(),
 })
 


### PR DESCRIPTION
## Summary
- Use lastCompactedMessageId as the compaction boundary instead of lastCompactedAt.
- Harden built-in command results, cancellation, and same-conversation concurrency.
- Preserve source event message status when forking conversations.
- Keep the existing lxgw-wenkai-mono-gb-screen-webfont font package from main.

## Verification
- pnpm exec vitest run packages/agent-core/src/compaction/__tests__/compaction.spec.ts packages/agent-core/src/loop/__tests__/loopContext.spec.ts packages/agent-runtime/src/commands/__tests__/commandController.spec.ts apps/web/src/components/Sender/__tests__/builtinCommandParser.spec.ts
- pnpm type-check
- pnpm lint --fix
- pnpm check
- git diff --check