### PR TITLE
refactor: 统一事件系统架构

### DIFF
--- a/apps/desktop/src/main/runtime/electronAppRuntimeEvents.ts
+++ b/apps/desktop/src/main/runtime/electronAppRuntimeEvents.ts
@@ -1,24 +1,25 @@
 import type { AppRuntime } from '@ant-chat/app-runtime'
+import type { IpcRendererEvent } from '@ant-chat/shared'
 import { sendToRenderer } from '@main/utils/ipc-events'
 import { getSettingsWindow } from '@main/windows/settings-window'
 import { getMainWindow } from '@main/windows/window'
 
 export function attachAppRuntimeEvents(runtime: AppRuntime): void {
-  function ipc(channel: string, ...data: unknown[]) {
+  function ipc<T extends keyof IpcRendererEvent & string>(channel: T, payload: IpcRendererEvent[T]) {
     const win = getMainWindow()
     if (!win)
       return
-    sendToRenderer(win.webContents, channel, ...data)
+    sendToRenderer(win.webContents, channel, payload)
   }
 
-  runtime.events.on('message.updated', ({ message }) => ipc('message:updated', message))
-  runtime.events.on('agent.task.updated', ({ task }) => ipc('agent:state-updated', { task }))
-  runtime.events.on('agent.approval.required', event => ipc('agent:approval-required', event))
-  runtime.events.on('workspace.changed', event => ipc('workspace:changed', event))
-  runtime.events.on('provider.changed', () => ipc('provider:changed'))
-  runtime.events.on('mcp.connection.changed', event =>
-    ipc('mcp:McpServerStatusChanged', event.serverName, event.status))
-  runtime.events.on('settings.changed', (event) => {
+  runtime.events.on('conversation:updated', event => ipc('conversation:updated', event))
+  runtime.events.on('message:updated', event => ipc('message:updated', event))
+  runtime.events.on('agent:task-updated', event => ipc('agent:task-updated', event))
+  runtime.events.on('agent:approval-required', event => ipc('agent:approval-required', event))
+  runtime.events.on('workspace:changed', event => ipc('workspace:changed', event))
+  runtime.events.on('provider:changed', event => ipc('provider:changed', event))
+  runtime.events.on('mcp:status-changed', event => ipc('mcp:status-changed', event))
+  runtime.events.on('settings:updated', (event) => {
     ipc('settings:updated', event)
     const settingsWindow = getSettingsWindow()
     if (settingsWindow && !settingsWindow.isDestroyed())

--- a/apps/desktop/src/main/utils/ipc-events.ts
+++ b/apps/desktop/src/main/utils/ipc-events.ts
@@ -4,7 +4,7 @@ import type { WebContents } from 'electron'
 export function sendToRenderer<T extends keyof IpcRendererEvent & string>(
   webContents: WebContents,
   channel: T,
-  ...args: IpcRendererEvent[T]
+  payload: IpcRendererEvent[T],
 ) {
-  webContents.send(channel, ...args)
+  webContents.send(channel, payload)
 }

--- a/apps/web/src/api/providerApi.ts
+++ b/apps/web/src/api/providerApi.ts
@@ -72,6 +72,8 @@ export const providerApi = {
   },
 
   importModelsDevModels: async (providerId: string): Promise<ModelsDevImportResult> => {
-    return (await getAppTransport()).provider.importModelsDevModels(providerId)
+    const result = await (await getAppTransport()).provider.importModelsDevModels(providerId)
+    emitProviderChanged()
+    return result
   },
 }

--- a/apps/web/src/api/providerApi.ts
+++ b/apps/web/src/api/providerApi.ts
@@ -1,4 +1,5 @@
 import type { AllAvailableModelsSchema, CreateProviderConfigModelSchema, CreateProviderConfigSchema, ModelsDevImportResult, ModelsDevModel, ModelsDevProvider, ProviderConfigModelSchema, ProviderConfigSchema, UpdateProviderConfigSchema } from '@ant-chat/shared'
+import { emitProviderChanged } from '@/constants/providerEvents'
 import { getAppTransport } from './transports/appTransport'
 
 export const providerApi = {
@@ -7,15 +8,21 @@ export const providerApi = {
   },
 
   createProvider: async (config: CreateProviderConfigSchema): Promise<ProviderConfigSchema> => {
-    return (await getAppTransport()).provider.createProvider(config)
+    const result = await (await getAppTransport()).provider.createProvider(config)
+    emitProviderChanged()
+    return result
   },
 
   updateProvider: async (config: UpdateProviderConfigSchema): Promise<ProviderConfigSchema> => {
-    return (await getAppTransport()).provider.updateProvider(config)
+    const result = await (await getAppTransport()).provider.updateProvider(config)
+    emitProviderChanged()
+    return result
   },
 
   deleteProvider: async (id: string): Promise<null> => {
-    return (await getAppTransport()).provider.deleteProvider(id)
+    const result = await (await getAppTransport()).provider.deleteProvider(id)
+    emitProviderChanged()
+    return result
   },
 
   getProviderById: async (id: string): Promise<ProviderConfigSchema> => {
@@ -35,15 +42,21 @@ export const providerApi = {
   },
 
   setModelEnabledStatus: async (id: string, status: boolean): Promise<ProviderConfigModelSchema> => {
-    return (await getAppTransport()).provider.setModelEnabledStatus(id, status)
+    const result = await (await getAppTransport()).provider.setModelEnabledStatus(id, status)
+    emitProviderChanged()
+    return result
   },
 
   createProviderModel: async (config: CreateProviderConfigModelSchema): Promise<ProviderConfigModelSchema> => {
-    return (await getAppTransport()).provider.createProviderModel(config)
+    const result = await (await getAppTransport()).provider.createProviderModel(config)
+    emitProviderChanged()
+    return result
   },
 
   deleteProviderModel: async (id: string): Promise<null> => {
-    return (await getAppTransport()).provider.deleteProviderModel(id)
+    const result = await (await getAppTransport()).provider.deleteProviderModel(id)
+    emitProviderChanged()
+    return result
   },
 
   getModelInfoById: async (id: string): Promise<ProviderConfigModelSchema> => {

--- a/apps/web/src/api/transports/appEventBus.ts
+++ b/apps/web/src/api/transports/appEventBus.ts
@@ -1,7 +1,8 @@
-import type { IpcRendererEvent } from '@ant-chat/shared'
+import type { AppRendererEvents, ElectronOnlyEvents } from '@ant-chat/shared'
 
-type AppEventChannel = keyof IpcRendererEvent & string
-type AppEventHandler<K extends AppEventChannel> = (event: unknown, ...args: IpcRendererEvent[K]) => void
+type AllEvents = AppRendererEvents & ElectronOnlyEvents
+type AppEventChannel = keyof AllEvents & string
+type AppEventHandler<K extends AppEventChannel> = (event: unknown, payload: AllEvents[K]) => void
 
 export interface AppEventBus {
   on: <K extends AppEventChannel>(channel: K, handler: AppEventHandler<K>) => void
@@ -60,10 +61,7 @@ function createSseEventBus(): AppEventBus {
       if (!handlers)
         return
       for (const handler of handlers) {
-        if (Array.isArray(data))
-          handler(null, ...data)
-        else
-          handler(null, data)
+        handler(null, data)
       }
     }) as EventListener)
   }

--- a/apps/web/src/components/Sender/PickerModel.tsx
+++ b/apps/web/src/components/Sender/PickerModel.tsx
@@ -8,7 +8,7 @@ import { useRequest } from 'ahooks'
 import { Settings } from 'lucide-react'
 import React from 'react'
 import { providerApi } from '@/api/providerApi'
-import { getAppEventBus } from '@/api/transports/appEventBus'
+import { PROVIDER_CHANGED_EVENT } from '@/constants/providerEvents'
 import { ModelParameterSettingsPanel } from './ModelParameterSettingsPanel'
 import { ProviderLogoDisplay } from './renderProviderLogo'
 import { SelectModel } from './SelectModel'
@@ -24,13 +24,12 @@ export function ModelControlPanel({ value, onChange }: ModelControlPanelProps) {
   const { data, refresh } = useRequest<AllAvailableModelsSchema[], []>(providerApi.getAllAbvailableModels)
 
   React.useEffect(() => {
-    const eventBus = getAppEventBus()
     const handleProviderChanged = () => {
       refresh()
     }
-    eventBus.on('provider:changed', handleProviderChanged)
+    window.addEventListener(PROVIDER_CHANGED_EVENT, handleProviderChanged)
     return () => {
-      eventBus.removeListener('provider:changed', handleProviderChanged)
+      window.removeEventListener(PROVIDER_CHANGED_EVENT, handleProviderChanged)
     }
   }, [refresh])
 

--- a/apps/web/src/constants/providerEvents.ts
+++ b/apps/web/src/constants/providerEvents.ts
@@ -1,0 +1,5 @@
+export const PROVIDER_CHANGED_EVENT = 'ant-chat:provider-changed'
+
+export function emitProviderChanged() {
+  window.dispatchEvent(new Event(PROVIDER_CHANGED_EVENT))
+}

--- a/apps/web/src/hooks/useAppEventListener.ts
+++ b/apps/web/src/hooks/useAppEventListener.ts
@@ -1,11 +1,13 @@
-import type { AgentPendingAction, AgentTaskSnapshot, IMessage, NotificationOption } from '@ant-chat/shared'
+import type { IMessage, NotificationOption } from '@ant-chat/shared'
 import { useEffect } from 'react'
 import { toast } from 'sonner'
 import { getAppEventBus } from '@/api/transports/appEventBus'
 import { onAgentApprovalRequired, onAgentStateUpdated } from '@/store/agent'
-import { addStreamingConversationId, removeStreamingConversationId } from '@/store/conversation'
+import { addStreamingConversationId, removeStreamingConversationId, upsertConversationAction } from '@/store/conversation'
+import { refreshGeneralSettings } from '@/store/generalSettings/actions'
 import { onMcpServerStatusChanged } from '@/store/mcpConfigs/action'
 import { updateMessageActionV2 } from '@/store/messages'
+import { useWorkspaceStore } from '@/store/workspace'
 
 export function useAppEventListener() {
   useEffect(() => {
@@ -30,27 +32,41 @@ export function useAppEventListener() {
     }
 
     eventBus.on('common:Notification', handle)
-    eventBus.on('mcp:McpServerStatusChanged', onMcpServerStatusChanged as (event: unknown, name: string, status: 'disconnected' | 'connected') => void)
-    eventBus.on('message:updated', (_, msg) => {
-      console.log('message:updated => ', msg)
+    eventBus.on('mcp:status-changed', (_, payload) => {
+      onMcpServerStatusChanged(payload.serverName, payload.status)
+    })
+    eventBus.on('conversation:updated', (_, payload) => {
+      upsertConversationAction(payload.conversation)
+    })
+    eventBus.on('message:updated', (_, payload) => {
+      console.log('message:updated => ', payload.message)
 
-      handleStreamingConversationStatus(msg)
-      updateMessageActionV2(msg)
+      handleStreamingConversationStatus(payload.message)
+      updateMessageActionV2(payload.message)
     })
 
-    eventBus.on('agent:state-updated', (_, payload: { task: AgentTaskSnapshot }) => {
+    eventBus.on('agent:task-updated', (_, payload) => {
       onAgentStateUpdated(payload.task)
     })
-    eventBus.on('agent:approval-required', (_, payload: { taskId: string, conversationId: string, pendingAction: AgentPendingAction }) => {
+    eventBus.on('agent:approval-required', (_, payload) => {
       onAgentApprovalRequired(payload.taskId, payload.pendingAction)
+    })
+    eventBus.on('settings:updated', () => {
+      void refreshGeneralSettings()
+    })
+    eventBus.on('workspace:changed', () => {
+      void useWorkspaceStore.getState().refresh()
     })
 
     return () => {
       eventBus.removeAllListeners('common:Notification')
-      eventBus.removeAllListeners('mcp:McpServerStatusChanged')
+      eventBus.removeAllListeners('mcp:status-changed')
+      eventBus.removeAllListeners('conversation:updated')
       eventBus.removeAllListeners('message:updated')
-      eventBus.removeAllListeners('agent:state-updated')
+      eventBus.removeAllListeners('agent:task-updated')
       eventBus.removeAllListeners('agent:approval-required')
+      eventBus.removeAllListeners('settings:updated')
+      eventBus.removeAllListeners('workspace:changed')
     }
   }, [])
 }

--- a/apps/web/src/store/mcpConfigs/action.ts
+++ b/apps/web/src/store/mcpConfigs/action.ts
@@ -67,7 +67,7 @@ export async function reconnectMcpServerAction(name: string) {
   await connectMcpServerAction(name)
 }
 
-export async function onMcpServerStatusChanged(_: Electron.IpcRendererEvent, name: string, status: McpServerStatus) {
+export async function onMcpServerStatusChanged(name: string, status: McpServerStatus) {
   console.log('onMcpServerStatusChanged => ', name, status)
   try {
     await getMcpConfigByServerName(name)

--- a/packages/app-runtime/src/__tests__/appRuntime.spec.ts
+++ b/packages/app-runtime/src/__tests__/appRuntime.spec.ts
@@ -51,8 +51,8 @@ describe.skipIf(!canRunDbIntegrationTests())('app runtime', () => {
   it('emits domain events after settings and workspace changes', async () => {
     const settingsEvents: { keys: string[] }[] = []
     const workspaceEvents: { currentWorkspacePath: string }[] = []
-    runtime.events.on('settings.changed', event => settingsEvents.push(event))
-    runtime.events.on('workspace.changed', event => workspaceEvents.push(event))
+    runtime.events.on('settings:updated', event => settingsEvents.push(event))
+    runtime.events.on('workspace:changed', event => workspaceEvents.push(event))
 
     await runtime.settings.update({ assistantModelId: 'model-2' })
     const workspace = runtime.workspace.list().workspaces[0]

--- a/packages/app-runtime/src/__tests__/events.spec.ts
+++ b/packages/app-runtime/src/__tests__/events.spec.ts
@@ -5,11 +5,11 @@ describe('runtime event bus', () => {
   it('delivers typed domain events and supports unsubscribe', () => {
     const events = new RuntimeEventBus()
     const listener = vi.fn()
-    const unsubscribe = events.on('settings.changed', listener)
+    const unsubscribe = events.on('settings:updated', listener)
 
-    events.emit('settings.changed', { keys: ['proxySettings'] })
+    events.emit('settings:updated', { keys: ['proxySettings'] })
     unsubscribe()
-    events.emit('settings.changed', { keys: ['assistantModelId'] })
+    events.emit('settings:updated', { keys: ['assistantModelId'] })
 
     expect(listener).toHaveBeenCalledOnce()
     expect(listener).toHaveBeenCalledWith({ keys: ['proxySettings'] })

--- a/packages/app-runtime/src/appRuntime.ts
+++ b/packages/app-runtime/src/appRuntime.ts
@@ -62,13 +62,13 @@ export function createAppRuntime(options: CreateAppRuntimeOptions) {
   const mcpClientHub = new MCPClientHub()
   const agentEventEmitter: IAgentEventEmitter = {
     emitMessageUpdated(message) {
-      events.emit('message.updated', { message })
+      events.emit('message:updated', { message })
     },
     emitTaskUpdated(task) {
-      events.emit('agent.task.updated', { task })
+      events.emit('agent:task-updated', { task })
     },
     emitApprovalRequired(taskId, conversationId, pendingAction) {
-      events.emit('agent.approval.required', { taskId, conversationId, pendingAction })
+      events.emit('agent:approval-required', { taskId, conversationId, pendingAction })
     },
     emitTurnStarted() {},
     emitTurnChunk() {},
@@ -109,25 +109,38 @@ export function createAppRuntime(options: CreateAppRuntimeOptions) {
 
   mcpClientHub.addStatusChangeCallback((serverName, status) => {
     if (status !== 'connecting') {
-      events.emit('mcp.connection.changed', { serverName, status })
+      events.emit('mcp:status-changed', { serverName, status })
     }
   })
 
   const runtime = {
     chat: {
-      createConversationTitle: (conversationId: string, modelId: string) =>
-        titleGenerator.updateTitle(conversationId, modelId),
+      createConversationTitle: async (conversationId: string, modelId: string) => {
+        const conversation = await titleGenerator.updateTitle(conversationId, modelId)
+        if (conversation) {
+          events.emit('conversation:updated', { conversation })
+        }
+        return conversation
+      },
       listConversations: async (pageIndex: number, pageSize: number, workspacePath?: string) => {
         const targetWorkspace = workspacePath ?? context.workspaceService.getCurrentWorkspacePath()
         const includeNullWorkspace = targetWorkspace === context.workspaceService.getDefaultWorkspacePath()
         return await context.conversationRepository.list(pageIndex, pageSize, targetWorkspace, includeNullWorkspace)
       },
       getConversation: (id: string) => context.conversationRepository.getById(id),
-      createConversation: (conversation: AddConversationsSchema) => context.conversationRepository.create({
-        ...conversation,
-        workspacePath: conversation.workspacePath ?? context.workspaceService.getCurrentWorkspacePath(),
-      }),
-      updateConversation: (conversation: UpdateConversationsSchema) => context.conversationRepository.update(conversation),
+      createConversation: async (conversation: AddConversationsSchema) => {
+        const result = await context.conversationRepository.create({
+          ...conversation,
+          workspacePath: conversation.workspacePath ?? context.workspaceService.getCurrentWorkspacePath(),
+        })
+        events.emit('conversation:updated', { conversation: result })
+        return result
+      },
+      updateConversation: async (conversation: UpdateConversationsSchema) => {
+        const result = await context.conversationRepository.update(conversation)
+        events.emit('conversation:updated', { conversation: result })
+        return result
+      },
       deleteConversation: async (id: string) => {
         await agentRuntime.closeConversation(id)
         await context.conversationRepository.delete(id)
@@ -152,13 +165,13 @@ export function createAppRuntime(options: CreateAppRuntimeOptions) {
         const settings = await context.settingsRepository.updateGeneralSettings(updates)
         if (updates.proxySettings)
           await networkProxy.apply(updates.proxySettings)
-        events.emit('settings.changed', { keys: Object.keys(updates) })
+        events.emit('settings:updated', { keys: Object.keys(updates) })
         return settings
       },
       reset: async () => {
         const settings = await context.settingsRepository.resetGeneralSettings()
         await networkProxy.apply(settings.proxySettings)
-        events.emit('settings.changed', { keys: ['all'] })
+        events.emit('settings:updated', { keys: ['all'] })
         return settings
       },
       testProxy: (proxyUrl: string) => networkProxy.test(proxyUrl),
@@ -167,17 +180,17 @@ export function createAppRuntime(options: CreateAppRuntimeOptions) {
       list: () => context.providerSettingsRepository.listProviders(),
       create: (config: CreateProviderConfigSchema) => {
         const result = context.providerSettingsRepository.createProvider(config)
-        events.emit('provider.changed', { providerId: result.id })
+        events.emit('provider:changed', { providerId: result.id })
         return result
       },
       update: (config: UpdateProviderConfigSchema) => {
         const result = context.providerSettingsRepository.updateProvider(config)
-        events.emit('provider.changed', { providerId: result.id })
+        events.emit('provider:changed', { providerId: result.id })
         return result
       },
       delete: (id: string) => {
         context.providerSettingsRepository.deleteProvider(id)
-        events.emit('provider.changed', { providerId: id })
+        events.emit('provider:changed', { providerId: id })
         return null
       },
       getById: (id: string) => requireValue(context.providerSettingsRepository.getProviderById(id), `Provider not found: ${id}`),
@@ -187,24 +200,24 @@ export function createAppRuntime(options: CreateAppRuntimeOptions) {
       getModel: (id: string) => requireValue(context.providerSettingsRepository.getModelById(id), `Provider model not found: ${id}`),
       setModelEnabled: (id: string, enabled: boolean) => {
         const result = context.providerSettingsRepository.setModelEnabledStatus(id, enabled)
-        events.emit('provider.changed', { providerId: result.providerId })
+        events.emit('provider:changed', { providerId: result.providerId })
         return result
       },
       createModel: (config: CreateProviderConfigModelSchema) => {
         const result = context.providerSettingsRepository.createProviderModel(config)
-        events.emit('provider.changed', { providerId: result.providerId })
+        events.emit('provider:changed', { providerId: result.providerId })
         return result
       },
       deleteModel: (id: string) => {
         context.providerSettingsRepository.deleteProviderModel(id)
-        events.emit('provider.changed', {})
+        events.emit('provider:changed', {})
         return null
       },
       getModelsDevProviders: () => modelsDevImporter.getModelsDevProviders(),
       getModelsDevModels: (providerId: string) => modelsDevImporter.getModelsDevModelsByProviderId(providerId),
       importModelsDevModels: async (providerId: string) => {
         const result = await modelsDevImporter.importModelsDevModels(providerId)
-        events.emit('provider.changed', { providerId })
+        events.emit('provider:changed', { providerId })
         return result
       },
     },
@@ -343,7 +356,7 @@ export function createAppRuntime(options: CreateAppRuntimeOptions) {
   }
 
   function emitWorkspaceResult(result: ReturnType<typeof context.workspaceService.listWorkspaces>) {
-    events.emit('workspace.changed', { currentWorkspacePath: result.currentWorkspacePath })
+    events.emit('workspace:changed', { currentWorkspacePath: result.currentWorkspacePath })
     return result
   }
 

--- a/packages/app-runtime/src/events.ts
+++ b/packages/app-runtime/src/events.ts
@@ -1,23 +1,6 @@
-import type { AgentPendingAction, AgentTaskSnapshot, IMessage } from '@ant-chat/shared'
+import type { AppRendererEvents } from '@ant-chat/shared'
 
-export interface AppRuntimeEvents {
-  'message.updated': { message: IMessage }
-  'agent.task.updated': { task: AgentTaskSnapshot }
-  'agent.approval.required': {
-    taskId: string
-    conversationId: string
-    pendingAction: AgentPendingAction
-  }
-  'workspace.changed': { currentWorkspacePath: string }
-  'provider.changed': { providerId?: string }
-  'settings.changed': { keys: string[] }
-  'mcp.connection.changed': {
-    serverName: string
-    status: 'connected' | 'disconnected'
-    error?: string
-  }
-}
-
+export type AppRuntimeEvents = AppRendererEvents
 export type AppRuntimeEventName = keyof AppRuntimeEvents
 export type AppRuntimeEventListener<K extends AppRuntimeEventName> = (event: AppRuntimeEvents[K]) => void
 

--- a/packages/local-server/src/dev.ts
+++ b/packages/local-server/src/dev.ts
@@ -39,14 +39,13 @@ async function main() {
   await runtime.initialize()
   const handleLocalApi = createLocalApiHandler(runtime)
 
-  runtime.events.on('message.updated', ({ message }) => sseBroadcast(sseClients, 'message:updated', message))
-  runtime.events.on('agent.task.updated', ({ task }) => sseBroadcast(sseClients, 'agent:state-updated', { task }))
-  runtime.events.on('agent.approval.required', event => sseBroadcast(sseClients, 'agent:approval-required', event))
-  runtime.events.on('workspace.changed', event => sseBroadcast(sseClients, 'workspace:changed', event))
-  runtime.events.on('provider.changed', event => sseBroadcast(sseClients, 'provider:changed', event))
-  runtime.events.on('settings.changed', event => sseBroadcast(sseClients, 'settings:updated', event))
-  runtime.events.on('mcp.connection.changed', event =>
-    sseBroadcast(sseClients, 'mcp:McpServerStatusChanged', [event.serverName, event.status]))
+  runtime.events.on('conversation:updated', event => sseBroadcast(sseClients, 'conversation:updated', event))
+  runtime.events.on('message:updated', event => sseBroadcast(sseClients, 'message:updated', event))
+  runtime.events.on('agent:task-updated', event => sseBroadcast(sseClients, 'agent:task-updated', event))
+  runtime.events.on('agent:approval-required', event => sseBroadcast(sseClients, 'agent:approval-required', event))
+  runtime.events.on('workspace:changed', event => sseBroadcast(sseClients, 'workspace:changed', event))
+  runtime.events.on('settings:updated', event => sseBroadcast(sseClients, 'settings:updated', event))
+  runtime.events.on('mcp:status-changed', event => sseBroadcast(sseClients, 'mcp:status-changed', event))
 
   // SSE endpoint: browser connects here for real-time events
   function handleSse(req: import('node:http').IncomingMessage, res: ServerResponse): boolean {

--- a/packages/shared/src/ipc-events.ts
+++ b/packages/shared/src/ipc-events.ts
@@ -1,4 +1,4 @@
-import type { AgentPendingAction, AgentTaskSnapshot, IMessage, NotificationOption, ProgressInfo, UpdateError, UpdateInfo, UpdateStatus } from './interfaces'
+import type { AgentPendingAction, AgentTaskSnapshot, IConversations, IMessage, NotificationOption, ProgressInfo, UpdateError, UpdateInfo, UpdateStatus } from './interfaces'
 
 export function createIpcResponse<T>(success: boolean, data: T, msg?: string): IpcResponse<T> | ErrorIpcResponse {
   if (success) {
@@ -59,22 +59,33 @@ export type IpcResponse<T> = IpcResponseSuccess<T> | ErrorIpcResponse
 export type IpcPaginatedResponse<T> = IpcPaginatedResponseSuccess<T> | ErrorIpcResponse
 
 /**
- * 这里是在渲染进程中接收的事件
+ * 跨平台渲染进程事件 - web 和 desktop 共享
  */
-export interface IpcRendererEvent {
-  'mcp:McpServerStatusChanged': [string, 'disconnected' | 'connected']
-  'common:Notification': [NotificationOption]
-  'message:updated': [IMessage]
-  'chat:stream-canceled': [string]
-  'workspace:changed': [{ currentWorkspacePath: string }]
-  'update:update-status-changed': [{ status: UpdateStatus, updateInfo: UpdateInfo | null }]
-  'update:update-available': [{ status: UpdateStatus, updateInfo: UpdateInfo | null }]
-  'update:update-not-available': []
-  'update:download-progress': [ProgressInfo]
-  'update:update-downloaded': [UpdateInfo]
-  'update:update-error': [UpdateError]
-  'agent:state-updated': [{ task: AgentTaskSnapshot }]
-  'agent:approval-required': [{ taskId: string, conversationId: string, pendingAction: AgentPendingAction }]
-  'settings:updated': [{ keys: string[] }]
-  [key: string]: unknown[]
+export interface AppRendererEvents {
+  'conversation:updated': { conversation: IConversations }
+  'message:updated': { message: IMessage }
+  'agent:task-updated': { task: AgentTaskSnapshot }
+  'agent:approval-required': { taskId: string, conversationId: string, pendingAction: AgentPendingAction }
+  'workspace:changed': { currentWorkspacePath: string }
+  'settings:updated': { keys: string[] }
+  'mcp:status-changed': { serverName: string, status: 'connected' | 'disconnected', error?: string }
+  'provider:changed': { providerId?: string }
 }
+
+/**
+ * Electron 专用事件
+ */
+export interface ElectronOnlyEvents {
+  'common:Notification': NotificationOption
+  'update:update-status-changed': { status: UpdateStatus, updateInfo: UpdateInfo | null }
+  'update:update-available': { status: UpdateStatus, updateInfo: UpdateInfo | null }
+  'update:update-not-available': never
+  'update:download-progress': ProgressInfo
+  'update:update-downloaded': UpdateInfo
+  'update:update-error': UpdateError
+}
+
+/**
+ * 渲染进程接收的事件（合并跨平台和 Electron 专用）
+ */
+export type IpcRendererEvent = AppRendererEvents & ElectronOnlyEvents


### PR DESCRIPTION
## 背景

当前事件系统存在三层定义（AppRuntimeEvents、IpcRendererEvent、useAppEventListener），命名规则和数据格式不一致，缺乏类型安全连接。

## 修改内容

### 核心架构变更

1. **新增 AppRendererEvents 接口**（packages/shared/src/ipc-events.ts）
   - 作为跨平台事件的单一数据源
   - 统一使用 domain:action 命名格式
   - 统一使用单一对象参数格式

2. **新增 ElectronOnlyEvents 接口**
   - 隔离 Electron 专用事件（update 系列、common:Notification）
   - 避免污染跨平台事件层

3. **简化 AppRuntimeEvents**
   - 改为 AppRendererEvents 的类型别名
   - 删除重复的事件定义

### 事件命名统一

- conversation.updated -> conversation:updated
- message.updated -> message:updated
- agent.task.updated -> agent:task-updated
- agent.approval.required -> agent:approval-required
- workspace.changed -> workspace:changed
- settings.changed -> settings:updated
- mcp.connection.changed -> mcp:status-changed
- provider.changed -> provider:changed

### 数据格式统一

- 所有事件使用单一对象参数，不再使用元组或解构
- 例如：(_, msg) -> (_, payload) 其中 payload.message 是消息内容

### 其他修复

- 修复 provider:changed 在 Electron 端数据丢失问题
- 删除未使用的 chat:stream-canceled 事件
- web 端 provider 变更使用 window 自定义事件（PROVIDER_CHANGED_EVENT）
- 简化 onMcpServerStatusChanged 函数签名

## 验证方式

- pnpm type-check - 类型检查通过
- pnpm lint - 代码规范检查通过
- pnpm test:unit - 单元测试全部通过