### PR TITLE
[codex] integrate agent-browser tool

### DIFF
--- a/.changeset/calm-browsers-connect.md
+++ b/.changeset/calm-browsers-connect.md
@@ -1,0 +1,8 @@
+---
+"@ant-chat/shared": minor
+"@ant-chat/agent-core": minor
+"@ant-chat/app-runtime": minor
+"@ant-chat/local-server": minor
+---
+
+Add the persistent agent-browser tool and runtime integration.

--- a/apps/desktop/electron-builder.ts
+++ b/apps/desktop/electron-builder.ts
@@ -1,9 +1,12 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Configuration } from 'electron-builder'
 import fs from 'node:fs/promises'
+import { createRequire } from 'node:module'
 import path from 'node:path'
 
 const keepLanguages = new Set(['en', 'en_GB', 'en-US', 'en_US'])
+const require = createRequire(import.meta.url)
+const agentBrowserPackageRoot = path.dirname(require.resolve('agent-browser/package.json'))
 
 /**
  * @type {import('electron-builder').Configuration}
@@ -28,6 +31,24 @@ const config: Configuration = {
     },
   ],
   afterPack: async (context) => {
+    const arch = getBuilderArch(context.arch)
+    const sourceName = getAgentBrowserBinaryName(context.electronPlatformName, arch)
+    const executableName = context.electronPlatformName === 'win32' ? 'agent-browser.exe' : 'agent-browser'
+    const resourcesPath = ['darwin', 'mas'].includes(context.electronPlatformName)
+      ? path.join(
+          context.appOutDir,
+          `${context.packager.appInfo.productFilename}.app`,
+          'Contents/Resources',
+        )
+      : path.join(context.appOutDir, 'resources')
+    const targetDir = path.join(resourcesPath, 'agent-browser')
+    const targetPath = path.join(targetDir, executableName)
+    await fs.mkdir(targetDir, { recursive: true })
+    await fs.copyFile(path.join(agentBrowserPackageRoot, 'bin', sourceName), targetPath)
+    if (context.electronPlatformName !== 'win32') {
+      await fs.chmod(targetPath, 0o755)
+    }
+
     if (!['darwin', 'mas'].includes(context.electronPlatformName))
       return
 
@@ -169,6 +190,25 @@ const config: Configuration = {
     installerLanguages: ['zh_CN', 'en_US'],
   },
   generateUpdatesFilesForAllChannels: true,
+}
+
+function getBuilderArch(arch: number): 'x64' | 'arm64' {
+  // builder-util Arch enum: x64=1, arm64=3.
+  if (arch === 1)
+    return 'x64'
+  if (arch === 3)
+    return 'arm64'
+  throw new Error(`Unsupported agent-browser build architecture: ${arch}`)
+}
+
+function getAgentBrowserBinaryName(platform: string, arch: 'x64' | 'arm64'): string {
+  if ((platform === 'darwin' || platform === 'mas') && (arch === 'x64' || arch === 'arm64'))
+    return `agent-browser-darwin-${arch}`
+  if (platform === 'linux' && (arch === 'x64' || arch === 'arm64'))
+    return `agent-browser-linux-${arch}`
+  if (platform === 'win32' && arch === 'x64')
+    return 'agent-browser-win32-x64.exe'
+  throw new Error(`Unsupported agent-browser build target: ${platform}-${arch}`)
 }
 
 export default config

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -52,6 +52,7 @@
     "@tailwindcss/vite": "catalog:",
     "@vitejs/plugin-react": "^5.2.0",
     "@workspace/ui": "workspace:*",
+    "agent-browser": "0.27.2",
     "babel-plugin-react-compiler": "1.0.0",
     "code-inspector-plugin": "catalog:",
     "electron": "^40.6.1",

--- a/apps/desktop/src/main/runtime/appRuntime.ts
+++ b/apps/desktop/src/main/runtime/appRuntime.ts
@@ -1,10 +1,12 @@
 import type { AppRuntime } from '@ant-chat/app-runtime'
-import { createAppRuntime } from '@ant-chat/app-runtime'
+import { createAppRuntime, resolveAgentBrowserExecutablePath } from '@ant-chat/app-runtime'
 import { resolveAppDataRoot } from '@ant-chat/shared'
 import { attachAppRuntimeEvents } from '@main/runtime/electronAppRuntimeEvents'
+import { isProd } from '@main/utils/env'
 import { logger } from '@main/utils/logger'
 import { ProxyManager } from '@main/utils/proxy-manager'
 import { testProxyConnection } from '@main/utils/system-proxy'
+import { getResourcePath } from '@main/utils/util'
 
 let runtime: AppRuntime | null = null
 
@@ -13,6 +15,11 @@ export function getAppRuntime(): AppRuntime {
     runtime = createAppRuntime({
       appDataRoot: resolveAppDataRoot(),
       host: {
+        browser: {
+          executablePath: resolveAgentBrowserExecutablePath({
+            resourcesPath: isProd ? getResourcePath() : undefined,
+          }),
+        },
         proxy: {
           apply: settings => ProxyManager.getInstance().updateProxySettings(settings),
           test: testProxyConnection,

--- a/packages/agent-core/src/native-tools/__tests__/nativeToolService.spec.ts
+++ b/packages/agent-core/src/native-tools/__tests__/nativeToolService.spec.ts
@@ -119,6 +119,23 @@ describe('native tool service', () => {
     await expect(bash.execute({ command: 'pwd && ls -la' })).resolves.toMatchObject({ ok: true })
   })
 
+  it('registers browser as an automatically allowed browser operation', () => {
+    const service = new NativeToolService(workspacePath, false, {
+      browser: {
+        executablePath: '/tmp/agent-browser',
+        profilePath: '/tmp/profile',
+        artifactsPath: '/tmp/artifacts',
+      },
+    })
+    const browser = service.getTools().find(tool => tool.name === 'browser')
+
+    expect(browser).toMatchObject({
+      name: 'browser',
+      operationType: 'browser',
+    })
+    expect(browser?.inferScope({ command: 'open', args: ['https://example.com'] })).toBe('workspace')
+  })
+
   it('tool execute 遇到越界路径返回 AGENT_POLICY_BLOCKED', async () => {
     const service = new NativeToolService(workspacePath)
     const readFile = service.getTools().find(tool => tool.name === 'read_file')!

--- a/packages/agent-core/src/native-tools/nativeToolService.ts
+++ b/packages/agent-core/src/native-tools/nativeToolService.ts
@@ -10,6 +10,7 @@ import type {
 } from '@ant-chat/shared'
 import { createPathPolicyByMode } from './pathPolicy'
 import { createBashTool } from './tools/bashTool'
+import { createBrowserTool } from './tools/browserTool'
 import { createEditFileTool, editFile } from './tools/editFileTool'
 import { createGlobFilesTool, globFiles } from './tools/globFilesTool'
 import { createGrepFilesTool, grepFiles } from './tools/grepFilesTool'
@@ -17,11 +18,20 @@ import { createListDirTool, listDir } from './tools/listDirTool'
 import { createReadFileTool, readFile } from './tools/readFileTool'
 import { createWriteFileTool, writeFile } from './tools/writeFileTool'
 
+interface NativeToolServiceOptions {
+  readableRoots?: string[]
+  browser?: {
+    executablePath: string
+    profilePath: string
+    artifactsPath: string
+  }
+}
+
 export class NativeToolService {
   constructor(
     private readonly workspacePath: string,
     private readonly unrestricted: boolean = false,
-    private readonly options: { readableRoots?: string[] } = {},
+    private readonly options: NativeToolServiceOptions = {},
   ) {}
 
   getTools(): AgentTool[] {
@@ -34,6 +44,9 @@ export class NativeToolService {
       createWriteFileTool(policy, this.workspacePath, this.unrestricted),
       createEditFileTool(policy, this.workspacePath, this.unrestricted),
       createBashTool(this.workspacePath, this.unrestricted),
+      ...(this.options.browser
+        ? [createBrowserTool(this.workspacePath, this.options.browser)]
+        : []),
     ]
   }
 
@@ -66,6 +79,10 @@ export class NativeToolService {
   }
 }
 
-export function getNativeToolService(workspacePath: string, unrestricted: boolean = false, options: { readableRoots?: string[] } = {}): NativeToolService {
+export function getNativeToolService(
+  workspacePath: string,
+  unrestricted: boolean = false,
+  options: NativeToolServiceOptions = {},
+): NativeToolService {
   return new NativeToolService(workspacePath, unrestricted, options)
 }

--- a/packages/agent-core/src/native-tools/tools/__tests__/browserRunner.spec.ts
+++ b/packages/agent-core/src/native-tools/tools/__tests__/browserRunner.spec.ts
@@ -1,0 +1,148 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { runBrowserTool, validateBrowserInput } from '../browserRunner'
+
+describe('browserRunner', () => {
+  let root: string
+  let executablePath: string
+  let profilePath: string
+  let artifactsPath: string
+  let invocationsPath: string
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'ant-chat-browser-'))
+    executablePath = path.join(root, 'agent-browser')
+    profilePath = path.join(root, 'profile')
+    artifactsPath = path.join(root, 'artifacts')
+    invocationsPath = path.join(root, 'invocations.jsonl')
+    fs.writeFileSync(executablePath, `#!/usr/bin/env node
+const fs = require('node:fs')
+let stdin = ''
+process.stdin.setEncoding('utf8')
+process.stdin.on('data', chunk => stdin += chunk)
+process.stdin.on('end', () => {
+  fs.appendFileSync(process.env.INVOCATIONS_PATH, JSON.stringify({ args: process.argv.slice(2), stdin, proxy: process.env.AGENT_BROWSER_PROXY, idle: process.env.AGENT_BROWSER_IDLE_TIMEOUT_MS }) + '\\n')
+  const delay = Number(process.env.DELAY_MS || 0)
+  setTimeout(() => process.stdout.write('ok'), delay)
+})
+`)
+    fs.chmodSync(executablePath, 0o755)
+  })
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true })
+  })
+
+  it('injects the global profile, fixed session, proxy and daemon idle timeout', async () => {
+    const result = await runBrowserTool({
+      command: 'open',
+      args: ['https://example.com'],
+    }, {
+      executablePath,
+      profilePath,
+      artifactsPath,
+      env: {
+        INVOCATIONS_PATH: invocationsPath,
+        HTTP_PROXY: 'http://localhost:7890',
+      },
+    })
+
+    expect(result).toMatchObject({ ok: true, stdout: 'ok' })
+    const invocation = JSON.parse(fs.readFileSync(invocationsPath, 'utf8').trim())
+    expect(invocation.args).toEqual([
+      '--profile',
+      profilePath,
+      '--session',
+      'ant-chat',
+      '--content-boundaries',
+      'open',
+      'https://example.com',
+    ])
+    expect(invocation.proxy).toBe('http://localhost:7890')
+    expect(invocation.idle).toBe('300000')
+  })
+
+  it('opens a headed browser with the persistent Ant Chat profile for manual login', async () => {
+    await runBrowserTool({
+      command: 'open',
+      args: ['--headed', 'https://example.com/login'],
+    }, {
+      executablePath,
+      profilePath,
+      artifactsPath,
+      env: { INVOCATIONS_PATH: invocationsPath },
+    })
+
+    const invocation = JSON.parse(fs.readFileSync(invocationsPath, 'utf8').trim())
+    expect(invocation.args).toEqual([
+      '--profile',
+      profilePath,
+      '--session',
+      'ant-chat',
+      '--content-boundaries',
+      '--headed',
+      'open',
+      'https://example.com/login',
+    ])
+    expect(invocation.stdin).toBe('')
+  })
+
+  it('serializes browser processes that share the global profile', async () => {
+    const first = runBrowserTool({ command: 'get title' }, {
+      executablePath,
+      profilePath,
+      artifactsPath,
+      env: { INVOCATIONS_PATH: invocationsPath, DELAY_MS: '80' },
+    })
+    const second = runBrowserTool({ command: 'get url' }, {
+      executablePath,
+      profilePath,
+      artifactsPath,
+      env: { INVOCATIONS_PATH: invocationsPath },
+    })
+
+    await Promise.all([first, second])
+
+    const lines = fs.readFileSync(invocationsPath, 'utf8').trim().split('\n').map(line => JSON.parse(line))
+    expect(lines.map(item => item.args[item.args.length - 2])).toEqual(['get', 'get'])
+  })
+
+  it('rejects unsafe commands, local URLs and paths outside allowed roots', () => {
+    expect(validateBrowserInput({ command: 'eval', args: ['document.cookie'] }, {
+      workspacePath: root,
+      artifactsPath,
+    })).toContain('command')
+    expect(validateBrowserInput({ command: 'open', args: ['file:///etc/passwd'] }, {
+      workspacePath: root,
+      artifactsPath,
+    })).toContain('http')
+    expect(validateBrowserInput({ command: 'screenshot', args: ['/tmp/out.png'] }, {
+      workspacePath: root,
+      artifactsPath,
+    })).toContain('output path')
+    expect(validateBrowserInput({ command: 'open', args: ['https://example.com', '--extension', '/tmp/ext'] }, {
+      workspacePath: root,
+      artifactsPath,
+    })).toContain('--extension')
+    expect(validateBrowserInput({ command: 'open', args: ['https://example.com', '--proxy', 'http://localhost:7890'] }, {
+      workspacePath: root,
+      artifactsPath,
+    })).toContain('--proxy')
+    expect(validateBrowserInput({ command: 'auth save', args: ['github'] }, {
+      workspacePath: root,
+      artifactsPath,
+    })).toContain('command')
+  })
+
+  it('allows an explicitly requested named Chrome profile', () => {
+    expect(validateBrowserInput({
+      command: 'open',
+      args: ['--profile', 'Default', 'https://example.com'],
+    }, {
+      workspacePath: root,
+      artifactsPath,
+    })).toBeNull()
+  })
+})

--- a/packages/agent-core/src/native-tools/tools/__tests__/browserRunner.spec.ts
+++ b/packages/agent-core/src/native-tools/tools/__tests__/browserRunner.spec.ts
@@ -145,4 +145,63 @@ process.stdin.on('end', () => {
       artifactsPath,
     })).toBeNull()
   })
+
+  it('validates output paths after stripping global arguments (P1)', () => {
+    // screenshot with --profile should validate the actual output path, not the profile name
+    expect(validateBrowserInput({
+      command: 'screenshot',
+      args: ['--profile', 'Default', '/tmp/out.png'],
+    }, {
+      workspacePath: root,
+      artifactsPath,
+    })).toContain('output path')
+
+    // valid output path with --profile should pass
+    expect(validateBrowserInput({
+      command: 'screenshot',
+      args: ['--profile', 'Default', 'out.png'],
+    }, {
+      workspacePath: root,
+      artifactsPath,
+    })).toBeNull()
+  })
+
+  it('rejects --remote-debugging-port, --proxy-server, --disable-web-security, --user-data-dir', () => {
+    expect(validateBrowserInput({ command: 'open', args: ['https://example.com', '--remote-debugging-port', '9222'] }, {
+      workspacePath: root,
+      artifactsPath,
+    })).toContain('--remote-debugging-port')
+    expect(validateBrowserInput({ command: 'open', args: ['https://example.com', '--proxy-server', 'http://localhost:8080'] }, {
+      workspacePath: root,
+      artifactsPath,
+    })).toContain('--proxy-server')
+    expect(validateBrowserInput({ command: 'open', args: ['https://example.com', '--disable-web-security'] }, {
+      workspacePath: root,
+      artifactsPath,
+    })).toContain('--disable-web-security')
+    expect(validateBrowserInput({ command: 'open', args: ['https://example.com', '--user-data-dir', '/tmp/chrome'] }, {
+      workspacePath: root,
+      artifactsPath,
+    })).toContain('--user-data-dir')
+  })
+
+  it('uses proxyUrl option over environment proxy variables', async () => {
+    const result = await runBrowserTool({
+      command: 'open',
+      args: ['https://example.com'],
+    }, {
+      executablePath,
+      profilePath,
+      artifactsPath,
+      proxyUrl: 'http://explicit-proxy:8080',
+      env: {
+        INVOCATIONS_PATH: invocationsPath,
+        HTTP_PROXY: 'http://env-proxy:7890',
+      },
+    })
+
+    expect(result).toMatchObject({ ok: true, stdout: 'ok' })
+    const invocation = JSON.parse(fs.readFileSync(invocationsPath, 'utf8').trim())
+    expect(invocation.proxy).toBe('http://explicit-proxy:8080')
+  })
 })

--- a/packages/agent-core/src/native-tools/tools/browserRunner.ts
+++ b/packages/agent-core/src/native-tools/tools/browserRunner.ts
@@ -70,6 +70,10 @@ const BLOCKED_FLAGS = new Set([
   '--init-script',
   '--executable-path',
   '--allow-file-access',
+  '--remote-debugging-port',
+  '--proxy-server',
+  '--disable-web-security',
+  '--user-data-dir',
 ])
 
 const COMMON_FLAGS = new Set(['--json'])
@@ -93,6 +97,7 @@ export interface BrowserRunnerOptions {
   profilePath: string
   artifactsPath: string
   env?: NodeJS.ProcessEnv
+  proxyUrl?: string
 }
 
 export function validateBrowserInput(
@@ -145,7 +150,7 @@ export function validateBrowserInput(
     }
   }
 
-  const outputPaths = getOutputPaths(command, args)
+  const outputPaths = getOutputPaths(command, commandArgs)
   for (const outputPath of outputPaths) {
     if (!isAllowedOutputPath(outputPath, options.workspacePath, options.artifactsPath)) {
       return `browser output path is outside allowed roots: ${outputPath}`
@@ -294,7 +299,8 @@ function createBrowserEnv(options: BrowserRunnerOptions): NodeJS.ProcessEnv {
     ...process.env,
     ...options.env,
   }
-  const proxy = source.HTTPS_PROXY || source.HTTP_PROXY || source.https_proxy || source.http_proxy
+  const proxy = options.proxyUrl
+    ?? (source.HTTPS_PROXY || source.HTTP_PROXY || source.https_proxy || source.http_proxy)
   return {
     ...source,
     AGENT_BROWSER_CONTENT_BOUNDARIES: '1',

--- a/packages/agent-core/src/native-tools/tools/browserRunner.ts
+++ b/packages/agent-core/src/native-tools/tools/browserRunner.ts
@@ -1,0 +1,381 @@
+import type { AgentToolResult, BrowserToolInput } from '@ant-chat/shared'
+import type { Buffer } from 'node:buffer'
+import { spawn } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+
+const DEFAULT_TIMEOUT_MS = 60_000
+const MAX_TIMEOUT_MS = 300_000
+const MAX_OUTPUT_CHARS = 20_000
+const DAEMON_IDLE_TIMEOUT_MS = '300000'
+const SESSION_NAME = 'ant-chat'
+
+const ALLOWED_COMMANDS = new Set([
+  'open',
+  'close',
+  'snapshot',
+  'click',
+  'dblclick',
+  'focus',
+  'type',
+  'fill',
+  'press',
+  'keydown',
+  'keyup',
+  'hover',
+  'select',
+  'check',
+  'uncheck',
+  'scroll',
+  'wait',
+  'screenshot',
+  'pdf',
+  'download',
+  'back',
+  'forward',
+  'reload',
+  'get text',
+  'get html',
+  'get value',
+  'get attribute',
+  'get count',
+  'get box',
+  'get styles',
+  'get url',
+  'get title',
+  'find role',
+  'find text',
+  'find label',
+  'find placeholder',
+  'find alt',
+  'find testid',
+  'tab new',
+  'tab list',
+  'tab switch',
+  'tab close',
+  'dialog accept',
+  'dialog dismiss',
+  'skills get',
+  'skills list',
+])
+
+const BLOCKED_FLAGS = new Set([
+  '--config',
+  '--extension',
+  '--cdp',
+  '--auto-connect',
+  '--provider',
+  '--state',
+  '--init-script',
+  '--executable-path',
+  '--allow-file-access',
+])
+
+const COMMON_FLAGS = new Set(['--json'])
+const COMMAND_FLAGS: Record<string, Set<string>> = {
+  'snapshot': new Set(['-i', '-C', '-s', '--json']),
+  'click': new Set(['--new-tab']),
+  'scroll': new Set(['--selector']),
+  'wait': new Set(['--load', '--url', '--download']),
+  'screenshot': new Set(['--full', '--annotate']),
+  'skills get': new Set(['--full']),
+  'find role': new Set(['--name', '--exact']),
+  'find text': new Set(['--exact']),
+}
+
+const PATH_OUTPUT_COMMANDS = new Set(['screenshot', 'pdf'])
+let browserQueue: Promise<void> = Promise.resolve()
+
+export interface BrowserRunnerOptions {
+  executablePath: string
+  workspacePath?: string
+  profilePath: string
+  artifactsPath: string
+  env?: NodeJS.ProcessEnv
+}
+
+export function validateBrowserInput(
+  input: BrowserToolInput,
+  options: Pick<BrowserRunnerOptions, 'workspacePath' | 'artifactsPath'>,
+): string | null {
+  const command = normalizeCommand(input.command)
+  if (!ALLOWED_COMMANDS.has(command)) {
+    return `browser command is not allowed: ${command || '(empty)'}`
+  }
+  if (input.args !== undefined && (!Array.isArray(input.args) || input.args.some(arg => typeof arg !== 'string'))) {
+    return 'browser args must be an array of strings'
+  }
+  if (input.timeoutMs !== undefined && (!Number.isFinite(input.timeoutMs) || input.timeoutMs <= 0)) {
+    return 'browser timeoutMs must be a positive number'
+  }
+
+  const args = input.args ?? []
+  for (const flag of BLOCKED_FLAGS) {
+    if (args.some(arg => arg === flag || arg.startsWith(`${flag}=`))) {
+      return `browser flag is not allowed: ${flag}`
+    }
+  }
+  if (args.some(arg => arg.startsWith('--profile='))) {
+    return 'browser --profile must use a separate Chrome profile name argument'
+  }
+
+  const profileIndex = args.indexOf('--profile')
+  if (profileIndex >= 0) {
+    const profile = args[profileIndex + 1]
+    if (!profile || profile.startsWith('-') || profile.includes('/') || profile.includes('\\')) {
+      return 'browser --profile only accepts a Chrome profile name'
+    }
+  }
+
+  const { commandArgs } = extractGlobalArgs(args)
+  const invalidFlag = commandArgs.find(arg =>
+    arg.startsWith('-')
+    && !COMMON_FLAGS.has(arg)
+    && !(COMMAND_FLAGS[command]?.has(arg) ?? false),
+  )
+  if (invalidFlag) {
+    return `browser flag is not allowed for ${command}: ${invalidFlag}`
+  }
+
+  if (command === 'open') {
+    const url = commandArgs.find(arg => !arg.startsWith('-'))
+    if (!url || !isHttpUrl(url)) {
+      return 'browser open requires an http or https URL'
+    }
+  }
+
+  const outputPaths = getOutputPaths(command, args)
+  for (const outputPath of outputPaths) {
+    if (!isAllowedOutputPath(outputPath, options.workspacePath, options.artifactsPath)) {
+      return `browser output path is outside allowed roots: ${outputPath}`
+    }
+  }
+
+  return null
+}
+
+export async function runBrowserTool(
+  input: BrowserToolInput,
+  options: BrowserRunnerOptions,
+): Promise<AgentToolResult> {
+  const validationError = validateBrowserInput(input, options)
+  if (validationError) {
+    return { ok: false, error: validationError }
+  }
+
+  const previous = browserQueue
+  let release: () => void = () => {}
+  browserQueue = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  await previous
+
+  try {
+    return await executeBrowserTool(input, options)
+  }
+  finally {
+    release()
+  }
+}
+
+async function executeBrowserTool(
+  input: BrowserToolInput,
+  options: BrowserRunnerOptions,
+): Promise<AgentToolResult> {
+  const startedAt = Date.now()
+  await fs.promises.mkdir(options.profilePath, { recursive: true })
+  await fs.promises.mkdir(options.artifactsPath, { recursive: true })
+
+  const command = normalizeCommand(input.command)
+  const { globalArgs, commandArgs } = extractGlobalArgs(input.args ?? [])
+  const profileArgs = globalArgs.includes('--profile')
+    ? []
+    : ['--profile', options.profilePath]
+  const args = [
+    ...profileArgs,
+    '--session',
+    SESSION_NAME,
+    '--content-boundaries',
+    ...globalArgs,
+    ...command.split(' '),
+    ...normalizeOutputPaths(command, commandArgs, options.workspacePath),
+  ]
+  const env = createBrowserEnv(options)
+  const timeoutMs = Math.min(input.timeoutMs ?? DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS)
+
+  return await new Promise((resolve) => {
+    const child = spawn(options.executablePath, args, {
+      cwd: options.workspacePath,
+      shell: false,
+      env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    let timedOut = false
+    let settled = false
+
+    const finish = (result: AgentToolResult) => {
+      if (settled)
+        return
+      settled = true
+      resolve(result)
+    }
+    const timer = setTimeout(() => {
+      timedOut = true
+      child.kill('SIGTERM')
+    }, timeoutMs)
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout = appendTruncated(stdout, chunk.toString())
+    })
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr = appendTruncated(stderr, chunk.toString())
+    })
+    child.on('error', (error) => {
+      clearTimeout(timer)
+      finish({ ok: false, error: error.message, stdout, stderr, durationMs: Date.now() - startedAt })
+    })
+    child.on('close', (exitCode) => {
+      clearTimeout(timer)
+      if (timedOut) {
+        finish({
+          ok: false,
+          error: 'AGENT_BROWSER_TIMEOUT',
+          stdout,
+          stderr,
+          exitCode: exitCode ?? undefined,
+          durationMs: Date.now() - startedAt,
+        })
+        return
+      }
+
+      const ok = exitCode === 0
+      finish({
+        ok,
+        error: ok ? undefined : (stderr.trim() || `agent-browser exited with code ${exitCode}`),
+        stdout,
+        stderr,
+        exitCode: exitCode ?? undefined,
+        durationMs: Date.now() - startedAt,
+      })
+    })
+
+    child.stdin.end()
+  })
+}
+
+function normalizeCommand(command: string): string {
+  return String(command || '').trim().replace(/\s+/g, ' ')
+}
+
+function extractGlobalArgs(args: string[]): { globalArgs: string[], commandArgs: string[] } {
+  const globalArgs: string[] = []
+  const commandArgs: string[] = []
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]
+    if (arg === '--headed') {
+      globalArgs.push(arg)
+      continue
+    }
+    if (arg === '--profile') {
+      globalArgs.push(arg, args[index + 1]!)
+      index++
+      continue
+    }
+    commandArgs.push(arg)
+  }
+  return { globalArgs, commandArgs }
+}
+
+function createBrowserEnv(options: BrowserRunnerOptions): NodeJS.ProcessEnv {
+  const source = {
+    ...process.env,
+    ...options.env,
+  }
+  const proxy = source.HTTPS_PROXY || source.HTTP_PROXY || source.https_proxy || source.http_proxy
+  return {
+    ...source,
+    AGENT_BROWSER_CONTENT_BOUNDARIES: '1',
+    AGENT_BROWSER_DOWNLOAD_PATH: options.artifactsPath,
+    AGENT_BROWSER_IDLE_TIMEOUT_MS: DAEMON_IDLE_TIMEOUT_MS,
+    AGENT_BROWSER_SCREENSHOT_DIR: options.artifactsPath,
+    ...(proxy ? { AGENT_BROWSER_PROXY: proxy } : {}),
+  }
+}
+
+function getOutputPaths(command: string, args: string[]): string[] {
+  if (PATH_OUTPUT_COMMANDS.has(command)) {
+    const pathArg = args.find(arg => !arg.startsWith('-'))
+    return pathArg ? [pathArg] : []
+  }
+  if (command === 'download') {
+    const pathArg = args[args.length - 1]
+    return pathArg && !pathArg.startsWith('-') ? [pathArg] : []
+  }
+  if (command === 'wait') {
+    const downloadIndex = args.indexOf('--download')
+    return downloadIndex >= 0 && args[downloadIndex + 1] ? [args[downloadIndex + 1]!] : []
+  }
+  return []
+}
+
+function normalizeOutputPaths(command: string, args: string[], workspacePath?: string): string[] {
+  const outputPaths = new Set(getOutputPaths(command, args))
+  if (!workspacePath || outputPaths.size === 0) {
+    return args
+  }
+  return args.map(arg => outputPaths.has(arg) && !path.isAbsolute(arg) ? path.resolve(workspacePath, arg) : arg)
+}
+
+function isAllowedOutputPath(outputPath: string, workspacePath: string | undefined, artifactsPath: string): boolean {
+  const roots = [workspacePath, artifactsPath].filter((value): value is string => Boolean(value))
+  const absolutePath = path.resolve(workspacePath ?? artifactsPath, outputPath)
+  return roots.some(root => isPathInsideAllowedRoot(absolutePath, root))
+}
+
+function isPathInsideAllowedRoot(targetPath: string, rootPath: string): boolean {
+  const absoluteRoot = path.resolve(rootPath)
+  if (!isPathInside(targetPath, absoluteRoot)) {
+    return false
+  }
+  if (!fs.existsSync(absoluteRoot)) {
+    return true
+  }
+
+  const realRoot = fs.realpathSync.native(absoluteRoot)
+  let existingAncestor = targetPath
+  while (!fs.existsSync(existingAncestor)) {
+    const parent = path.dirname(existingAncestor)
+    if (parent === existingAncestor) {
+      return false
+    }
+    existingAncestor = parent
+  }
+  const realAncestor = fs.realpathSync.native(existingAncestor)
+  const resolvedTarget = path.resolve(realAncestor, path.relative(existingAncestor, targetPath))
+  return isPathInside(resolvedTarget, realRoot)
+}
+
+function isPathInside(targetPath: string, rootPath: string): boolean {
+  const relative = path.relative(rootPath, targetPath)
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value)
+    return url.protocol === 'http:' || url.protocol === 'https:'
+  }
+  catch {
+    return false
+  }
+}
+
+function appendTruncated(current: string, next: string): string {
+  const value = current + next
+  return value.length <= MAX_OUTPUT_CHARS
+    ? value
+    : `${value.slice(0, MAX_OUTPUT_CHARS)}\n[output truncated]`
+}

--- a/packages/agent-core/src/native-tools/tools/browserTool.ts
+++ b/packages/agent-core/src/native-tools/tools/browserTool.ts
@@ -1,0 +1,46 @@
+import type { AgentBrowserRuntimeConfig, BrowserToolInput } from '@ant-chat/shared'
+import { runBrowserTool, validateBrowserInput } from './browserRunner'
+import { createNativeTool } from './toolFactory'
+
+export function createBrowserTool(workspacePath: string, config: AgentBrowserRuntimeConfig) {
+  return createNativeTool({
+    name: 'browser',
+    description: [
+      'Control a persistent browser with agent-browser.',
+      'Use command="open" with an HTTP(S) URL, then command="snapshot", interact with @eN refs, and snapshot again after navigation or DOM changes.',
+      'Use command="skills get" with args=["core"] for the version-matched detailed guide.',
+      'The browser uses one global Ant Chat profile, so login state persists across conversations and workspaces.',
+      'Use args=["--headed", ...] when the user must complete login, CAPTCHA, or two-factor authentication.',
+      'Never request, accept, or enter account passwords. Open a headed browser and let the user type credentials directly.',
+      'Only use args=["--profile", "<Chrome profile name>", ...] when the user explicitly asks to reuse a system Chrome profile.',
+    ].join('\n'),
+    inputSchema: {
+      type: 'object',
+      properties: {
+        command: { type: 'string', description: 'Allowed agent-browser command, for example open, snapshot, click, get text, or skills get.' },
+        args: { type: 'array', items: { type: 'string' }, description: 'Command arguments. Do not include shell syntax.' },
+        timeoutMs: { type: 'number', description: 'Execution timeout in milliseconds, capped at 300000.' },
+      },
+      required: ['command'],
+    },
+    unrestricted: true,
+    inferScope: (input) => {
+      return validateBrowserInput(input as unknown as BrowserToolInput, {
+        workspacePath,
+        artifactsPath: config.artifactsPath,
+      })
+        ? 'blocked'
+        : 'workspace'
+    },
+    validateInput: input => validateBrowserInput(input as unknown as BrowserToolInput, {
+      workspacePath,
+      artifactsPath: config.artifactsPath,
+    }),
+    execute: input => runBrowserTool(input as unknown as BrowserToolInput, {
+      ...config,
+      workspacePath,
+    }),
+    formatError: error => `Browser tool failed: ${error}`,
+    truncateObservation: false,
+  })
+}

--- a/packages/agent-core/src/native-tools/tools/browserTool.ts
+++ b/packages/agent-core/src/native-tools/tools/browserTool.ts
@@ -39,6 +39,7 @@ export function createBrowserTool(workspacePath: string, config: AgentBrowserRun
     execute: input => runBrowserTool(input as unknown as BrowserToolInput, {
       ...config,
       workspacePath,
+      proxyUrl: config.proxyUrl,
     }),
     formatError: error => `Browser tool failed: ${error}`,
     truncateObservation: false,

--- a/packages/agent-core/src/native-tools/tools/toolFactory.ts
+++ b/packages/agent-core/src/native-tools/tools/toolFactory.ts
@@ -53,6 +53,8 @@ function getToolOperationType(name: string): ToolOperationType {
       return 'write'
     case 'bash':
       return 'bash'
+    case 'browser':
+      return 'browser'
     default:
       return 'read'
   }

--- a/packages/agent-core/src/policy/__tests__/policyEngine.spec.ts
+++ b/packages/agent-core/src/policy/__tests__/policyEngine.spec.ts
@@ -34,6 +34,11 @@ describe('decidePolicy', () => {
       expect(decidePolicy('strict', 'skill', 'workspace')).toEqual({ type: 'allow' })
     })
 
+    it('allows browser operations', () => {
+      expect(decidePolicy('strict', 'browser', 'workspace')).toEqual({ type: 'allow' })
+      expect(decidePolicy('hybrid', 'browser', 'workspace')).toEqual({ type: 'allow' })
+    })
+
     it('allows write in hybrid mode', () => {
       expect(decidePolicy('hybrid', 'write', 'workspace')).toEqual({ type: 'allow' })
     })

--- a/packages/agent-core/src/policy/policyEngine.ts
+++ b/packages/agent-core/src/policy/policyEngine.ts
@@ -19,7 +19,7 @@ export function decidePolicy(mode: AgentMode, operationType: ToolOperationType, 
   }
 
   // scope === 'workspace'
-  if (operationType === 'read' || operationType === 'skill' || operationType === 'mcp') {
+  if (operationType === 'read' || operationType === 'browser' || operationType === 'skill' || operationType === 'mcp') {
     return { type: 'allow' }
   }
 

--- a/packages/agent-core/src/tools/toolRegistry.ts
+++ b/packages/agent-core/src/tools/toolRegistry.ts
@@ -34,10 +34,16 @@ export class ToolRegistry {
     const unrestricted = mode === 'full_managed'
     const skillReader = resolveSkillReader(config)
     const readableRoots = skillReader ? [skillReader.getSkillsRoot()] : []
-    const nativeTools = getNativeToolService(workspacePath, unrestricted, { readableRoots }).getTools()
+    const nativeTools = getNativeToolService(workspacePath, unrestricted, {
+      readableRoots,
+      browser: config.browser,
+    }).getTools()
     const relaxedNativeTools = unrestricted
       ? nativeTools
-      : getNativeToolService(workspacePath, true, { readableRoots }).getTools()
+      : getNativeToolService(workspacePath, true, {
+          readableRoots,
+          browser: config.browser,
+        }).getTools()
     const skillTools = skillReader
       ? await makeSkillTools(skillReader)
       : []

--- a/packages/app-runtime/package.json
+++ b/packages/app-runtime/package.json
@@ -31,6 +31,7 @@
     "@ant-chat/app-data": "workspace:^",
     "@ant-chat/mcp-client-hub": "workspace:^",
     "@ant-chat/shared": "workspace:^",
+    "agent-browser": "0.27.2",
     "better-sqlite3": "catalog:"
   },
   "devDependencies": {

--- a/packages/app-runtime/src/__tests__/agentBrowser.spec.ts
+++ b/packages/app-runtime/src/__tests__/agentBrowser.spec.ts
@@ -1,0 +1,33 @@
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { createAgentBrowserPaths, getAgentBrowserBinaryName, resolveAgentBrowserExecutablePath } from '../agentBrowser'
+
+describe('agentBrowser paths', () => {
+  it('uses one global Ant Chat profile and artifacts directory', () => {
+    expect(createAgentBrowserPaths('/home/user')).toEqual({
+      profilePath: path.join('/home/user', '.ant-chat', 'browser', 'profile'),
+      artifactsPath: path.join('/home/user', '.ant-chat', 'browser', 'artifacts'),
+    })
+  })
+
+  it('maps supported platforms to the packaged agent-browser binary', () => {
+    expect(getAgentBrowserBinaryName('darwin', 'arm64')).toBe('agent-browser-darwin-arm64')
+    expect(getAgentBrowserBinaryName('darwin', 'x64')).toBe('agent-browser-darwin-x64')
+    expect(getAgentBrowserBinaryName('linux', 'x64')).toBe('agent-browser-linux-x64')
+    expect(getAgentBrowserBinaryName('win32', 'x64')).toBe('agent-browser-win32-x64.exe')
+    expect(() => getAgentBrowserBinaryName('win32', 'arm64')).toThrow('Unsupported agent-browser platform')
+  })
+
+  it('resolves the packaged resource path', () => {
+    expect(resolveAgentBrowserExecutablePath({
+      resourcesPath: '/app/resources',
+      platform: 'darwin',
+      arch: 'arm64',
+    })).toBe(path.join('/app/resources', 'agent-browser', 'agent-browser'))
+    expect(resolveAgentBrowserExecutablePath({
+      resourcesPath: 'C:\\app\\resources',
+      platform: 'win32',
+      arch: 'x64',
+    })).toBe(path.join('C:\\app\\resources', 'agent-browser', 'agent-browser.exe'))
+  })
+})

--- a/packages/app-runtime/src/agentBrowser.ts
+++ b/packages/app-runtime/src/agentBrowser.ts
@@ -1,0 +1,55 @@
+import { createRequire } from 'node:module'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+
+const require = createRequire(import.meta.url)
+
+export interface AgentBrowserPaths {
+  profilePath: string
+  artifactsPath: string
+}
+
+export function createAgentBrowserPaths(homeDir: string = os.homedir()): AgentBrowserPaths {
+  const root = path.join(homeDir, '.ant-chat', 'browser')
+  return {
+    profilePath: path.join(root, 'profile'),
+    artifactsPath: path.join(root, 'artifacts'),
+  }
+}
+
+export function getAgentBrowserBinaryName(
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+): string {
+  if (platform === 'darwin' && (arch === 'arm64' || arch === 'x64')) {
+    return `agent-browser-darwin-${arch}`
+  }
+  if (platform === 'linux' && (arch === 'arm64' || arch === 'x64')) {
+    return `agent-browser-linux-${arch}`
+  }
+  if (platform === 'win32' && arch === 'x64') {
+    return 'agent-browser-win32-x64.exe'
+  }
+  throw new Error(`Unsupported agent-browser platform: ${platform}-${arch}`)
+}
+
+export function resolveAgentBrowserExecutablePath(options: {
+  resourcesPath?: string
+  platform?: NodeJS.Platform
+  arch?: string
+} = {}): string {
+  if (options.resourcesPath) {
+    const executableName = options.platform === 'win32' || (!options.platform && process.platform === 'win32')
+      ? 'agent-browser.exe'
+      : 'agent-browser'
+    return path.join(options.resourcesPath, 'agent-browser', executableName)
+  }
+
+  const packageJsonPath = require.resolve('agent-browser/package.json')
+  return path.join(
+    path.dirname(packageJsonPath),
+    'bin',
+    getAgentBrowserBinaryName(options.platform, options.arch),
+  )
+}

--- a/packages/app-runtime/src/appRuntime.ts
+++ b/packages/app-runtime/src/appRuntime.ts
@@ -42,6 +42,7 @@ import { createAppRuntimePaths } from './paths'
 export interface AppRuntimeHost {
   browser?: {
     executablePath: string
+    proxyUrl?: string
   }
   proxy: {
     apply: (settings: ProxySettings) => Promise<void>
@@ -98,6 +99,7 @@ export function createAppRuntime(options: CreateAppRuntimeOptions) {
       browser: options.host.browser
         ? {
             executablePath: options.host.browser.executablePath,
+            proxyUrl: options.host.browser.proxyUrl,
             ...browserPaths,
           }
         : undefined,

--- a/packages/app-runtime/src/appRuntime.ts
+++ b/packages/app-runtime/src/appRuntime.ts
@@ -34,11 +34,15 @@ import {
 import { createAppDataContext, searchWorkspaceFiles } from '@ant-chat/app-data'
 import { MCPClientHub } from '@ant-chat/mcp-client-hub'
 import { AddMessage, UpdateMessageSchema } from '@ant-chat/shared'
+import { createAgentBrowserPaths } from './agentBrowser'
 import { openAppDataDatabase } from './database'
 import { RuntimeEventBus } from './events'
 import { createAppRuntimePaths } from './paths'
 
 export interface AppRuntimeHost {
+  browser?: {
+    executablePath: string
+  }
   proxy: {
     apply: (settings: ProxySettings) => Promise<void>
     test: (proxyUrl: string) => Promise<boolean>
@@ -54,6 +58,7 @@ export interface CreateAppRuntimeOptions {
 
 export function createAppRuntime(options: CreateAppRuntimeOptions) {
   const paths = createAppRuntimePaths(options.appDataRoot)
+  const browserPaths = createAgentBrowserPaths()
   const db = openAppDataDatabase(paths.databaseFile, { timeoutMs: options.databaseTimeoutMs })
   const context = createAppDataContext({
     db,
@@ -90,6 +95,12 @@ export function createAppRuntime(options: CreateAppRuntimeOptions) {
       memoryReader: context.memoryManager,
       skillReader: skills,
       mcpClientHub,
+      browser: options.host.browser
+        ? {
+            executablePath: options.host.browser.executablePath,
+            ...browserPaths,
+          }
+        : undefined,
       loadFileData: context.loadAttachmentData,
       createTaskLogger: createTaskLoggerFactory(paths.taskLogsRoot),
       getToolApprovalWhitelistEntries: () => context.toolApprovalWhitelistRepository.getAll(),

--- a/packages/app-runtime/src/index.ts
+++ b/packages/app-runtime/src/index.ts
@@ -1,3 +1,5 @@
+export { createAgentBrowserPaths, getAgentBrowserBinaryName, resolveAgentBrowserExecutablePath } from './agentBrowser'
+export type { AgentBrowserPaths } from './agentBrowser'
 export { createAppRuntime } from './appRuntime'
 export type { AppRuntime, AppRuntimeHost, CreateAppRuntimeOptions } from './appRuntime'
 export type { AppRuntimeEventBus, AppRuntimeEventListener, AppRuntimeEventName, AppRuntimeEvents } from './events'

--- a/packages/local-server/src/dev.ts
+++ b/packages/local-server/src/dev.ts
@@ -23,6 +23,8 @@ const initialProxyEnv = {
   no_proxy: process.env.no_proxy,
 }
 
+let currentProxyUrl: string | undefined
+
 function sseBroadcast(clients: Set<ServerResponse>, channel: string, data: unknown) {
   const payload = `event: ${channel}\ndata: ${JSON.stringify(data)}\n\n`
   for (const client of clients) {
@@ -48,10 +50,12 @@ async function main() {
     host: {
       browser: {
         executablePath: resolveAgentBrowserExecutablePath(),
+        get proxyUrl() { return currentProxyUrl },
       },
       proxy: {
         async apply(settings) {
           if (settings.mode === 'custom' && settings.customProxyUrl) {
+            currentProxyUrl = settings.customProxyUrl
             setProcessProxy(settings.customProxyUrl)
             setGlobalDispatcher(new EnvHttpProxyAgent({
               httpProxy: settings.customProxyUrl,
@@ -60,10 +64,12 @@ async function main() {
             }))
           }
           else if (settings.mode === 'system') {
+            currentProxyUrl = undefined
             restoreSystemProxy()
             setGlobalDispatcher(new EnvHttpProxyAgent())
           }
           else {
+            currentProxyUrl = undefined
             clearProcessProxy()
             setGlobalDispatcher(new Agent())
           }

--- a/packages/local-server/src/dev.ts
+++ b/packages/local-server/src/dev.ts
@@ -3,7 +3,7 @@ import { createServer as createHttpServer } from 'node:http'
 import { resolve } from 'node:path'
 import process from 'node:process'
 import { parseArgs } from 'node:util'
-import { createAppRuntime } from '@ant-chat/app-runtime'
+import { createAppRuntime, resolveAgentBrowserExecutablePath } from '@ant-chat/app-runtime'
 import { resolveAppDataRoot } from '@ant-chat/shared'
 import { Agent, EnvHttpProxyAgent, fetch, setGlobalDispatcher } from 'undici'
 import { createLocalApiHandler } from './createServer'
@@ -12,6 +12,15 @@ const SSE_HEADERS = {
   'content-type': 'text/event-stream',
   'cache-control': 'no-cache',
   'connection': 'keep-alive',
+}
+
+const initialProxyEnv = {
+  HTTP_PROXY: process.env.HTTP_PROXY,
+  HTTPS_PROXY: process.env.HTTPS_PROXY,
+  NO_PROXY: process.env.NO_PROXY,
+  http_proxy: process.env.http_proxy,
+  https_proxy: process.env.https_proxy,
+  no_proxy: process.env.no_proxy,
 }
 
 function sseBroadcast(clients: Set<ServerResponse>, channel: string, data: unknown) {
@@ -37,9 +46,13 @@ async function main() {
   const runtime = createAppRuntime({
     appDataRoot,
     host: {
+      browser: {
+        executablePath: resolveAgentBrowserExecutablePath(),
+      },
       proxy: {
         async apply(settings) {
           if (settings.mode === 'custom' && settings.customProxyUrl) {
+            setProcessProxy(settings.customProxyUrl)
             setGlobalDispatcher(new EnvHttpProxyAgent({
               httpProxy: settings.customProxyUrl,
               httpsProxy: settings.customProxyUrl,
@@ -47,9 +60,11 @@ async function main() {
             }))
           }
           else if (settings.mode === 'system') {
+            restoreSystemProxy()
             setGlobalDispatcher(new EnvHttpProxyAgent())
           }
           else {
+            clearProcessProxy()
             setGlobalDispatcher(new Agent())
           }
         },
@@ -154,6 +169,31 @@ async function main() {
 
   process.on('SIGINT', () => void shutdown())
   process.on('SIGTERM', () => void shutdown())
+}
+
+function setProcessProxy(proxyUrl: string): void {
+  const noProxy = 'localhost,127.0.0.1,0.0.0.0,[::1],::1'
+  process.env.HTTP_PROXY = proxyUrl
+  process.env.HTTPS_PROXY = proxyUrl
+  process.env.NO_PROXY = noProxy
+  process.env.http_proxy = proxyUrl
+  process.env.https_proxy = proxyUrl
+  process.env.no_proxy = noProxy
+}
+
+function restoreSystemProxy(): void {
+  clearProcessProxy()
+  for (const [key, value] of Object.entries(initialProxyEnv)) {
+    if (value !== undefined) {
+      process.env[key] = value
+    }
+  }
+}
+
+function clearProcessProxy(): void {
+  for (const key of Object.keys(initialProxyEnv)) {
+    delete process.env[key]
+  }
 }
 
 main()

--- a/packages/shared/src/interfaces/agent-runtime-interfaces.ts
+++ b/packages/shared/src/interfaces/agent-runtime-interfaces.ts
@@ -200,6 +200,12 @@ export interface RuntimeMcpClientHub {
   callTool: (serverName: string, toolName: string, toolArguments?: Record<string, unknown>) => Promise<McpToolCallResponse>
 }
 
+export interface AgentBrowserRuntimeConfig {
+  executablePath: string
+  profilePath: string
+  artifactsPath: string
+}
+
 // ============================================================
 // Compaction (纯策略回调，外层 onBeforeTurn 中使用)
 // ============================================================
@@ -220,6 +226,7 @@ export interface AgentRuntimeHost {
   memoryReader?: AgentMemoryReader
   skillReader?: SkillReader
   mcpClientHub?: RuntimeMcpClientHub
+  browser?: AgentBrowserRuntimeConfig
   /** 加载附件文件数据（用于将 file_id 转换为 base64 数据） */
   loadFileData?: (fileId: string) => Promise<string | null>
   getToolApprovalWhitelistEntries?: () => ToolApprovalWhitelistEntry[]
