### PR TITLE
fix(agent-core): only pass --content-boundaries to browser open command

### DIFF
--- a/packages/agent-core/src/native-tools/tools/browserRunner.ts
+++ b/packages/agent-core/src/native-tools/tools/browserRunner.ts
@@ -201,7 +201,7 @@ async function executeBrowserTool(
     ...profileArgs,
     '--session',
     SESSION_NAME,
-    '--content-boundaries',
+    ...(command === 'open' ? ['--content-boundaries'] : []),
     ...globalArgs,
     ...command.split(' '),
     ...normalizeOutputPaths(command, commandArgs, options.workspacePath),


### PR DESCRIPTION
## Summary
- Fix browser window closing after second tool call in agent loop
- The `--content-boundaries` flag was incorrectly passed to all browser commands including `snapshot`, causing the browser to navigate to `about:blank` and close the window

## Root Cause
In `browserRunner.ts`, `--content-boundaries` was hardcoded for every command. This flag is only meaningful for the `open` command. When passed to `snapshot`, it caused agent-browser to navigate to a blank page and close the window.

## Fix
Conditionally include `--content-boundaries` only for the `open` command:
```ts
...(command === 'open' ? ['--content-boundaries'] : []),
```

## Testing
Verified manually that:
1. `open --headed` still loads pages correctly
2. `snapshot` now returns actual page content instead of `about:blank`
3. Browser window stays open across multiple tool calls