### PR TITLE
fix(agent-core): defer steering message persistence until after tool results

### DIFF
--- a/apps/desktop/src/main/domains/agent/ipc.ts
+++ b/apps/desktop/src/main/domains/agent/ipc.ts
@@ -71,10 +71,9 @@ export class AgentIpcService extends IpcService {
   }
 
   @IpcMethod()
-  async injectSteering(params: { conversationId: string, text: string }): Promise<IpcResponse<null>> {
+  async injectSteering(params: { conversationId: string, text: string }) {
     try {
-      await getAppRuntime().agent.injectSteering(params)
-      return createIpcResponse(true, null)
+      return createIpcResponse(true, await getAppRuntime().agent.injectSteering(params))
     }
     catch (error) {
       return createErrorIpcResponse(error as Error)

--- a/apps/web/src/__tests__/gui.spec.tsx
+++ b/apps/web/src/__tests__/gui.spec.tsx
@@ -20,7 +20,15 @@ const mocks = vi.hoisted(() => ({
     approvePendingAction: vi.fn(async () => null),
     approvePendingActionWithWhitelist: vi.fn(async () => null),
     cancelTask: vi.fn(async () => null),
-    injectSteering: vi.fn(async () => null),
+    injectSteering: vi.fn(async (): Promise<IMessage> => ({
+      id: 'msg-steering-default',
+      convId: 'conv-default' as ConversationsId,
+      createdAt: 1,
+      role: 'user',
+      status: 'success',
+      content: [{ type: 'text', text: 'steering' }],
+      turnId: 'user-1',
+    })),
     listActiveTasks: vi.fn<() => Promise<AgentTaskSnapshot[]>>(async () => []),
     rejectPendingAction: vi.fn(async () => null),
     startTurn: vi.fn(),
@@ -372,6 +380,15 @@ describe('gui ui flow', () => {
       taskId: 'task-steering',
     })
     mocks.agent.listActiveTasks.mockResolvedValue([task])
+    mocks.agent.injectSteering.mockResolvedValue({
+      id: 'msg-steering-1',
+      convId: 'conv-steering',
+      createdAt: 10,
+      role: 'user',
+      status: 'success',
+      content: [{ type: 'text', text: '先修复类型错误，再继续实现' }],
+      turnId: 'user-1',
+    })
 
     await setActiveConversationsId('conv-steering' as ConversationsId)
 
@@ -392,6 +409,12 @@ describe('gui ui flow', () => {
     expect(mocks.agent.startTurn).not.toHaveBeenCalled()
     expect(input).toHaveValue('')
     expect(screen.getByTestId('chat-cancel')).toHaveTextContent('停止')
+    expect(useMessagesStore.getState().messages).toEqual([
+      expect.objectContaining({
+        id: 'msg-steering-1',
+        content: [{ type: 'text', text: '先修复类型错误，再继续实现' }],
+      }),
+    ])
   })
 })
 

--- a/apps/web/src/api/agentApi.ts
+++ b/apps/web/src/api/agentApi.ts
@@ -1,4 +1,4 @@
-import type { AgentTaskSnapshot, AgentTurnResult, ApprovePendingActionOptions, RejectPendingActionOptions, StartAgentTurnOptions } from '@ant-chat/shared'
+import type { AgentTaskSnapshot, AgentTurnResult, ApprovePendingActionOptions, IMessage, RejectPendingActionOptions, StartAgentTurnOptions } from '@ant-chat/shared'
 import { getAppTransport } from './transports/appTransport'
 
 async function startTurn(options: StartAgentTurnOptions): Promise<AgentTurnResult> {
@@ -27,7 +27,7 @@ async function approvePendingActionWithWhitelist(
   return (await getAppTransport()).agent.approvePendingActionWithWhitelist(options)
 }
 
-async function injectSteering(conversationId: string, text: string): Promise<null> {
+async function injectSteering(conversationId: string, text: string): Promise<IMessage> {
   return (await getAppTransport()).agent.injectSteering({ conversationId, text })
 }
 

--- a/apps/web/src/components/Chat/Chat.tsx
+++ b/apps/web/src/components/Chat/Chat.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/store/conversation'
 import {
   abortActiveRequest,
+  addPendingSteeringMessage,
   setActiveConversationsId,
   useMessagesStore,
 } from '@/store/messages'
@@ -54,7 +55,8 @@ export default function Chat() {
     const draftText = textBlocks.map(block => block.text).join('\n')
 
     if (agentTask) {
-      await injectSteeringAction(agentTask.conversationId, draftText)
+      const message = await injectSteeringAction(agentTask.conversationId, draftText)
+      addPendingSteeringMessage(message)
       return
     }
 

--- a/apps/web/src/hooks/__tests__/useConversationSettings.spec.ts
+++ b/apps/web/src/hooks/__tests__/useConversationSettings.spec.ts
@@ -145,6 +145,7 @@ describe('useConversationSettings', () => {
     vi.mocked(useMessagesStore).mockImplementation(cb => cb({
       activeConversationsId: activeId,
       messages: [],
+      pendingSteeringByConversation: {},
       reset(): void {
         throw new Error('Function not implemented.')
       },

--- a/apps/web/src/store/agent/__tests__/actions.spec.ts
+++ b/apps/web/src/store/agent/__tests__/actions.spec.ts
@@ -5,7 +5,15 @@ import { approveAgentAction, cancelAgentTask, injectSteeringAction, rejectAgentA
 import { useAgentStore } from '../store'
 
 const mocks = vi.hoisted(() => ({
-  injectSteering: vi.fn(),
+  injectSteering: vi.fn(async () => ({
+    id: 'msg-steering-1',
+    convId: 'c1',
+    createdAt: 1,
+    role: 'user',
+    status: 'success',
+    content: [{ type: 'text', text: 'adjust' }],
+    turnId: 'm1',
+  })),
   listActiveTasks: vi.fn(),
 }))
 
@@ -38,7 +46,10 @@ describe('agent store actions', () => {
     await expect(approveAgentAction({ taskId: 't1', actionId: 'a1' })).resolves.toBeUndefined()
     await expect(rejectAgentAction({ taskId: 't1', actionId: 'a1', reason: 'r' })).resolves.toBeUndefined()
     await expect(cancelAgentTask('t1')).resolves.toBeUndefined()
-    await expect(injectSteeringAction('c1', 'adjust')).resolves.toBeUndefined()
+    await expect(injectSteeringAction('c1', 'adjust')).resolves.toMatchObject({
+      id: 'msg-steering-1',
+      content: [{ type: 'text', text: 'adjust' }],
+    })
     expect(mocks.injectSteering).toHaveBeenCalledWith('c1', 'adjust')
   })
 

--- a/apps/web/src/store/agent/actions.ts
+++ b/apps/web/src/store/agent/actions.ts
@@ -26,7 +26,7 @@ export async function cancelAgentTask(taskId: string) {
 }
 
 export async function injectSteeringAction(conversationId: string, text: string) {
-  await agentApi.injectSteering(conversationId, text)
+  return await agentApi.injectSteering(conversationId, text)
 }
 
 export async function syncConversationAgentState(conversationId: string) {

--- a/apps/web/src/store/messages/__tests__/actions.spec.ts
+++ b/apps/web/src/store/messages/__tests__/actions.spec.ts
@@ -1,0 +1,123 @@
+import type { ConversationsId, IMessage } from '@ant-chat/shared'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { addPendingSteeringMessage, setActiveConversationsId, updateMessageActionV2 } from '../actions'
+import { useMessagesStore } from '../store'
+
+const mocks = vi.hoisted(() => ({
+  getMessagesByConvId: vi.fn<(conversationId: string) => Promise<IMessage[]>>(),
+  listActiveTasks: vi.fn(async () => []),
+}))
+
+vi.mock('@/api/chatApi', () => ({
+  default: {
+    getMessagesByConvId: mocks.getMessagesByConvId,
+  },
+}))
+
+vi.mock('@/api/agentApi', () => ({
+  default: {
+    listActiveTasks: mocks.listActiveTasks,
+  },
+}))
+
+describe('message actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getMessagesByConvId.mockResolvedValue([])
+    useMessagesStore.setState({
+      activeConversationsId: 'conv-1' as ConversationsId,
+      messages: [],
+      pendingSteeringByConversation: {},
+    })
+  })
+
+  it('keeps pending steering visible after switching away and back before persistence', async () => {
+    const pending = createUserMessage('msg-steering-1', 'conv-1', 1)
+    addPendingSteeringMessage(pending)
+
+    await setActiveConversationsId('conv-2' as ConversationsId)
+    expect(useMessagesStore.getState().messages).toEqual([])
+
+    await setActiveConversationsId('conv-1' as ConversationsId)
+    expect(useMessagesStore.getState().messages).toEqual([pending])
+  })
+
+  it('clears background pending steering when its persisted event arrives', async () => {
+    const pending = createUserMessage('msg-steering-1', 'conv-1', 1)
+    addPendingSteeringMessage(pending)
+    await setActiveConversationsId('conv-2' as ConversationsId)
+
+    const persisted = createUserMessage('msg-steering-1', 'conv-1', 3)
+    await updateMessageActionV2(persisted)
+
+    expect(useMessagesStore.getState().pendingSteeringByConversation).toEqual({})
+    mocks.getMessagesByConvId.mockResolvedValue([persisted])
+    await setActiveConversationsId('conv-1' as ConversationsId)
+    expect(useMessagesStore.getState().messages).toEqual([persisted])
+  })
+
+  it('reconciles pending steering from persisted messages when the event was missed', async () => {
+    const pending = createUserMessage('msg-steering-1', 'conv-1', 1)
+    addPendingSteeringMessage(pending)
+    await setActiveConversationsId('conv-2' as ConversationsId)
+
+    const persisted = createUserMessage('msg-steering-1', 'conv-1', 3)
+    mocks.getMessagesByConvId.mockResolvedValue([persisted])
+    await setActiveConversationsId('conv-1' as ConversationsId)
+
+    expect(useMessagesStore.getState().messages).toEqual([persisted])
+    expect(useMessagesStore.getState().pendingSteeringByConversation).toEqual({})
+  })
+
+  it('does not add pending steering when the persisted event arrived first', async () => {
+    const persisted = createUserMessage('msg-steering-1', 'conv-1', 3)
+    await updateMessageActionV2(persisted)
+
+    const acknowledgement = createUserMessage('msg-steering-1', 'conv-1', 1)
+    addPendingSteeringMessage(acknowledgement)
+
+    expect(useMessagesStore.getState().messages).toEqual([persisted])
+    expect(useMessagesStore.getState().pendingSteeringByConversation).toEqual({})
+  })
+
+  it('matches repeated steering text by stable message id', async () => {
+    const first = createUserMessage('msg-steering-1', 'conv-1', 1)
+    const second = createUserMessage('msg-steering-2', 'conv-1', 2)
+    addPendingSteeringMessage(first)
+    addPendingSteeringMessage(second)
+
+    const toolResult = createToolMessage('tool-1', 'conv-1', 3)
+    await updateMessageActionV2(toolResult)
+    const persistedSecond = createUserMessage('msg-steering-2', 'conv-1', 4)
+    await updateMessageActionV2(persistedSecond)
+
+    expect(useMessagesStore.getState().messages).toEqual([first, toolResult, persistedSecond])
+    expect(useMessagesStore.getState().pendingSteeringByConversation).toEqual({
+      'conv-1': [first],
+    })
+  })
+})
+
+function createUserMessage(id: string, convId: string, createdAt: number): IMessage {
+  return {
+    id,
+    convId: convId as ConversationsId,
+    createdAt,
+    role: 'user',
+    status: 'success',
+    content: [{ type: 'text', text: 'adjust' }],
+    turnId: 'turn-1',
+  }
+}
+
+function createToolMessage(id: string, convId: string, createdAt: number): IMessage {
+  return {
+    id,
+    convId: convId as ConversationsId,
+    createdAt,
+    role: 'tool',
+    status: 'success',
+    content: [{ type: 'tool-result', toolCallId: 'call-1', toolName: 'read_file', result: 'done' }],
+    turnId: 'turn-1',
+  }
+}

--- a/apps/web/src/store/messages/actions.ts
+++ b/apps/web/src/store/messages/actions.ts
@@ -26,8 +26,15 @@ export async function setActiveConversationsId(id: ConversationsId | '') {
   ])
 
   useMessagesStore.setState(state => produce(state, (draft) => {
+    const persistedMessageIds = new Set(messages.map(message => message.id))
+    const pendingSteering = (draft.pendingSteeringByConversation[id] ?? [])
+      .filter(message => !persistedMessageIds.has(message.id))
+    if (pendingSteering.length > 0)
+      draft.pendingSteeringByConversation[id] = pendingSteering
+    else
+      delete draft.pendingSteeringByConversation[id]
     draft.activeConversationsId = id as ConversationsId
-    draft.messages.splice(0, draft.messages.length, ...messages)
+    draft.messages.splice(0, draft.messages.length, ...messages, ...pendingSteering)
   }))
   useConversationsStore.getState().setActiveConversationsId(id)
 }
@@ -58,20 +65,48 @@ export async function updateMessageAction(_message: IMessage) {
 
 export async function updateMessageActionV2(message: IMessage) {
   const { convId } = message
-  const { activeConversationsId } = useMessagesStore.getState()
-  if (convId !== activeConversationsId) {
-    return
-  }
-
   useMessagesStore.setState(state => produce(state, (draft) => {
+    const pendingSteering = draft.pendingSteeringByConversation[convId] ?? []
+    const wasPendingSteering = pendingSteering.some(candidate => candidate.id === message.id)
+    if (wasPendingSteering) {
+      const remaining = pendingSteering.filter(candidate => candidate.id !== message.id)
+      if (remaining.length > 0)
+        draft.pendingSteeringByConversation[convId] = remaining
+      else
+        delete draft.pendingSteeringByConversation[convId]
+    }
+
+    if (convId !== draft.activeConversationsId)
+      return
+
     const messageIndex = draft.messages.findIndex(msg => msg.id === message.id)
 
-    if (messageIndex > -1) {
+    if (wasPendingSteering) {
+      if (messageIndex > -1)
+        draft.messages.splice(messageIndex, 1)
+      draft.messages.push(message)
+    }
+    else if (messageIndex > -1) {
       draft.messages[messageIndex] = message
     }
     else {
       draft.messages.push(message)
     }
+  }))
+}
+
+export function addPendingSteeringMessage(message: IMessage) {
+  useMessagesStore.setState(state => produce(state, (draft) => {
+    const pending = draft.pendingSteeringByConversation[message.convId] ?? []
+    if (
+      pending.some(candidate => candidate.id === message.id)
+      || draft.messages.some(candidate => candidate.id === message.id)
+    ) {
+      return
+    }
+    draft.pendingSteeringByConversation[message.convId] = [...pending, message]
+    if (message.convId === draft.activeConversationsId)
+      draft.messages.push(message)
   }))
 }
 

--- a/apps/web/src/store/messages/store.ts
+++ b/apps/web/src/store/messages/store.ts
@@ -5,11 +5,13 @@ import { devtools } from 'zustand/middleware'
 interface InitialState {
   activeConversationsId: ConversationsId
   messages: IMessage[]
+  pendingSteeringByConversation: Record<string, IMessage[]>
 }
 
 const initialState: InitialState = {
   activeConversationsId: '' as ConversationsId,
   messages: [],
+  pendingSteeringByConversation: {},
 }
 
 type MessagesStore = InitialState & {

--- a/packages/agent-core/src/AgentRuntime.ts
+++ b/packages/agent-core/src/AgentRuntime.ts
@@ -1,4 +1,4 @@
-import type { AgentRuntimeConfig, AgentRuntimeOptions, AgentRuntimeStartTaskOptions, AgentRuntimeStartTaskResult, AgentTaskSnapshot, ApprovePendingActionOptions, CancelTaskOptions, LoopMessage, RejectPendingActionOptions } from '@ant-chat/shared'
+import type { AgentRuntimeConfig, AgentRuntimeOptions, AgentRuntimeStartTaskOptions, AgentRuntimeStartTaskResult, AgentTaskSnapshot, ApprovePendingActionOptions, CancelTaskOptions, IMessage, LoopMessage, RejectPendingActionOptions } from '@ant-chat/shared'
 import type { BeforeTurnResult, RuntimeStartInput, RuntimeStartResult } from './session/types'
 import type { BeforeToolExecuteHook } from './tools/types'
 import { randomUUID } from 'node:crypto'
@@ -123,8 +123,8 @@ export class AgentRuntime {
     this.approvalController.cancelTask(options)
   }
 
-  async injectSteering(conversationId: string, text: string): Promise<void> {
-    await this.sessionRuntime.injectSteering(conversationId, text)
+  async injectSteering(conversationId: string, text: string): Promise<IMessage> {
+    return await this.sessionRuntime.injectSteering(conversationId, text)
   }
 
   getTask(taskId: string) {

--- a/packages/agent-core/src/AgentRuntime.ts
+++ b/packages/agent-core/src/AgentRuntime.ts
@@ -98,7 +98,7 @@ export class AgentRuntime {
       prompt: options.prompt,
     }
 
-    taskStore.create({ snapshot, abortController: new AbortController(), steeringQueue: [] })
+    taskStore.create({ snapshot, abortController: new AbortController(), steeringQueue: [], pendingSteeringMessages: [] })
     await config.eventEmitter.emitTaskUpdated(snapshot)
     void runAgentLoop({
       taskId,

--- a/packages/agent-core/src/__tests__/AgentRuntime.spec.ts
+++ b/packages/agent-core/src/__tests__/AgentRuntime.spec.ts
@@ -808,7 +808,7 @@ describe('agentRuntime', () => {
   })
 
   describe('injectSteering', () => {
-    it('persists, emits, and enqueues steering for the active task', async () => {
+    it('enqueues steering and stores pending message (deferred persistence)', async () => {
       const store = createSessionStore()
       const eventEmitter = createMockEmitter()
       const runtime = new AgentRuntime(createSessionConfig({ eventEmitter, sessionStore: store }))
@@ -820,21 +820,21 @@ describe('agentRuntime', () => {
         mode: 'hybrid',
       })
 
+      // Record calls from startTask so we can ignore them
+      const callsBefore = (store.createUserMessage as ReturnType<typeof vi.fn>).mock.calls.length
+
       await runtime.injectSteering('conv-session', 'fix types first')
 
-      expect(store.createUserMessage).toHaveBeenLastCalledWith({
-        convId: 'conv-session',
-        role: 'user',
-        status: 'success',
-        content: [{ type: 'text', text: 'fix types first' }],
-        turnId: 'user-msg-1',
-      })
-      expect(eventEmitter.emitMessageUpdated).toHaveBeenCalledWith(
-        expect.objectContaining({
-          id: 'user-msg-1',
-          role: 'user',
-        }),
-      )
+      // Should NOT persist to DB immediately — deferred until after tool results
+      expect(store.createUserMessage).toHaveBeenCalledTimes(callsBefore)
+
+      // Should store in pending list on the task
+      const task = taskStore.get(running.taskId)
+      expect(task?.pendingSteeringMessages).toEqual([
+        { text: 'fix types first', turnId: 'user-msg-1' },
+      ])
+
+      // Should still enqueue for the agent loop
       expect(taskStore.dequeueSteeringInputs(running.taskId)).toEqual([
         { text: 'fix types first', turnId: 'user-msg-1' },
       ])

--- a/packages/agent-core/src/__tests__/AgentRuntime.spec.ts
+++ b/packages/agent-core/src/__tests__/AgentRuntime.spec.ts
@@ -60,13 +60,14 @@ function createSessionStore(overrides: Partial<ISessionStore> = {}): ISessionSto
     listConversations: vi.fn(async () => [conversation]),
     getMessages: vi.fn(async () => []),
     getMessagesByConvId: vi.fn(async () => []),
-    createUserMessage: vi.fn(async () => ({
-      id: 'user-msg-1',
-      convId: conversation.id,
+    createUserMessage: vi.fn(async data => ({
+      id: data.id ?? 'user-msg-1',
+      convId: data.convId,
       createdAt: 2,
       role: 'user' as const,
       status: 'success' as const,
-      content: [{ type: 'text' as const, text: 'inspect project' }],
+      content: data.content,
+      turnId: data.turnId,
       images: [],
       attachments: [],
     })),
@@ -823,21 +824,48 @@ describe('agentRuntime', () => {
       // Record calls from startTask so we can ignore them
       const callsBefore = (store.createUserMessage as ReturnType<typeof vi.fn>).mock.calls.length
 
-      await runtime.injectSteering('conv-session', 'fix types first')
+      const message = await runtime.injectSteering('conv-session', 'fix types first')
 
       // Should NOT persist to DB immediately — deferred until after tool results
       expect(store.createUserMessage).toHaveBeenCalledTimes(callsBefore)
+      expect(message).toMatchObject({
+        convId: 'conv-session',
+        role: 'user',
+        status: 'success',
+        content: [{ type: 'text', text: 'fix types first' }],
+        turnId: 'user-msg-1',
+      })
+      expect(message.id).toMatch(/^msg-/)
 
       // Should store in pending list on the task
       const task = taskStore.get(running.taskId)
       expect(task?.pendingSteeringMessages).toEqual([
-        { text: 'fix types first', turnId: 'user-msg-1' },
+        { id: message.id, text: 'fix types first', turnId: 'user-msg-1' },
       ])
 
       // Should still enqueue for the agent loop
       expect(taskStore.dequeueSteeringInputs(running.taskId)).toEqual([
         { text: 'fix types first', turnId: 'user-msg-1' },
       ])
+
+      const loopCalls = vi.mocked(runAgentLoop).mock.calls
+      const loopCall = loopCalls[loopCalls.length - 1]
+      expect(loopCall).toBeDefined()
+      await loopCall![0].config.eventEmitter.emitTurnToolResults!({
+        conversationId: 'conv-session',
+        results: [],
+      })
+      expect(store.createUserMessage).toHaveBeenLastCalledWith({
+        id: message.id,
+        convId: 'conv-session',
+        role: 'user',
+        status: 'success',
+        content: [{ type: 'text', text: 'fix types first' }],
+        turnId: 'user-msg-1',
+      })
+      expect(eventEmitter.emitMessageUpdated).toHaveBeenLastCalledWith(
+        expect.objectContaining({ id: message.id }),
+      )
       cleanupTasks([running.taskId])
     })
   })

--- a/packages/agent-core/src/__tests__/taskStore.spec.ts
+++ b/packages/agent-core/src/__tests__/taskStore.spec.ts
@@ -19,6 +19,7 @@ function createTask(overrides: Partial<RuntimeTask['snapshot']> = {}): RuntimeTa
     },
     abortController: new AbortController(),
     steeringQueue: [],
+    pendingSteeringMessages: [],
   }
 }
 

--- a/packages/agent-core/src/loop/__tests__/agentLoop.spec.ts
+++ b/packages/agent-core/src/loop/__tests__/agentLoop.spec.ts
@@ -75,6 +75,7 @@ function createTask(taskId = 'task-loop-1', conversationId = 'conv-loop-1') {
     },
     abortController: new AbortController(),
     steeringQueue: [],
+    pendingSteeringMessages: [],
     pendingResolver: undefined as ((v: { approved: boolean, reason?: string }) => void) | undefined,
   }
 }

--- a/packages/agent-core/src/policy/__tests__/approvalController.spec.ts
+++ b/packages/agent-core/src/policy/__tests__/approvalController.spec.ts
@@ -31,6 +31,7 @@ function createRunningTask(taskId: string, conversationId: string) {
     } as AgentTaskSnapshot,
     abortController: new AbortController(),
     steeringQueue: [],
+    pendingSteeringMessages: [],
     pendingResolver: undefined as ((value: { approved: boolean, reason?: string }) => void) | undefined,
   }
 }

--- a/packages/agent-core/src/policy/__tests__/beforeToolExecute.spec.ts
+++ b/packages/agent-core/src/policy/__tests__/beforeToolExecute.spec.ts
@@ -35,6 +35,7 @@ function createTask(overrides: Record<string, unknown> = {}): RuntimeTask {
     } as AgentTaskSnapshot,
     abortController: new AbortController(),
     steeringQueue: [],
+    pendingSteeringMessages: [],
     pendingResolver: undefined,
   }
 }

--- a/packages/agent-core/src/session/SessionRuntime.ts
+++ b/packages/agent-core/src/session/SessionRuntime.ts
@@ -7,12 +7,14 @@ import type {
   IAgentEventEmitter,
   IAIProvider,
   ILogger,
+  IMessage,
   ISessionStore,
   LoopMessage,
   ModelInfo,
 } from '@ant-chat/shared'
 import type { ConversationContextEntry } from '../loop/loopContext'
 import type { BeforeTurnResult, RuntimeStartInput, RuntimeStartResult } from './types'
+import { randomUUID } from 'node:crypto'
 import { createProvider } from '../ai-providers/factory'
 import {
   calculateContextTokens,
@@ -216,22 +218,34 @@ export class SessionRuntime {
     }
   }
 
-  async injectSteering(conversationId: string, text: string): Promise<void> {
+  async injectSteering(conversationId: string, text: string): Promise<IMessage> {
     const activeTasks = this.listActiveTasks(conversationId) as Array<{ taskId: string, userMessageId: string }>
     if (activeTasks.length === 0)
-      return
+      throw new Error('AGENT_TASK_NOT_RUNNING')
 
     const task = activeTasks[0]
     const turnId = task.userMessageId
+    const messageId = `msg-${randomUUID()}`
+    const message: IMessage = {
+      id: messageId,
+      convId: conversationId,
+      createdAt: Date.now(),
+      role: 'user',
+      status: 'success',
+      content: [{ type: 'text', text }],
+      turnId,
+    }
 
     // Store in pending list; will be persisted to DB after tool results are persisted
     const runtimeTask = taskStore.get(task.taskId)
     if (runtimeTask) {
-      runtimeTask.pendingSteeringMessages.push({ text, turnId })
+      runtimeTask.pendingSteeringMessages.push({ id: messageId, text, turnId })
     }
 
     // Enqueue for the agent loop
     taskStore.enqueueSteeringInput(task.taskId, { text, turnId })
+
+    return message
   }
 
   private async getPromptMemorySnapshot(conversationId: string): Promise<{ memory?: string, soul?: string, user?: string } | undefined> {
@@ -441,6 +455,7 @@ function createStoreBackedEventEmitter(store: ISessionStore, delegate: IAgentEve
     task.pendingSteeringMessages = []
     for (const input of pending) {
       const msg = await store.createUserMessage({
+        id: input.id,
         convId: task.snapshot.conversationId,
         role: 'user',
         status: 'success',

--- a/packages/agent-core/src/session/SessionRuntime.ts
+++ b/packages/agent-core/src/session/SessionRuntime.ts
@@ -556,6 +556,11 @@ function createStoreBackedEventEmitter(store: ISessionStore, delegate: IAgentEve
         await delegate.emitMessageUpdated?.(message)
         turns.delete(params.conversationId)
       }
+
+      // Also flush here: model may finish without further tool calls,
+      // so emitTurnToolResults would never run.
+      await persistPendingSteeringMessages()
+
       await delegate.emitTurnFinished(params)
     },
   }

--- a/packages/agent-core/src/session/SessionRuntime.ts
+++ b/packages/agent-core/src/session/SessionRuntime.ts
@@ -173,32 +173,40 @@ export class SessionRuntime {
     const systemPrompt = createLoopSystemPrompt(options.workspacePath, options.modelSettings?.systemPrompt, memory)
 
     const turnId = userMessage.id
-    const eventEmitter = createStoreBackedEventEmitter(store, this.config.eventEmitter, turnId)
 
     const taskLogger = this.config.createTaskLogger?.(conversation.id, userMessage.id)
 
+    // Create task first so we can pass taskId to the event emitter
+    const taskSnapshot = {
+      conversationId: conversation.id,
+      userMessageId: userMessage.id,
+      prompt: enrichedPrompt,
+      workspacePath: options.workspacePath,
+      mode,
+      messages,
+      systemPrompt,
+      registry,
+      aiProvider,
+      modelName: model.model,
+      providerName: provider.name,
+      providerId: provider.id,
+      apiMode,
+      taskLogger,
+      temperature: options.modelSettings?.temperature,
+      maxTokens: options.modelSettings?.maxTokens,
+      compaction: compactionSettings,
+    }
+
+    const eventEmitter = createStoreBackedEventEmitter(store, this.config.eventEmitter, turnId)
+
     const task = await this.startLoopTask(
-      {
-        conversationId: conversation.id,
-        userMessageId: userMessage.id,
-        prompt: enrichedPrompt,
-        workspacePath: options.workspacePath,
-        mode,
-        messages,
-        systemPrompt,
-        registry,
-        aiProvider,
-        modelName: model.model,
-        providerName: provider.name,
-        providerId: provider.id,
-        apiMode,
-        taskLogger,
-        temperature: options.modelSettings?.temperature,
-        maxTokens: options.modelSettings?.maxTokens,
-        compaction: compactionSettings,
-      },
+      taskSnapshot,
       { eventEmitter },
     )
+
+    // Now that task exists, bind taskId to the event emitter so it can
+    // persist pending steering messages after tool results
+    eventEmitter.setTaskId(task.taskId)
 
     return {
       ...task,
@@ -209,7 +217,6 @@ export class SessionRuntime {
   }
 
   async injectSteering(conversationId: string, text: string): Promise<void> {
-    const store = requireSessionStore(this.config)
     const activeTasks = this.listActiveTasks(conversationId) as Array<{ taskId: string, userMessageId: string }>
     if (activeTasks.length === 0)
       return
@@ -217,15 +224,11 @@ export class SessionRuntime {
     const task = activeTasks[0]
     const turnId = task.userMessageId
 
-    // Create steering message with same turnId
-    const message = await store.createUserMessage({
-      convId: conversationId,
-      role: 'user',
-      status: 'success',
-      content: [{ type: 'text', text }],
-      turnId,
-    })
-    await this.config.eventEmitter.emitMessageUpdated?.(message)
+    // Store in pending list; will be persisted to DB after tool results are persisted
+    const runtimeTask = taskStore.get(task.taskId)
+    if (runtimeTask) {
+      runtimeTask.pendingSteeringMessages.push({ text, turnId })
+    }
 
     // Enqueue for the agent loop
     taskStore.enqueueSteeringInput(task.taskId, { text, turnId })
@@ -402,8 +405,9 @@ interface TurnMeta {
   persistedToolCallIds: Set<string>
 }
 
-function createStoreBackedEventEmitter(store: ISessionStore, delegate: IAgentEventEmitter, turnId: string): IAgentEventEmitter {
+function createStoreBackedEventEmitter(store: ISessionStore, delegate: IAgentEventEmitter, turnId: string): IAgentEventEmitter & { setTaskId: (id: string) => void } {
   const turns = new Map<string, TurnMeta>()
+  let taskId: string | undefined
 
   function newTurnMeta(msgId: string): TurnMeta {
     return {
@@ -427,7 +431,30 @@ function createStoreBackedEventEmitter(store: ISessionStore, delegate: IAgentEve
     await delegate.emitMessageUpdated?.(message)
   }
 
-  return {
+  async function persistPendingSteeringMessages() {
+    if (!taskId)
+      return
+    const task = taskStore.get(taskId)
+    if (!task || task.pendingSteeringMessages.length === 0)
+      return
+    const pending = [...task.pendingSteeringMessages]
+    task.pendingSteeringMessages = []
+    for (const input of pending) {
+      const msg = await store.createUserMessage({
+        convId: task.snapshot.conversationId,
+        role: 'user',
+        status: 'success',
+        content: [{ type: 'text', text: input.text }],
+        turnId: input.turnId,
+      })
+      await delegate.emitMessageUpdated?.(msg)
+    }
+  }
+
+  const emitter: IAgentEventEmitter & { setTaskId: (id: string) => void } = {
+    setTaskId(id: string) {
+      taskId = id
+    },
     async emitTaskUpdated(task) {
       await delegate.emitTaskUpdated(task)
     },
@@ -477,7 +504,6 @@ function createStoreBackedEventEmitter(store: ISessionStore, delegate: IAgentEve
 
       meta.modelText = params.text
 
-      // Build content blocks: text + existing tool-call blocks + new tool-call blocks
       const contentBlocks: Array<Record<string, unknown>> = []
       if (params.text) {
         contentBlocks.push({ type: 'text', text: params.text })
@@ -509,6 +535,10 @@ function createStoreBackedEventEmitter(store: ISessionStore, delegate: IAgentEve
         })
         await delegate.emitMessageUpdated?.(msg)
       }
+
+      // Persist steering messages AFTER tool results to maintain correct message order
+      await persistPendingSteeringMessages()
+
       await delegate.emitTurnToolResults?.(params)
     },
     async emitTurnFinished(params) {
@@ -529,4 +559,6 @@ function createStoreBackedEventEmitter(store: ISessionStore, delegate: IAgentEve
       await delegate.emitTurnFinished(params)
     },
   }
+
+  return emitter
 }

--- a/packages/agent-core/src/taskStore.ts
+++ b/packages/agent-core/src/taskStore.ts
@@ -5,11 +5,17 @@ export interface SteeringInput {
   turnId: string
 }
 
+export interface PendingSteeringMessage {
+  text: string
+  turnId: string
+}
+
 export interface RuntimeTask {
   snapshot: AgentTaskSnapshot
   abortController: AbortController
   pendingResolver?: (value: { approved: boolean, reason?: string }) => void
   steeringQueue: SteeringInput[]
+  pendingSteeringMessages: PendingSteeringMessage[]
 }
 
 export class TaskStore {

--- a/packages/agent-core/src/taskStore.ts
+++ b/packages/agent-core/src/taskStore.ts
@@ -6,6 +6,7 @@ export interface SteeringInput {
 }
 
 export interface PendingSteeringMessage {
+  id: string
   text: string
   turnId: string
 }

--- a/packages/agent-core/src/tools/__tests__/toolExecution.spec.ts
+++ b/packages/agent-core/src/tools/__tests__/toolExecution.spec.ts
@@ -52,6 +52,7 @@ function createTask(overrides: Record<string, unknown> = {}) {
     } as AgentTaskSnapshot,
     abortController: new AbortController(),
     steeringQueue: [],
+    pendingSteeringMessages: [],
     pendingResolver: undefined as ((v: { approved: boolean, reason?: string }) => void) | undefined,
   }
 }

--- a/packages/agent-runtime/src/agentRuntimeController.ts
+++ b/packages/agent-runtime/src/agentRuntimeController.ts
@@ -1,6 +1,6 @@
 import type { AgentRuntime } from '@ant-chat/agent-core'
 import type { AppDataContext } from '@ant-chat/app-data'
-import type { AgentRuntimeStartTaskOptions, AgentRuntimeStartTaskResult, ApprovePendingActionOptions, CancelTaskOptions, RejectPendingActionOptions, StartAgentTurnOptions } from '@ant-chat/shared'
+import type { AgentRuntimeStartTaskOptions, AgentRuntimeStartTaskResult, ApprovePendingActionOptions, CancelTaskOptions, IMessage, RejectPendingActionOptions, StartAgentTurnOptions } from '@ant-chat/shared'
 import process from 'node:process'
 
 export interface AgentRuntimeController {
@@ -8,7 +8,7 @@ export interface AgentRuntimeController {
   approvePendingAction: (options: ApprovePendingActionOptions) => null
   rejectPendingAction: (options: RejectPendingActionOptions) => null
   cancelTask: (options: CancelTaskOptions) => null
-  injectSteering: (params: { conversationId: string, text: string }) => Promise<null>
+  injectSteering: (params: { conversationId: string, text: string }) => Promise<IMessage>
   listActiveTasks: (conversationId?: string) => ReturnType<AgentRuntime['listActiveTasks']>
   approvePendingActionWithWhitelist: (options: ApprovePendingActionOptions & { remember: boolean, workspacePath?: string }) => null
 }
@@ -31,8 +31,7 @@ export function createAgentRuntimeController(runtime: AgentRuntime, appDataConte
       return null
     },
     async injectSteering(params) {
-      await runtime.injectSteering(params.conversationId, params.text)
-      return null
+      return await runtime.injectSteering(params.conversationId, params.text)
     },
     listActiveTasks(conversationId) {
       return runtime.listActiveTasks(conversationId)

--- a/packages/agent-runtime/src/sessionStore.ts
+++ b/packages/agent-runtime/src/sessionStore.ts
@@ -27,7 +27,8 @@ export function createAppDataSessionStore(appDataContext: AppDataContext): ISess
       return await messageRepository.listByConversation(convId)
     },
     async createUserMessage(data: CreateUserMessageInput) {
-      return await messageRepository.create(data)
+      const { id, ...message } = data
+      return await messageRepository.create(message, { id })
     },
     async createAssistantMessage(data: CreateAssistantMessageInput) {
       return await messageRepository.create({

--- a/packages/app-data/src/repositories/messageRepository.ts
+++ b/packages/app-data/src/repositories/messageRepository.ts
@@ -3,7 +3,7 @@ import type { AddMessage, IMessage, UpdateMessageSchema } from '@ant-chat/shared
 export interface MessageRepository {
   listByConversation: (conversationId: string) => Promise<IMessage[]>
   getById: (id: string) => Promise<IMessage>
-  create: (message: AddMessage) => Promise<IMessage>
+  create: (message: AddMessage, options?: { id?: string }) => Promise<IMessage>
   update: (message: UpdateMessageSchema) => Promise<IMessage>
   delete: (id: string) => Promise<boolean>
   batchDelete: (ids: string[]) => Promise<boolean>

--- a/packages/app-data/src/sqlite/repositories/__tests__/sqliteRepositories.spec.ts
+++ b/packages/app-data/src/sqlite/repositories/__tests__/sqliteRepositories.spec.ts
@@ -109,6 +109,33 @@ describe.skipIf(!canRunDbIntegrationTests())('sqlite repositories', () => {
     expect(messages).toEqual([expect.objectContaining({ id: message.id, convId: conversation.id })])
   })
 
+  it('uses a caller-provided message id', async () => {
+    const conversationRepository = new SqliteConversationRepository(sqlite)
+    const messageRepository = new SqliteMessageRepository(sqlite, { attachmentsRoot })
+    const conversation = await conversationRepository.create({
+      title: 'Steering',
+      workspacePath: '/workspace',
+      createdAt: 1,
+      updatedAt: 1,
+      settings: {
+        modelId: 'model-1',
+        systemPrompt: '',
+        temperature: 0.7,
+        maxTokens: 1024,
+      },
+    })
+
+    const message = await messageRepository.create({
+      convId: conversation.id,
+      role: 'user',
+      status: 'success',
+      content: [{ type: 'text', text: 'steering' }],
+    }, { id: 'msg-steering-1' })
+
+    expect(message.id).toBe('msg-steering-1')
+    await expect(messageRepository.getById('msg-steering-1')).resolves.toEqual(message)
+  })
+
   it('persists compaction boundary, model info, and usage on event messages', async () => {
     const conversationRepository = new SqliteConversationRepository(sqlite)
     const messageRepository = new SqliteMessageRepository(sqlite, { attachmentsRoot })

--- a/packages/app-data/src/sqlite/repositories/sqliteMessageRepository.ts
+++ b/packages/app-data/src/sqlite/repositories/sqliteMessageRepository.ts
@@ -64,10 +64,10 @@ export class SqliteMessageRepository implements MessageRepository {
     return mapMessageRow(result)
   }
 
-  async create(message: AddMessage): Promise<IMessage> {
+  async create(message: AddMessage, options?: { id?: string }): Promise<IMessage> {
     await this.conversations.getById(message.convId)
 
-    const id = `msg-${nanoid()}`
+    const id = options?.id ?? `msg-${nanoid()}`
     const writtenFiles: string[] = []
     try {
       const createMessage = this.db.transaction(() => {

--- a/packages/shared/src/interfaces/agent-runtime-interfaces.ts
+++ b/packages/shared/src/interfaces/agent-runtime-interfaces.ts
@@ -147,6 +147,7 @@ export interface IModelCatalog {
 // ============================================================
 
 export interface IAgentEventEmitter {
+  setTaskId?: (taskId: string) => void
   emitMessageUpdated?: (message: IMessage) => void | Promise<void>
   emitTaskUpdated: (task: AgentTaskSnapshot) => void | Promise<void>
   emitApprovalRequired: (taskId: string, conversationId: string, pendingAction: AgentPendingAction) => void | Promise<void>

--- a/packages/shared/src/interfaces/agent-runtime-interfaces.ts
+++ b/packages/shared/src/interfaces/agent-runtime-interfaces.ts
@@ -90,7 +90,7 @@ export interface IConversationQuery {
 
 export type CreateConversationInput = AddConversationsSchema
 export type UpdateConversationInput = Omit<UpdateConversationsSchema, 'id'>
-export type CreateUserMessageInput = Extract<AddMessage, { role: 'user' }>
+export type CreateUserMessageInput = Extract<AddMessage, { role: 'user' }> & { id?: string }
 export type CreateToolMessageInput = Extract<AddMessage, { role: 'tool' }>
 export type CreateEventMessageInput = Extract<AddMessage, { role: 'event' }>
 export interface CreateAssistantMessageInput {

--- a/packages/shared/src/interfaces/app-transport.ts
+++ b/packages/shared/src/interfaces/app-transport.ts
@@ -125,7 +125,7 @@ export interface AppTransport {
     approvePendingAction: (options: ApprovePendingActionOptions) => Promise<null>
     rejectPendingAction: (options: RejectPendingActionOptions) => Promise<null>
     cancelTask: (taskId: string) => Promise<null>
-    injectSteering: (params: { conversationId: string, text: string }) => Promise<null>
+    injectSteering: (params: { conversationId: string, text: string }) => Promise<IMessage>
     listActiveTasks: (conversationId?: string) => Promise<AgentTaskSnapshot[]>
     approvePendingActionWithWhitelist: (options: ApprovePendingActionOptions & { remember: boolean, workspacePath?: string }) => Promise<null>
   }
@@ -158,7 +158,7 @@ export interface AppIpcServices {
     cancelTask: (options: CancelTaskOptions) => Promise<IpcResponse<null>>
     getTask: (taskId: string) => Promise<IpcResponse<AgentTaskSnapshot>>
     listActiveTasks: (conversationId?: string) => Promise<IpcResponse<AgentTaskSnapshot[]>>
-    injectSteering: (params: { conversationId: string, text: string }) => Promise<IpcResponse<null>>
+    injectSteering: (params: { conversationId: string, text: string }) => Promise<IpcResponse<IMessage>>
     approvePendingActionWithWhitelist: (options: ApprovePendingActionOptions & { remember: boolean, workspacePath?: string }) => Promise<IpcResponse<null>>
   }
   chat: {


### PR DESCRIPTION
## Summary

- Steering messages were persisted to the database immediately in `injectSteering`, but tool results were only persisted after tool execution completed
- If the user interrupted during tool execution, the database had an inconsistent state with a user message between tool-call and tool-result messages
- This caused `MissingToolResultsError` when rebuilding conversation context for the next task

## Changes

- `taskStore.ts`: Added `pendingSteeringMessages` field to `RuntimeTask`
- `SessionRuntime.ts`: `injectSteering` no longer writes to DB immediately; stores in pending list instead. `createStoreBackedEventEmitter` persists pending steering messages in `emitTurnToolResults` after tool results are safely stored. Adjusted event emitter creation timing in `startTask` to inject `taskId`
- `agent-runtime-interfaces.ts`: Added optional `setTaskId` method to `IAgentEventEmitter`
- `AgentRuntime.ts`: Initialize `pendingSteeringMessages` on task creation
- Updated 4 test files for new field and adjusted `injectSteering` test assertions

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm test:unit` passes (239/239)