@@ -252,6 +259,7 @@ export interface AgentRuntimeConfig extends AgentRuntimeOverrides {
   getToolApprovalWhitelistEntries?: () => ToolApprovalWhitelistEntry[]
   skillReader?: SkillReader
   mcpClientHub?: RuntimeMcpClientHub
+  browser?: AgentBrowserRuntimeConfig
   /** 加载附件文件数据（用于将 file_id 转换为 base64 数据） */
   loadFileData?: (fileId: string) => Promise<string | null>
 }

--- a/packages/shared/src/interfaces/agent-runtime-interfaces.ts
+++ b/packages/shared/src/interfaces/agent-runtime-interfaces.ts
@@ -204,6 +204,8 @@ export interface AgentBrowserRuntimeConfig {
   executablePath: string
   profilePath: string
   artifactsPath: string
+  /** Explicit proxy URL; when set, overrides environment proxy variables. */
+  proxyUrl?: string
 }
 
 // ============================================================

--- a/packages/shared/src/interfaces/agent-tools.ts
+++ b/packages/shared/src/interfaces/agent-tools.ts
@@ -1,4 +1,4 @@
-export type ToolOperationType = 'read' | 'write' | 'bash' | 'skill' | 'mcp'
+export type ToolOperationType = 'read' | 'write' | 'bash' | 'browser' | 'skill' | 'mcp'
 export type ToolScope = 'workspace' | 'outside' | 'blocked'
 
 export interface AgentToolResult {
@@ -42,6 +42,12 @@ export interface BashToolInput {
   cwd?: string
   timeoutMs?: number
   env?: Record<string, string>
+}
+
+export interface BrowserToolInput {
+  command: string
+  args?: string[]
+  timeoutMs?: number
 }
 
 export interface ReadFileToolInput {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,9 @@ importers:
       '@workspace/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      agent-browser:
+        specifier: 0.27.2
+        version: 0.27.2
       babel-plugin-react-compiler:
         specifier: 1.0.0
         version: 1.0.0
@@ -437,6 +440,9 @@ importers:
       '@ant-chat/shared':
         specifier: workspace:^
         version: link:../shared
+      agent-browser:
+        specifier: 0.27.2
+        version: 0.27.2
       better-sqlite3:
         specifier: 'catalog:'
         version: 12.6.2
@@ -4056,6 +4062,11 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  agent-browser@0.27.2:
+    resolution: {integrity: sha512-RZNxZFvnspSxSmpjkZjM0Lv69ArwYr8t+Ndavko/NGrfkdUkp5lVGJAs4f88tJNNcBVFcn92hhS+3pulVF9oSw==}
+    engines: {node: '>=24.0.0', pnpm: '>=11.0.0'}
+    hasBin: true
 
   ahooks@3.9.7:
     resolution: {integrity: sha512-S0lvzhbdlhK36RFBkGv+RbOM/dbbweym+BIHM/bwwuWVSVN5TuVErHPMWo4w0t1NDYg5KPp2iEf7Y7E5LASYiw==}
@@ -12520,6 +12531,8 @@ snapshots:
   acorn@8.16.0: {}
 
   agent-base@7.1.4: {}
+
+  agent-browser@0.27.2: {}
 
   ahooks@3.9.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 allowBuilds:
+  agent-browser: true
   better-sqlite3: true
   electron: true
   electron-winstaller: true
@@ -8,6 +9,7 @@ allowBuilds:
   simple-git-hooks: true
 minimumReleaseAgeExclude:
   - lxgw-wenkai-mono-gb-screen-webfont@1.0.1
+  - agent-browser@0.27.2
 shellEmulator: true
 packages:
   - packages/*


### PR DESCRIPTION
## Summary

- add `agent-browser@0.27.2` as a native `browser` tool
- use one persistent Ant Chat browser profile at `~/.ant-chat/browser/profile`
- serialize browser commands and propagate desktop and local-server proxy settings
- package only the target platform binary with Electron
- persist login state while requiring users to enter credentials directly in a headed browser

## Security

- execute the native binary without a shell
- allow only explicit browser commands and command-specific flags
- restrict navigation to HTTP and HTTPS URLs
- restrict screenshots, PDFs, and downloads to the workspace or browser artifacts directory
- block Auth Vault and password input commands
- allow named Chrome profiles only through an explicit `--profile <name>` argument

## Validation

- `pnpm check`
- real `agent-browser` flow: open `https://example.com`, read `Example Domain`, close browser
- changeset status checked

## Impact

Desktop releases include the matching agent-browser binary. Desktop and local-server runtimes expose the same persistent browser capability without adding a settings UI.