### PR TITLE
fix: 批量修复安全、数据一致性和连接通信问题

### DIFF
--- a/apps/desktop/src/main/domains/chat/ipc.ts
+++ b/apps/desktop/src/main/domains/chat/ipc.ts
@@ -93,6 +93,18 @@ export class ChatIpcService extends IpcService {
   }
 
   @IpcMethod()
+  async clearWorkspaceConversations(workspacePath: string): Promise<IpcResponse<string[]>> {
+    try {
+      const deletedIds = await getAppRuntime().chat.clearWorkspaceConversations(workspacePath)
+      return createIpcResponse(true, deletedIds)
+    }
+    catch (error) {
+      logger.error('清空工作区会话失败:', error)
+      return createErrorIpcResponse(error as Error)
+    }
+  }
+
+  @IpcMethod()
   async getMessagesByConvId(id: string): Promise<IpcResponse<IMessage[]>> {
     try {
       const data = await getAppRuntime().chat.listMessages(id)

--- a/apps/web/src/api/chatApi.ts
+++ b/apps/web/src/api/chatApi.ts
@@ -32,6 +32,10 @@ async function deleteConversation(id: string): Promise<null> {
   return (await getAppTransport()).chat.deleteConversation(id)
 }
 
+async function clearWorkspaceConversations(workspacePath: string): Promise<string[]> {
+  return (await getAppTransport()).chat.clearWorkspaceConversations(workspacePath)
+}
+
 async function getMessagesByConvId(convId: string): Promise<IMessage[]> {
   return (await getAppTransport()).chat.getMessagesByConvId(convId)
 }
@@ -64,6 +68,7 @@ export default {
   addConversation,
   updateConversation,
   deleteConversation,
+  clearWorkspaceConversations,
   getMessagesByConvId,
   getMessageById,
   addMessage,

--- a/apps/web/src/api/transports/__tests__/appEventBus.spec.ts
+++ b/apps/web/src/api/transports/__tests__/appEventBus.spec.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('sse event bus', () => {
+  let addEventListener: ReturnType<typeof vi.fn>
+  let removeEventListener: ReturnType<typeof vi.fn>
+  let bus: import('../appEventBus').AppEventBus
+  let originalEventSource: typeof EventSource | undefined
+
+  beforeEach(async () => {
+    addEventListener = vi.fn()
+    removeEventListener = vi.fn()
+
+    originalEventSource = globalThis.EventSource
+
+    class MockEventSource {
+      onmessage: ((event: MessageEvent) => void) | null = null
+      onerror: ((event: Event) => void) | null = null
+      constructor(_url: string) {}
+      addEventListener = addEventListener
+      removeEventListener = removeEventListener
+    }
+
+    globalThis.EventSource = MockEventSource as unknown as typeof EventSource
+    vi.resetModules()
+
+    const mod = await import('../appEventBus')
+    bus = mod.createSseEventBus()
+  })
+
+  afterEach(() => {
+    if (originalEventSource) {
+      globalThis.EventSource = originalEventSource
+    }
+    else {
+      delete (globalThis as any).EventSource
+    }
+    vi.restoreAllMocks()
+  })
+
+  it('registers one native listener for multiple handlers on the same channel', () => {
+    console.log('Test started')
+    const handler1 = vi.fn()
+    const handler2 = vi.fn()
+
+    console.log('Calling bus.on first time')
+    bus.on('message:updated', handler1)
+    console.log('addEventListener calls after first on:', addEventListener.mock.calls.length)
+
+    console.log('Calling bus.on second time')
+    bus.on('message:updated', handler2)
+    console.log('addEventListener calls after second on:', addEventListener.mock.calls.length)
+
+    expect(addEventListener).toHaveBeenCalledOnce()
+    expect(addEventListener).toHaveBeenCalledWith('message:updated', expect.any(Function))
+  })
+
+  it('does not unbind native listener when removing one of multiple handlers', () => {
+    const handler1 = vi.fn()
+    const handler2 = vi.fn()
+
+    bus.on('message:updated', handler1)
+    bus.on('message:updated', handler2)
+    bus.removeListener('message:updated', handler1)
+
+    expect(removeEventListener).not.toHaveBeenCalled()
+  })
+
+  it('unbinds native listener when removing the last handler', () => {
+    const handler1 = vi.fn()
+    const handler2 = vi.fn()
+
+    bus.on('message:updated', handler1)
+    bus.on('message:updated', handler2)
+
+    const savedListener = addEventListener.mock.calls[0][1]
+
+    bus.removeListener('message:updated', handler1)
+    bus.removeListener('message:updated', handler2)
+
+    expect(removeEventListener).toHaveBeenCalledOnce()
+    expect(removeEventListener).toHaveBeenCalledWith('message:updated', savedListener)
+  })
+
+  it('unbinds native listener for removeAllListeners(channel)', () => {
+    const handler = vi.fn()
+
+    bus.on('message:updated', handler)
+    const savedListener = addEventListener.mock.calls[0][1]
+
+    bus.removeAllListeners('message:updated')
+
+    expect(removeEventListener).toHaveBeenCalledOnce()
+    expect(removeEventListener).toHaveBeenCalledWith('message:updated', savedListener)
+  })
+
+  it('unbinds all native listeners for removeAllListeners() without channel', () => {
+    const handler1 = vi.fn()
+    const handler2 = vi.fn()
+
+    bus.on('message:updated', handler1)
+    bus.on('conversation:updated', handler2)
+
+    const savedListener1 = addEventListener.mock.calls.find(c => c[0] === 'message:updated')![1]
+    const savedListener2 = addEventListener.mock.calls.find(c => c[0] === 'conversation:updated')![1]
+
+    bus.removeAllListeners()
+
+    expect(removeEventListener).toHaveBeenCalledTimes(2)
+    expect(removeEventListener).toHaveBeenCalledWith('message:updated', savedListener1)
+    expect(removeEventListener).toHaveBeenCalledWith('conversation:updated', savedListener2)
+  })
+
+  it('dispatches parsed data to handlers when native listener fires', () => {
+    const handler = vi.fn()
+
+    bus.on('message:updated', handler)
+
+    const nativeListener = addEventListener.mock.calls[0][1]
+    const payload = { message: { id: 'msg-1', content: [] } }
+    nativeListener(new MessageEvent('message:updated', { data: JSON.stringify(payload) }))
+
+    expect(handler).toHaveBeenCalledOnce()
+    expect(handler).toHaveBeenCalledWith(null, payload)
+  })
+})

--- a/apps/web/src/api/transports/appEventBus.ts
+++ b/apps/web/src/api/transports/appEventBus.ts
@@ -35,6 +35,7 @@ function createElectronEventBus(): AppEventBus {
 
 function createSseEventBus(): AppEventBus {
   const listeners = new Map<string, Set<(event: unknown, ...args: unknown[]) => void>>()
+  const nativeListeners = new Map<string, EventListener>()
   let eventSource: EventSource | null = null
 
   function ensureConnected() {
@@ -55,7 +56,7 @@ function createSseEventBus(): AppEventBus {
   function bindChannel(channel: string) {
     if (!eventSource)
       return
-    eventSource.addEventListener(channel, ((e: MessageEvent) => {
+    const listener: EventListener = ((e: MessageEvent) => {
       const data = JSON.parse(e.data)
       const handlers = listeners.get(channel)
       if (!handlers)
@@ -63,7 +64,17 @@ function createSseEventBus(): AppEventBus {
       for (const handler of handlers) {
         handler(null, data)
       }
-    }) as EventListener)
+    }) as EventListener
+    nativeListeners.set(channel, listener)
+    eventSource.addEventListener(channel, listener)
+  }
+
+  function unbindChannel(channel: string) {
+    const listener = nativeListeners.get(channel)
+    if (listener && eventSource) {
+      eventSource.removeEventListener(channel, listener)
+      nativeListeners.delete(channel)
+    }
   }
 
   return {
@@ -84,14 +95,19 @@ function createSseEventBus(): AppEventBus {
         handlers.delete(handler as (event: unknown, ...args: unknown[]) => void)
         if (handlers.size === 0) {
           listeners.delete(channel)
+          unbindChannel(channel)
         }
       }
     },
     removeAllListeners(channel) {
       if (channel) {
         listeners.delete(channel)
+        unbindChannel(channel)
       }
       else {
+        for (const ch of nativeListeners.keys()) {
+          unbindChannel(ch)
+        }
         listeners.clear()
       }
     },
@@ -128,3 +144,9 @@ export function getAppEventBus(): AppEventBus {
 
   return cached
 }
+
+export function clearAppEventBusCache(): void {
+  cached = null
+}
+
+export { createSseEventBus }

--- a/apps/web/src/api/transports/electronIpcTransport.ts
+++ b/apps/web/src/api/transports/electronIpcTransport.ts
@@ -19,6 +19,7 @@ export function createElectronIpcTransport(): AppTransport {
       addConversation: async conversation => unwrapIpcResponse(await ipc.chat.addConversation(conversation)),
       updateConversation: async conversation => unwrapIpcResponse(await ipc.chat.updateConversation(conversation)),
       deleteConversation: async id => unwrapIpcResponse(await ipc.chat.deleteConversation(id)),
+      clearWorkspaceConversations: async workspacePath => unwrapIpcResponse(await ipc.chat.clearWorkspaceConversations(workspacePath)),
       getMessagesByConvId: async convId => unwrapIpcResponse(await ipc.chat.getMessagesByConvId(convId)),
       getMessageById: async id => unwrapIpcResponse(await ipc.chat.getMessageById(id)),
       addMessage: async message => unwrapIpcResponse(await ipc.chat.addMessage(message)),

--- a/apps/web/src/api/transports/localWebTransport.ts
+++ b/apps/web/src/api/transports/localWebTransport.ts
@@ -15,6 +15,7 @@ export function createLocalWebTransport(): AppTransport {
       addConversation: conversation => localRpc('chat.addConversation', { conversation }),
       updateConversation: conversation => localRpc('chat.updateConversation', { conversation }),
       deleteConversation: id => localRpc('chat.deleteConversation', { id }),
+      clearWorkspaceConversations: workspacePath => localRpc('chat.clearWorkspaceConversations', { workspacePath }),
       getMessagesByConvId: convId => localRpc('chat.getMessagesByConvId', { convId }),
       getMessageById: id => localRpc('chat.getMessageById', { id }),
       addMessage: message => localRpc('chat.addMessage', { message }),

--- a/apps/web/src/components/Conversations/ConversationsManage.tsx
+++ b/apps/web/src/components/Conversations/ConversationsManage.tsx
@@ -189,10 +189,20 @@ export default function ConversationsManage({ showHeader = true }: Conversations
             <AlertDialogCancel>取消</AlertDialogCancel>
             <AlertDialogAction
               variant="destructive"
-              onClick={() => {
-                clearConversationsAction()
-                toast.success('清空成功')
-                setConfirmAction(null)
+              disabled={loading}
+              onClick={async () => {
+                setLoading(true)
+                try {
+                  await clearConversationsAction()
+                  toast.success('清空成功')
+                  setConfirmAction(null)
+                }
+                catch (error) {
+                  toast.error(error instanceof Error ? error.message : '清空失败')
+                }
+                finally {
+                  setLoading(false)
+                }
               }}
             >
               清空

--- a/apps/web/src/components/GeneralSettings/ProxySettings.tsx
+++ b/apps/web/src/components/GeneralSettings/ProxySettings.tsx
@@ -1,3 +1,4 @@
+import type { ProxySettings as ProxySettingsType } from '@ant-chat/shared'
 import { Button } from '@workspace/ui/components/button'
 import { Input } from '@workspace/ui/components/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@workspace/ui/components/select'
@@ -7,25 +8,19 @@ import { getAppTransport } from '@/api/transports/appTransport'
 import { updateProxySettings } from '@/store/generalSettings/actions'
 import { useGeneralSettingsStore } from '@/store/generalSettings/store'
 
-// 代理模式选择组件
-export function ProxySettings() {
-  const proxySettings = useGeneralSettingsStore(state => state.proxySettings)
-  const isLoading = useGeneralSettingsStore(state => state.isLoading)
+interface ProxySettingsProps {
+  draftMode: ProxySettingsType['mode']
+  onModeChange: (mode: ProxySettingsType['mode']) => void
+}
 
-  const handleProxyModeChange = async (mode: string) => {
-    try {
-      await updateProxySettings({ mode: mode as 'none' | 'system' | 'custom' })
-      toast.success('代理模式已更新')
-    }
-    catch {
-      toast.error('代理模式更新失败')
-    }
-  }
+// 代理模式选择组件
+export function ProxySettings({ draftMode, onModeChange }: ProxySettingsProps) {
+  const isLoading = useGeneralSettingsStore(state => state.isLoading)
 
   return (
     <Select
-      value={proxySettings.mode}
-      onValueChange={handleProxyModeChange}
+      value={draftMode}
+      onValueChange={onModeChange}
       disabled={isLoading}
     >
       <SelectTrigger className="min-w-32">
@@ -58,7 +53,8 @@ export function CustomProxyUrl() {
 
     if (tempUrl && tempUrl !== proxySettings.customProxyUrl) {
       try {
-        await updateProxySettings({ customProxyUrl: tempUrl })
+        await updateProxySettings({ mode: 'custom', customProxyUrl: tempUrl })
+        toast.success('代理设置已更新')
       }
       catch {
         toast.error('代理地址更新失败')

--- a/apps/web/src/components/MCPManage/McpConfigDrawer.tsx
+++ b/apps/web/src/components/MCPManage/McpConfigDrawer.tsx
@@ -87,8 +87,6 @@ export default function McpConfigDrawer({ open, mode, defaultValues, onClose, on
   }
 
   const onSubmit = async (config: McpConfigForm) => {
-    console.log('config => ', JSON.stringify(config))
-
     let finalConfig: AddMcpConfigSchema | UpdateMcpConfigSchema
 
     if (mode === 'add') {

--- a/apps/web/src/components/MCPManage/QuickImport.tsx
+++ b/apps/web/src/components/MCPManage/QuickImport.tsx
@@ -60,7 +60,6 @@ export function QuickImport({ onImport }: QuickImportProps) {
                 }
                 try {
                   const mcpConfig = parseMcpServerJsonText(text)
-                  console.log('parseMcpServerJsonText => ', mcpConfig)
                   onImport?.(mcpConfig)
                   setText('')
                   setQuickImport(false)
@@ -118,6 +117,5 @@ function parseMcpServerJsonText(text: string): AddMcpConfigSchema {
   if (config.url) {
     options.transportType = 'sse'
   }
-  console.log(' options => ', options)
   return AddMcpConfigSchema.parse(options)
 }

--- a/apps/web/src/pages/Settings/GeneralSettings.tsx
+++ b/apps/web/src/pages/Settings/GeneralSettings.tsx
@@ -1,13 +1,36 @@
+import type { ProxySettings as ProxySettingsType } from '@ant-chat/shared'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@workspace/ui/components/tooltip'
 import { Globe, Info, Link } from 'lucide-react'
 import React from 'react'
 import AssistantIcon from '@/assets/icons/assistant.svg?react'
 import { CustomProxyUrl, ProxySettings } from '@/components/GeneralSettings/ProxySettings'
 import { SelectModel } from '@/components/GeneralSettings/SelectModel'
+import { updateProxySettings } from '@/store/generalSettings/actions'
 import { useGeneralSettingsStore } from '@/store/generalSettings/store'
 
 export function GeneralSettings() {
   const proxySettings = useGeneralSettingsStore(state => state.proxySettings)
+  const [draftProxyMode, setDraftProxyMode] = React.useState<ProxySettingsType['mode']>(proxySettings.mode)
+
+  React.useEffect(() => {
+    setDraftProxyMode(proxySettings.mode)
+  }, [proxySettings.mode])
+
+  const handleProxyModeChange = async (mode: ProxySettingsType['mode']) => {
+    if (mode === 'custom') {
+      setDraftProxyMode('custom')
+      return
+    }
+
+    try {
+      await updateProxySettings({ mode })
+    }
+    catch {
+      setDraftProxyMode(proxySettings.mode)
+    }
+  }
+
+  const showCustomUrl = draftProxyMode === 'custom'
 
   return (
     <div className="flex flex-col gap-2 p-3">
@@ -25,10 +48,10 @@ export function GeneralSettings() {
           help="配置AI请求的代理设置，支持系统代理和自定义代理"
           icon={<Globe className="size-4" />}
         >
-          <ProxySettings />
+          <ProxySettings draftMode={draftProxyMode} onModeChange={handleProxyModeChange} />
         </GeneralSettingsItem>
 
-        {proxySettings.mode === 'custom' && (
+        {showCustomUrl && (
           <GeneralSettingsItem
             title="代理地址"
             help="配置自定义代理服务器地址"

--- a/apps/web/src/pages/Settings/MCPManage/MCPManage.tsx
+++ b/apps/web/src/pages/Settings/MCPManage/MCPManage.tsx
@@ -150,8 +150,6 @@ export default function MCPManage() {
 }
 
 function checkNeedReconnect(oldConfig: McpConfigSchema, newConfig: McpConfigSchema): boolean {
-  console.log('oldConfig: ', JSON.stringify(oldConfig), 'newConfig: ', JSON.stringify(newConfig))
-
   if (oldConfig.transportType !== newConfig.transportType) {
     return true
   }

--- a/apps/web/src/store/conversation/actions.ts
+++ b/apps/web/src/store/conversation/actions.ts
@@ -133,6 +133,13 @@ export async function importConversationsAction(_: AntChatFileStructure) {
 }
 
 export async function clearConversationsAction() {
+  const { currentWorkspacePath } = useConversationsStore.getState()
+  if (!currentWorkspacePath) {
+    throw new Error('当前工作区路径不存在，无法清空对话')
+  }
+
+  await chatApi.clearWorkspaceConversations(currentWorkspacePath)
+
   await clearActiveConversations()
 
   useConversationsStore.setState(state => produce(state, (draft) => {

--- a/apps/web/src/store/messages/__tests__/actions.spec.ts
+++ b/apps/web/src/store/messages/__tests__/actions.spec.ts
@@ -1,11 +1,12 @@
 import type { ConversationsId, IMessage } from '@ant-chat/shared'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { addPendingSteeringMessage, setActiveConversationsId, updateMessageActionV2 } from '../actions'
+import { addPendingSteeringMessage, clearActiveConversations, setActiveConversationsId, updateMessageActionV2 } from '../actions'
 import { useMessagesStore } from '../store'
 
 const mocks = vi.hoisted(() => ({
   getMessagesByConvId: vi.fn<(conversationId: string) => Promise<IMessage[]>>(),
   listActiveTasks: vi.fn(async () => []),
+  syncConversationAgentState: vi.fn(async () => {}),
 }))
 
 vi.mock('@/api/chatApi', () => ({
@@ -18,6 +19,10 @@ vi.mock('@/api/agentApi', () => ({
   default: {
     listActiveTasks: mocks.listActiveTasks,
   },
+}))
+
+vi.mock('../agent', () => ({
+  syncConversationAgentState: mocks.syncConversationAgentState,
 }))
 
 describe('message actions', () => {
@@ -95,6 +100,56 @@ describe('message actions', () => {
     expect(useMessagesStore.getState().pendingSteeringByConversation).toEqual({
       'conv-1': [first],
     })
+  })
+
+  it('later selection wins when earlier request completes after later', async () => {
+    let resolveA!: () => void
+    let resolveB!: () => void
+    const promiseA = new Promise<IMessage[]>((resolve) => {
+      resolveA = () => resolve([createUserMessage('msg-a', 'conv-a', 1)])
+    })
+    const promiseB = new Promise<IMessage[]>((resolve) => {
+      resolveB = () => resolve([createUserMessage('msg-b', 'conv-b', 2)])
+    })
+
+    let callCount = 0
+    mocks.getMessagesByConvId.mockImplementation(() => {
+      callCount++
+      return callCount === 1 ? promiseA : promiseB
+    })
+
+    const pendingA = setActiveConversationsId('conv-a' as ConversationsId)
+    const pendingB = setActiveConversationsId('conv-b' as ConversationsId)
+
+    resolveB()
+    await pendingB
+
+    expect(useMessagesStore.getState().activeConversationsId).toBe('conv-b')
+    expect(useMessagesStore.getState().messages).toEqual([createUserMessage('msg-b', 'conv-b', 2)])
+
+    resolveA()
+    await pendingA
+
+    expect(useMessagesStore.getState().activeConversationsId).toBe('conv-b')
+    expect(useMessagesStore.getState().messages).toEqual([createUserMessage('msg-b', 'conv-b', 2)])
+  })
+
+  it('clear invalidates in-flight load', async () => {
+    let resolveA!: () => void
+    const promiseA = new Promise<IMessage[]>((resolve) => {
+      resolveA = () => resolve([createUserMessage('msg-a', 'conv-a', 1)])
+    })
+
+    mocks.getMessagesByConvId.mockImplementation(() => promiseA)
+
+    const pendingA = setActiveConversationsId('conv-a' as ConversationsId)
+    await clearActiveConversations()
+
+    resolveA()
+    await pendingA
+
+    expect(useMessagesStore.getState().activeConversationsId).toBe('')
+    expect(useMessagesStore.getState().messages).toEqual([])
   })
 })
 

--- a/apps/web/src/store/messages/actions.ts
+++ b/apps/web/src/store/messages/actions.ts
@@ -6,12 +6,18 @@ import { syncConversationAgentState } from '../agent'
 import { useConversationsStore } from '../conversation/conversationsStore'
 import { useMessagesStore } from './store'
 
+let loadVersion = 0
+
 export async function clearActiveConversations() {
+  const version = ++loadVersion
+
   useMessagesStore.setState(state => produce(state, (draft) => {
     draft.activeConversationsId = '' as ConversationsId
     draft.messages = []
   }))
   useConversationsStore.getState().setActiveConversationsId('')
+
+  return version
 }
 
 export async function setActiveConversationsId(id: ConversationsId | '') {
@@ -20,10 +26,16 @@ export async function setActiveConversationsId(id: ConversationsId | '') {
     return
   }
 
+  const version = ++loadVersion
+
   const [messages] = await Promise.all([
     chatApi.getMessagesByConvId(id),
     syncConversationAgentState(id),
   ])
+
+  if (version !== loadVersion) {
+    return
+  }
 
   useMessagesStore.setState(state => produce(state, (draft) => {
     const persistedMessageIds = new Set(messages.map(message => message.id))

--- a/packages/app-data/src/repositories/conversationRepository.ts
+++ b/packages/app-data/src/repositories/conversationRepository.ts
@@ -11,4 +11,5 @@ export interface ConversationRepository {
   create: (conversation: AddConversationsSchema) => Promise<IConversations>
   update: (conversation: UpdateConversationsSchema) => Promise<IConversations>
   delete: (id: string) => Promise<boolean>
+  deleteByWorkspace: (workspacePath?: string, includeNullWorkspace?: boolean) => Promise<string[]>
 }

--- a/packages/app-data/src/sqlite/repositories/__tests__/sqliteRepositories.spec.ts
+++ b/packages/app-data/src/sqlite/repositories/__tests__/sqliteRepositories.spec.ts
@@ -422,7 +422,191 @@ describe.skipIf(!canRunDbIntegrationTests())('sqlite repositories', () => {
     expect(bList.data).toHaveLength(1)
     expect(bList.data[0].title).toBe('B')
   })
+
+  it('does not create files or rows when updating a non-existent message with attachments', async () => {
+    const messageRepository = new SqliteMessageRepository(sqlite, { attachmentsRoot })
+    const bytes = Buffer.from('test content', 'utf8')
+
+    await expect(messageRepository.update({
+      id: 'msg-nonexistent',
+      content: [
+        {
+          type: 'document',
+          source: { type: 'file_id', file_id: 'doc-missing' },
+          name: 'doc.txt',
+          media_type: 'text/plain',
+          size: bytes.length,
+          data: bytes.toString('base64'),
+        },
+      ],
+    })).rejects.toThrow('消息未找到')
+
+    await expect(messageRepository.loadAttachmentData('doc-missing')).resolves.toBeNull()
+    expect(existsSync(getAttachmentFilePath(attachmentsRoot, 'doc-missing'))).toBe(false)
+  })
+
+  it('rejects duplicate file_id and preserves old file and metadata', async () => {
+    const messageRepository = new SqliteMessageRepository(sqlite, { attachmentsRoot })
+    const conversationRepository = new SqliteConversationRepository(sqlite, {
+      prepareConversationAttachmentCleanup: messageRepository.prepareConversationAttachmentCleanup.bind(messageRepository),
+    })
+    const oldBytes = Buffer.from('old content', 'utf8')
+    const newBytes = Buffer.from('new content', 'utf8')
+
+    const conversation = await conversationRepository.create({
+      title: 'Duplicate test',
+      workspacePath: '/workspace',
+      createdAt: 1,
+      updatedAt: 1,
+      settings: { modelId: 'model-1', systemPrompt: '', temperature: 0.7, maxTokens: 1024 },
+    })
+
+    await messageRepository.create({
+      convId: conversation.id,
+      role: 'user',
+      status: 'success',
+      content: [
+        {
+          type: 'document',
+          source: { type: 'file_id', file_id: 'doc-dup' },
+          name: 'old.txt',
+          media_type: 'text/plain',
+          size: oldBytes.length,
+          data: oldBytes.toString('base64'),
+        },
+      ],
+    })
+
+    const message2 = await messageRepository.create({
+      convId: conversation.id,
+      role: 'user',
+      status: 'success',
+      content: [
+        {
+          type: 'document',
+          source: { type: 'file_id', file_id: 'doc-dup' },
+          name: 'new.txt',
+          media_type: 'text/plain',
+          size: newBytes.length,
+          data: newBytes.toString('base64'),
+        },
+      ],
+    })
+
+    await expect(messageRepository.loadAttachmentData('doc-dup')).resolves.toBe(oldBytes.toString('base64'))
+
+    const content = (await messageRepository.getById(message2.id)).content
+    const docBlock = content.find((b: { type: string }) => b.type === 'document')
+    expect(docBlock).toBeDefined()
+    expect((docBlock as any).source.file_id).toBe('doc-dup')
+  })
+
+  it('cleans up staging files when database update fails', async () => {
+    const messageRepository = new SqliteMessageRepository(sqlite, { attachmentsRoot })
+    const conversationRepository = new SqliteConversationRepository(sqlite, {
+      prepareConversationAttachmentCleanup: messageRepository.prepareConversationAttachmentCleanup.bind(messageRepository),
+    })
+    const bytes = Buffer.from('staging test', 'utf8')
+
+    const conversation = await conversationRepository.create({
+      title: 'Staging test',
+      workspacePath: '/workspace',
+      createdAt: 1,
+      updatedAt: 1,
+      settings: { modelId: 'model-1', systemPrompt: '', temperature: 0.7, maxTokens: 1024 },
+    })
+
+    const message = await messageRepository.create({
+      convId: conversation.id,
+      role: 'user',
+      status: 'success',
+      content: [{ type: 'text', text: 'hello' }],
+    })
+
+    await expect(messageRepository.update({
+      id: message.id,
+      content: [
+        {
+          type: 'document',
+          source: { type: 'file_id', file_id: 'doc-staging' },
+          name: 'staging.txt',
+          media_type: 'text/plain',
+          size: bytes.length,
+          data: bytes.toString('base64'),
+        },
+      ],
+    })).resolves.toBeDefined()
+
+    await expect(messageRepository.loadAttachmentData('doc-staging')).resolves.toBe(bytes.toString('base64'))
+  })
+
+  it('normal create and update with new IDs succeed and loadAttachmentData returns original bytes', async () => {
+    const messageRepository = new SqliteMessageRepository(sqlite, { attachmentsRoot })
+    const conversationRepository = new SqliteConversationRepository(sqlite, {
+      prepareConversationAttachmentCleanup: messageRepository.prepareConversationAttachmentCleanup.bind(messageRepository),
+    })
+    const bytes = Buffer.from('normal test', 'utf8')
+
+    const conversation = await conversationRepository.create({
+      title: 'Normal test',
+      workspacePath: '/workspace',
+      createdAt: 1,
+      updatedAt: 1,
+      settings: { modelId: 'model-1', systemPrompt: '', temperature: 0.7, maxTokens: 1024 },
+    })
+
+    const message = await messageRepository.create({
+      convId: conversation.id,
+      role: 'user',
+      status: 'success',
+      content: [
+        { type: 'text', text: 'see file' },
+        {
+          type: 'document',
+          source: { type: 'file_id', file_id: 'doc-normal' },
+          name: 'normal.txt',
+          media_type: 'text/plain',
+          size: bytes.length,
+          data: bytes.toString('base64'),
+        },
+      ],
+    })
+
+    const createdContent = message.content
+    expect(createdContent.find((b: { type: string }) => b.type === 'document')).toBeUndefined()
+    await expect(messageRepository.loadAttachmentData('doc-normal')).resolves.toBe(bytes.toString('base64'))
+
+    const newBytes = Buffer.from('updated content', 'utf8')
+    const updated = await messageRepository.update({
+      id: message.id,
+      content: [
+        { type: 'text', text: 'see updated file' },
+        {
+          type: 'document',
+          source: { type: 'file_id', file_id: 'doc-updated' },
+          name: 'updated.txt',
+          media_type: 'text/plain',
+          size: newBytes.length,
+          data: newBytes.toString('base64'),
+        },
+      ],
+    })
+
+    const updatedContent = updated.content
+    expect(updatedContent.find((b: { type: string }) => b.type === 'document')).toBeUndefined()
+    await expect(messageRepository.loadAttachmentData('doc-updated')).resolves.toBe(newBytes.toString('base64'))
+  })
 })
+
+function existsSync(filePath: string): boolean {
+  try {
+    readFileSync(filePath)
+    return true
+  }
+  catch {
+    return false
+  }
+}
 
 function canRunDbIntegrationTests() {
   const result = spawnSync(process.execPath, ['-e', `

--- a/packages/app-data/src/sqlite/repositories/__tests__/sqliteRepositories.spec.ts
+++ b/packages/app-data/src/sqlite/repositories/__tests__/sqliteRepositories.spec.ts
@@ -379,6 +379,49 @@ describe.skipIf(!canRunDbIntegrationTests())('sqlite repositories', () => {
     await conversationRepository.delete(conversation.id)
     await expect(messageRepository.loadAttachmentData('file-1')).resolves.toBeNull()
   })
+
+  it('deletes all conversations in target workspace via deleteByWorkspace', async () => {
+    const conversationRepository = new SqliteConversationRepository(sqlite)
+
+    await conversationRepository.create({ title: 'Target 1', workspacePath: '/ws-a', createdAt: 1, updatedAt: 1, settings: { modelId: 'm', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
+    await conversationRepository.create({ title: 'Target 2', workspacePath: '/ws-a', createdAt: 2, updatedAt: 2, settings: { modelId: 'm', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
+    await conversationRepository.create({ title: 'Other', workspacePath: '/ws-b', createdAt: 3, updatedAt: 3, settings: { modelId: 'm', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
+
+    const deletedIds = await conversationRepository.deleteByWorkspace('/ws-a')
+
+    expect(deletedIds).toHaveLength(2)
+    const remaining = await conversationRepository.list(0, 100, '/ws-b')
+    expect(remaining.data).toHaveLength(1)
+    expect(remaining.data[0].title).toBe('Other')
+  })
+
+  it('includes null workspace conversations when includeNullWorkspace is true', async () => {
+    const conversationRepository = new SqliteConversationRepository(sqlite)
+
+    await conversationRepository.create({ title: 'Named', workspacePath: '/ws-a', createdAt: 1, updatedAt: 1, settings: { modelId: 'm', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
+    await conversationRepository.create({ title: 'Default', workspacePath: undefined, createdAt: 2, updatedAt: 2, settings: { modelId: 'm', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
+    await conversationRepository.create({ title: 'Other', workspacePath: '/ws-b', createdAt: 3, updatedAt: 3, settings: { modelId: 'm', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
+
+    const deletedIds = await conversationRepository.deleteByWorkspace('/ws-a', true)
+
+    expect(deletedIds).toHaveLength(2)
+    const remaining = await conversationRepository.list(0, 100)
+    expect(remaining.data).toHaveLength(1)
+    expect(remaining.data[0].title).toBe('Other')
+  })
+
+  it('preserves conversations in other workspaces', async () => {
+    const conversationRepository = new SqliteConversationRepository(sqlite)
+
+    await conversationRepository.create({ title: 'A', workspacePath: '/ws-a', createdAt: 1, updatedAt: 1, settings: { modelId: 'm', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
+    await conversationRepository.create({ title: 'B', workspacePath: '/ws-b', createdAt: 2, updatedAt: 2, settings: { modelId: 'm', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
+
+    await conversationRepository.deleteByWorkspace('/ws-a')
+
+    const bList = await conversationRepository.list(0, 100, '/ws-b')
+    expect(bList.data).toHaveLength(1)
+    expect(bList.data[0].title).toBe('B')
+  })
 })
 
 function canRunDbIntegrationTests() {

--- a/packages/app-data/src/sqlite/repositories/__tests__/sqliteRepositories.spec.ts
+++ b/packages/app-data/src/sqlite/repositories/__tests__/sqliteRepositories.spec.ts
@@ -573,7 +573,9 @@ describe.skipIf(!canRunDbIntegrationTests())('sqlite repositories', () => {
     })
 
     const createdContent = message.content
-    expect(createdContent.find((b: { type: string }) => b.type === 'document')).toBeUndefined()
+    const createdDoc = createdContent.find((b: { type: string }) => b.type === 'document')
+    expect(createdDoc).toBeDefined()
+    expect((createdDoc as any).data).toBeUndefined()
     await expect(messageRepository.loadAttachmentData('doc-normal')).resolves.toBe(bytes.toString('base64'))
 
     const newBytes = Buffer.from('updated content', 'utf8')
@@ -593,7 +595,9 @@ describe.skipIf(!canRunDbIntegrationTests())('sqlite repositories', () => {
     })
 
     const updatedContent = updated.content
-    expect(updatedContent.find((b: { type: string }) => b.type === 'document')).toBeUndefined()
+    const updatedDoc = updatedContent.find((b: { type: string }) => b.type === 'document')
+    expect(updatedDoc).toBeDefined()
+    expect((updatedDoc as any).data).toBeUndefined()
     await expect(messageRepository.loadAttachmentData('doc-updated')).resolves.toBe(newBytes.toString('base64'))
   })
 })

--- a/packages/app-data/src/sqlite/repositories/sqliteConversationRepository.ts
+++ b/packages/app-data/src/sqlite/repositories/sqliteConversationRepository.ts
@@ -140,6 +140,36 @@ export class SqliteConversationRepository implements ConversationRepository {
     return true
   }
 
+  async deleteByWorkspace(workspacePath?: string, includeNullWorkspace = false): Promise<string[]> {
+    const workspaceWhere = getWorkspaceWhere(workspacePath, includeNullWorkspace)
+    const rows = this.db.prepare<unknown[], { id: string }>(`
+      SELECT id FROM conversations ${workspaceWhere.sql}
+    `).all(...workspaceWhere.params)
+    const ids = rows.map(row => row.id)
+
+    if (ids.length === 0) {
+      return []
+    }
+
+    const cleanupCallbacks: (() => void)[] = []
+    const deleteAll = this.db.transaction(() => {
+      for (const id of ids) {
+        const cleanup = this.options.prepareConversationAttachmentCleanup?.(id)
+        if (cleanup) {
+          cleanupCallbacks.push(cleanup)
+        }
+        this.db.prepare('DELETE FROM conversations WHERE id = ?').run(id)
+      }
+    })
+
+    deleteAll()
+    for (const cleanup of cleanupCallbacks) {
+      cleanup()
+    }
+
+    return ids
+  }
+
   async exists(id: string): Promise<boolean> {
     const result = this.db.prepare<unknown[], { count: number }>(`
       SELECT count(1) AS count

--- a/packages/app-data/src/sqlite/repositories/sqliteMessageRepository.ts
+++ b/packages/app-data/src/sqlite/repositories/sqliteMessageRepository.ts
@@ -83,7 +83,7 @@ export class SqliteMessageRepository implements MessageRepository {
       const content = this.stageAttachmentData(message.content, stagedFiles)
 
       const createMessage = this.db.transaction(() => {
-        this.commitStagedAttachments(stagedFiles)
+        this.commitStagedAttachments(stagedFiles, true)
         for (const staged of stagedFiles) {
           committedFiles.add(staged.fileId)
         }
@@ -209,7 +209,7 @@ export class SqliteMessageRepository implements MessageRepository {
       }
 
       const updateMessage = this.db.transaction(() => {
-        this.commitStagedAttachments(stagedFiles)
+        this.commitStagedAttachments(stagedFiles, true)
         for (const staged of stagedFiles) {
           committedFiles.add(staged.fileId)
         }
@@ -338,10 +338,18 @@ export class SqliteMessageRepository implements MessageRepository {
     })
   }
 
-  private commitStagedAttachments(stagedFiles: StagedAttachment[]): void {
+  private commitStagedAttachments(stagedFiles: StagedAttachment[], skipExisting = false): void {
     for (const staged of stagedFiles) {
       const existing = this.db.prepare<unknown[], { id: string }>('SELECT id FROM attachments WHERE id = ?').get(staged.fileId)
       if (existing) {
+        if (skipExisting) {
+          // 附件已存在时跳过写入，清理临时文件，保留旧数据
+          try {
+            rmSync(staged.tempPath, { force: true })
+          }
+          catch {}
+          continue
+        }
         throw new Error(`附件 ID 已存在: ${staged.fileId}`)
       }
 

--- a/packages/app-data/src/sqlite/repositories/sqliteMessageRepository.ts
+++ b/packages/app-data/src/sqlite/repositories/sqliteMessageRepository.ts
@@ -2,13 +2,22 @@ import type { AddMessage, AIMessage, IMessage, MessageContent, UpdateMessageSche
 import type { MessageRepository } from '../../repositories'
 import type { MessageRow } from '../rows'
 import type { AppDataDatabase } from '../types'
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import { nanoid } from 'nanoid'
 import { getAttachmentFileCandidates, getAttachmentFilePath } from '../attachmentFiles'
 import { decodeAttachmentData } from '../migrations/migrateAttachments'
 import { mapMessageRow, parseMessageContent, stringifyJson } from '../rows'
 import { SqliteConversationRepository } from './sqliteConversationRepository'
+
+interface StagedAttachment {
+  fileId: string
+  tempPath: string
+  finalPath: string
+  name: string
+  mediaType: string
+  size: number
+}
 
 interface SqliteMessageRepositoryOptions {
   attachmentsRoot?: string
@@ -68,10 +77,16 @@ export class SqliteMessageRepository implements MessageRepository {
     await this.conversations.getById(message.convId)
 
     const id = options?.id ?? `msg-${nanoid()}`
-    const writtenFiles: string[] = []
+    const stagedFiles: StagedAttachment[] = []
+    const committedFiles = new Set<string>()
     try {
+      const content = this.stageAttachmentData(message.content, stagedFiles)
+
       const createMessage = this.db.transaction(() => {
-        const content = this.persistAttachmentData(message.content, writtenFiles)
+        this.commitStagedAttachments(stagedFiles)
+        for (const staged of stagedFiles) {
+          committedFiles.add(staged.fileId)
+        }
         return this.db.prepare<unknown[], MessageRow>(`
           INSERT INTO messages (
             id,
@@ -115,7 +130,7 @@ export class SqliteMessageRepository implements MessageRepository {
       return mapMessageRow(result)
     }
     catch (error) {
-      cleanupWrittenFiles(writtenFiles)
+      this.cleanupStagedFiles(stagedFiles, committedFiles)
       throw error
     }
   }
@@ -133,6 +148,8 @@ export class SqliteMessageRepository implements MessageRepository {
   }
 
   async update(message: UpdateMessageSchema): Promise<IMessage> {
+    const existing = await this.getById(message.id)
+
     const fields: string[] = []
     const params: unknown[] = []
 
@@ -144,7 +161,8 @@ export class SqliteMessageRepository implements MessageRepository {
       fields.push('role = ?')
       params.push(message.role)
     }
-    const writtenFiles: string[] = []
+    const stagedFiles: StagedAttachment[] = []
+    const committedFiles = new Set<string>()
     if (message.content !== undefined)
       fields.push('content = ?')
     if (message.status !== undefined) {
@@ -181,40 +199,50 @@ export class SqliteMessageRepository implements MessageRepository {
     }
 
     if (fields.length === 0) {
-      return this.getById(message.id)
+      return existing
     }
 
-    const updateMessage = this.db.transaction(() => {
-      const transactionParams = [...params]
-      if (message.content !== undefined) {
-        transactionParams.splice(fields.findIndex(field => field === 'content = ?'), 0, stringifyJson(this.persistAttachmentData(message.content, writtenFiles)))
-      }
-
-      const result = this.db.prepare<unknown[], MessageRow>(`
-        UPDATE messages
-        SET ${fields.join(', ')}
-        WHERE id = ?
-        RETURNING ${MESSAGE_COLUMNS}
-      `).get(...transactionParams, message.id)
-
-      if (!result) {
-        throw new Error('消息未找到')
-      }
-
-      this.db.prepare(`
-        UPDATE conversations
-        SET updated_at = ?
-        WHERE id = ?
-      `).run(Date.now(), result.conv_id)
-
-      return result
-    })
-
     try {
+      let content: MessageContent | undefined
+      if (message.content !== undefined) {
+        content = this.stageAttachmentData(message.content, stagedFiles)
+      }
+
+      const updateMessage = this.db.transaction(() => {
+        this.commitStagedAttachments(stagedFiles)
+        for (const staged of stagedFiles) {
+          committedFiles.add(staged.fileId)
+        }
+
+        const transactionParams = [...params]
+        if (content !== undefined) {
+          transactionParams.splice(fields.findIndex(field => field === 'content = ?'), 0, stringifyJson(content))
+        }
+
+        const result = this.db.prepare<unknown[], MessageRow>(`
+          UPDATE messages
+          SET ${fields.join(', ')}
+          WHERE id = ?
+          RETURNING ${MESSAGE_COLUMNS}
+        `).get(...transactionParams, message.id)
+
+        if (!result) {
+          throw new Error('消息未找到')
+        }
+
+        this.db.prepare(`
+          UPDATE conversations
+          SET updated_at = ?
+          WHERE id = ?
+        `).run(Date.now(), result.conv_id)
+
+        return result
+      })
+
       return mapMessageRow(updateMessage())
     }
     catch (error) {
-      cleanupWrittenFiles(writtenFiles)
+      this.cleanupStagedFiles(stagedFiles, committedFiles)
       throw error
     }
   }
@@ -271,7 +299,7 @@ export class SqliteMessageRepository implements MessageRepository {
     return () => this.removeAttachmentFiles(fileIds)
   }
 
-  private persistAttachmentData(content: MessageContent, writtenFiles: string[]): MessageContent {
+  private stageAttachmentData(content: MessageContent, stagedFiles: StagedAttachment[]): MessageContent {
     return content.map((block) => {
       if (
         block.type !== 'image-block'
@@ -289,26 +317,61 @@ export class SqliteMessageRepository implements MessageRepository {
         throw new Error('Attachment content with inline data must use file_id source')
       }
 
-      const filePath = getAttachmentFilePath(this.requireAttachmentsRoot(), block.source.file_id)
-      mkdirSync(path.dirname(filePath), { recursive: true })
+      const attachmentsRoot = this.requireAttachmentsRoot()
+      const finalPath = getAttachmentFilePath(attachmentsRoot, block.source.file_id)
+      const tempPath = `${finalPath}.staging-${nanoid()}`
+      mkdirSync(path.dirname(finalPath), { recursive: true })
       const bytes = decodeAttachmentData(block.data)
-      writeFileSync(filePath, bytes)
-      writtenFiles.push(filePath)
+      writeFileSync(tempPath, bytes)
 
-      this.db.prepare(`
-        INSERT OR REPLACE INTO attachments (id, name, media_type, size, created_at)
-        VALUES (?, ?, ?, ?, ?)
-      `).run(
-        block.source.file_id,
-        block.type === 'file' ? block.filename ?? block.name ?? 'file' : block.name ?? block.type,
-        block.media_type ?? 'application/octet-stream',
-        block.size ?? bytes.byteLength,
-        Date.now(),
-      )
+      stagedFiles.push({
+        fileId: block.source.file_id,
+        tempPath,
+        finalPath,
+        name: block.type === 'file' ? block.filename ?? block.name ?? 'file' : block.name ?? block.type,
+        mediaType: block.media_type ?? 'application/octet-stream',
+        size: block.size ?? bytes.byteLength,
+      })
 
       const { data: _data, ...persistedBlock } = block
       return persistedBlock
     })
+  }
+
+  private commitStagedAttachments(stagedFiles: StagedAttachment[]): void {
+    for (const staged of stagedFiles) {
+      const existing = this.db.prepare<unknown[], { id: string }>('SELECT id FROM attachments WHERE id = ?').get(staged.fileId)
+      if (existing) {
+        throw new Error(`附件 ID 已存在: ${staged.fileId}`)
+      }
+
+      renameSync(staged.tempPath, staged.finalPath)
+
+      this.db.prepare(`
+        INSERT INTO attachments (id, name, media_type, size, created_at)
+        VALUES (?, ?, ?, ?, ?)
+      `).run(
+        staged.fileId,
+        staged.name,
+        staged.mediaType,
+        staged.size,
+        Date.now(),
+      )
+    }
+  }
+
+  private cleanupStagedFiles(stagedFiles: StagedAttachment[], committedFiles: Set<string>): void {
+    for (const staged of stagedFiles) {
+      try {
+        rmSync(staged.tempPath, { force: true })
+      }
+      catch {
+        // 临时文件可能已被 rename 移除
+      }
+      if (committedFiles.has(staged.fileId)) {
+        rmSync(staged.finalPath, { force: true })
+      }
+    }
   }
 
   private getMessageAttachmentFileIds(messageIds: string[]): string[] {
@@ -359,12 +422,6 @@ export class SqliteMessageRepository implements MessageRepository {
       throw new Error('attachmentsRoot is required for attachment file storage')
     }
     return this.options.attachmentsRoot
-  }
-}
-
-function cleanupWrittenFiles(filePaths: string[]): void {
-  for (const filePath of filePaths) {
-    rmSync(filePath, { force: true })
   }
 }
 

--- a/packages/app-runtime/src/__tests__/appRuntime.spec.ts
+++ b/packages/app-runtime/src/__tests__/appRuntime.spec.ts
@@ -61,6 +61,17 @@ describe.skipIf(!canRunDbIntegrationTests())('app runtime', () => {
     expect(settingsEvents).toEqual([{ keys: ['assistantModelId'] }])
     expect(workspaceEvents).toEqual([{ currentWorkspacePath: workspace.path }])
   })
+
+  it('clears all conversations in current workspace', async () => {
+    await runtime.chat.createConversation({ title: 'Conv 1', createdAt: 1, updatedAt: 1, settings: { modelId: 'm', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
+    await runtime.chat.createConversation({ title: 'Conv 2', createdAt: 2, updatedAt: 2, settings: { modelId: 'm', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
+
+    const deletedIds = await runtime.chat.clearWorkspaceConversations()
+
+    expect(deletedIds.length).toBe(2)
+    const remaining = await runtime.chat.listConversations(0, 100)
+    expect(remaining.total).toBe(0)
+  })
 })
 
 function canRunDbIntegrationTests(): boolean {

--- a/packages/app-runtime/src/appRuntime.ts
+++ b/packages/app-runtime/src/appRuntime.ts
@@ -146,6 +146,23 @@ export function createAppRuntime(options: CreateAppRuntimeOptions) {
         await context.conversationRepository.delete(id)
         return null
       },
+      clearWorkspaceConversations: async (workspacePath?: string) => {
+        const targetWorkspace = workspacePath ?? context.workspaceService.getCurrentWorkspacePath()
+        const includeNullWorkspace = targetWorkspace === context.workspaceService.getDefaultWorkspacePath()
+
+        const listResult = await context.conversationRepository.list(0, Number.MAX_SAFE_INTEGER, targetWorkspace, includeNullWorkspace)
+        const targetIds = listResult.data.map(c => c.id)
+
+        if (targetIds.length === 0) {
+          return []
+        }
+
+        for (const id of targetIds) {
+          await agentRuntime.closeConversation(id)
+        }
+
+        return await context.conversationRepository.deleteByWorkspace(targetWorkspace, includeNullWorkspace)
+      },
       listMessages: (conversationId: string) => context.messageRepository.listByConversation(conversationId),
       getMessage: (id: string) => context.messageRepository.getById(id),
       createMessage: (message: IMessage) => context.messageRepository.create(AddMessage.parse(message)),

--- a/packages/app-runtime/src/appRuntime.ts
+++ b/packages/app-runtime/src/appRuntime.ts
@@ -179,11 +179,31 @@ export function createAppRuntime(options: CreateAppRuntimeOptions) {
     settings: {
       get: () => context.settingsRepository.getGeneralSettings(),
       update: async (updates: Partial<GeneralSettingsState>) => {
-        const settings = await context.settingsRepository.updateGeneralSettings(updates)
-        if (updates.proxySettings)
-          await networkProxy.apply(updates.proxySettings)
-        events.emit('settings:updated', { keys: Object.keys(updates) })
-        return settings
+        if (!updates.proxySettings) {
+          const settings = await context.settingsRepository.updateGeneralSettings(updates)
+          events.emit('settings:updated', { keys: Object.keys(updates) })
+          return settings
+        }
+
+        const currentSettings = await context.settingsRepository.getGeneralSettings()
+        const previousProxySettings = currentSettings.proxySettings
+
+        await networkProxy.apply(updates.proxySettings)
+
+        try {
+          const settings = await context.settingsRepository.updateGeneralSettings(updates)
+          events.emit('settings:updated', { keys: Object.keys(updates) })
+          return settings
+        }
+        catch (persistError) {
+          try {
+            await networkProxy.apply(previousProxySettings)
+          }
+          catch {
+            // 恢复失败时不覆盖原始错误
+          }
+          throw persistError
+        }
       },
       reset: async () => {
         const settings = await context.settingsRepository.resetGeneralSettings()

--- a/packages/local-server/src/__tests__/createServer.spec.ts
+++ b/packages/local-server/src/__tests__/createServer.spec.ts
@@ -3,6 +3,7 @@ import type { AppRuntime } from '@ant-chat/app-runtime'
 import { request } from 'node:http'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createLocalServer } from '../createServer'
+import type { RpcLimits } from '../createServer'
 
 const runtime = {
   chat: {
@@ -13,15 +14,19 @@ const runtime = {
 let server: ReturnType<typeof createLocalServer>
 let baseUrl: URL
 
-beforeEach(async () => {
+async function startServer(limits?: RpcLimits) {
   vi.clearAllMocks()
   runtime.chat.listConversations = vi.fn().mockResolvedValue({ data: [], total: 0 })
-  server = createLocalServer(runtime)
+  server = createLocalServer(runtime, limits)
   await new Promise<void>((resolve) => {
     server.listen(0, '127.0.0.1', resolve)
   })
   const address = server.address() as AddressInfo
   baseUrl = new URL(`http://127.0.0.1:${address.port}`)
+}
+
+beforeEach(async () => {
+  await startServer()
 })
 
 afterEach(async () => {
@@ -65,6 +70,69 @@ describe('createLocalServer', () => {
     })
     expect(runtime.chat.listConversations).toHaveBeenCalledWith(0, 20)
   })
+
+  it('接受恰好等于上限的请求体', async () => {
+    await startServer({ maxBodyBytes: 100 })
+    const body = JSON.stringify({ method: 'chat.getConversations', params: { pageIndex: 0, pageSize: 20 } })
+    const response = await send({
+      method: 'POST',
+      path: '/api/rpc',
+      body,
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(JSON.parse(response.body).success).toBe(true)
+  })
+
+  it('超过大小限制返回 413', async () => {
+    await startServer({ maxBodyBytes: 10 })
+    const body = JSON.stringify({ method: 'chat.getConversations', params: { pageIndex: 0, pageSize: 20 } })
+    const response = await send({
+      method: 'POST',
+      path: '/api/rpc',
+      body,
+    })
+
+    expect(response.statusCode).toBe(413)
+    expect(JSON.parse(response.body).success).toBe(false)
+    expect(runtime.chat.listConversations).not.toHaveBeenCalled()
+  })
+
+  it('分多个 chunk 超限也返回 413', async () => {
+    await startServer({ maxBodyBytes: 10 })
+    const response = await sendChunked({
+      method: 'POST',
+      path: '/api/rpc',
+      chunks: ['{"method":', '"chat.getConversations","params":{}', '}'],
+    })
+
+    expect(response.statusCode).toBe(413)
+    expect(JSON.parse(response.body).success).toBe(false)
+  })
+
+  it('超时请求返回 408', async () => {
+    await startServer({ bodyTimeoutMs: 100 })
+    const response = await sendSlow({
+      method: 'POST',
+      path: '/api/rpc',
+      body: '{"method":"chat.getConversations","params":{}}',
+      delayMs: 200,
+    })
+
+    expect(response.statusCode).toBe(408)
+    expect(JSON.parse(response.body).success).toBe(false)
+  })
+
+  it('非 JSON 请求返回 500', async () => {
+    const response = await send({
+      method: 'POST',
+      path: '/api/rpc',
+      body: 'not json',
+    })
+
+    expect(response.statusCode).toBe(500)
+    expect(JSON.parse(response.body).success).toBe(false)
+  })
 })
 
 function send(options: { method: string, path: string, body?: string }): Promise<{ statusCode: number, headers: Record<string, string | string[] | undefined>, body: string }> {
@@ -90,5 +158,60 @@ function send(options: { method: string, path: string, body?: string }): Promise
     if (options.body)
       req.write(options.body)
     req.end()
+  })
+}
+
+function sendChunked(options: { method: string, path: string, chunks: string[] }): Promise<{ statusCode: number, headers: Record<string, string | string[] | undefined>, body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = request(
+      new URL(options.path, baseUrl),
+      {
+        method: options.method,
+        headers: { 'content-type': 'application/json' },
+      },
+      (res) => {
+        let body = ''
+        res.setEncoding('utf8')
+        res.on('data', chunk => body += chunk)
+        res.on('end', () => resolve({
+          statusCode: res.statusCode ?? 0,
+          headers: res.headers,
+          body,
+        }))
+      },
+    )
+    req.on('error', reject)
+    for (const chunk of options.chunks) {
+      req.write(chunk)
+    }
+    req.end()
+  })
+}
+
+function sendSlow(options: { method: string, path: string, body: string, delayMs: number }): Promise<{ statusCode: number, headers: Record<string, string | string[] | undefined>, body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = request(
+      new URL(options.path, baseUrl),
+      {
+        method: options.method,
+        headers: { 'content-type': 'application/json' },
+      },
+      (res) => {
+        let body = ''
+        res.setEncoding('utf8')
+        res.on('data', chunk => body += chunk)
+        res.on('end', () => resolve({
+          statusCode: res.statusCode ?? 0,
+          headers: res.headers,
+          body,
+        }))
+      },
+    )
+    req.on('error', reject)
+    req.write(options.body.slice(0, 1))
+    setTimeout(() => {
+      req.write(options.body.slice(1))
+      req.end()
+    }, options.delayMs)
   })
 }

--- a/packages/local-server/src/createServer.ts
+++ b/packages/local-server/src/createServer.ts
@@ -4,10 +4,28 @@ import type { IncomingMessage, ServerResponse } from 'node:http'
 import { Buffer } from 'node:buffer'
 import { createServer as createHttpServer } from 'node:http'
 
+const MAX_RPC_BODY_BYTES = 32 * 1024 * 1024
+const RPC_BODY_TIMEOUT_MS = 30_000
+
+class RpcRequestError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+  ) {
+    super(message)
+    this.name = 'RpcRequestError'
+  }
+}
+
+export interface RpcLimits {
+  maxBodyBytes?: number
+  bodyTimeoutMs?: number
+}
+
 export type LocalApiHandler = (req: IncomingMessage, res: ServerResponse) => Promise<boolean>
 
-export function createLocalServer(runtime: object) {
-  const handleLocalApiRequest = createLocalApiHandler(runtime)
+export function createLocalServer(runtime: object, limits?: RpcLimits) {
+  const handleLocalApiRequest = createLocalApiHandler(runtime, limits)
 
   return createHttpServer(async (req, res) => {
     const handled = await handleLocalApiRequest(req, res)
@@ -19,8 +37,10 @@ export function createLocalServer(runtime: object) {
   })
 }
 
-export function createLocalApiHandler(runtime: object): LocalApiHandler {
+export function createLocalApiHandler(runtime: object, limits?: RpcLimits): LocalApiHandler {
   const appRuntime = runtime as AppRuntime
+  const maxBodyBytes = limits?.maxBodyBytes ?? MAX_RPC_BODY_BYTES
+  const bodyTimeoutMs = limits?.bodyTimeoutMs ?? RPC_BODY_TIMEOUT_MS
 
   return async (req, res) => {
     try {
@@ -34,7 +54,7 @@ export function createLocalApiHandler(runtime: object): LocalApiHandler {
         return true
       }
 
-      const body = await readJsonBody(req)
+      const body = await readJsonBody(req, maxBodyBytes, bodyTimeoutMs)
       const result = await routeRequest(url, body, appRuntime)
 
       res.writeHead(200, { 'content-type': 'application/json; charset=utf-8' })
@@ -42,7 +62,8 @@ export function createLocalApiHandler(runtime: object): LocalApiHandler {
     }
     catch (error) {
       const message = error instanceof Error ? error.message : String(error)
-      res.writeHead(500, { 'content-type': 'application/json; charset=utf-8' })
+      const statusCode = error instanceof RpcRequestError ? error.statusCode : 500
+      res.writeHead(statusCode, { 'content-type': 'application/json; charset=utf-8' })
       res.end(JSON.stringify({ success: false, msg: message }))
     }
     return true
@@ -273,10 +294,39 @@ function booleanParam(value: unknown): boolean {
   return value
 }
 
-async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+async function readJsonBody(
+  req: IncomingMessage,
+  maxBytes = MAX_RPC_BODY_BYTES,
+  timeoutMs = RPC_BODY_TIMEOUT_MS,
+): Promise<unknown> {
   const chunks: Buffer[] = []
-  for await (const chunk of req) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  let totalBytes = 0
+  let timer: ReturnType<typeof setTimeout> | null = null
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new RpcRequestError('请求体读取超时', 408))
+    }, timeoutMs)
+  })
+
+  try {
+    const readPromise = (async () => {
+      for await (const chunk of req) {
+        const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+        totalBytes += buf.length
+        if (totalBytes > maxBytes) {
+          throw new RpcRequestError('请求体超过大小限制', 413)
+        }
+        chunks.push(buf)
+      }
+    })()
+
+    await Promise.race([readPromise, timeoutPromise])
+  }
+  finally {
+    if (timer) {
+      clearTimeout(timer)
+    }
   }
 
   if (chunks.length === 0) {

--- a/packages/local-server/src/createServer.ts
+++ b/packages/local-server/src/createServer.ts
@@ -79,6 +79,8 @@ async function dispatchRpc(body: unknown, runtime: AppRuntime): Promise<unknown>
       return runtime.chat.updateConversation(params.conversation as UpdateConversationsSchema)
     case 'chat.deleteConversation':
       return runtime.chat.deleteConversation(stringParam(params.id))
+    case 'chat.clearWorkspaceConversations':
+      return runtime.chat.clearWorkspaceConversations(stringParam(params.workspacePath))
     case 'chat.getMessagesByConvId':
       return runtime.chat.listMessages(stringParam(params.convId))
     case 'chat.getMessageById':

--- a/packages/mcp-client-hub/package.json
+++ b/packages/mcp-client-hub/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "build": "tsdown",
     "clean": "rm -rf dist node_modules",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -29,6 +30,7 @@
   },
   "devDependencies": {
     "@ant-chat/shared": "workspace:^",
-    "tsdown": "catalog:"
+    "tsdown": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/mcp-client-hub/src/__tests__/mcpClientHub.spec.ts
+++ b/packages/mcp-client-hub/src/__tests__/mcpClientHub.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_MCP_TIMEOUT_SECONDS, resolveMcpToolTimeoutMs } from '../schema'
+
+describe('resolveMcpToolTimeoutMs', () => {
+  it('未传值时返回默认超时毫秒', () => {
+    expect(resolveMcpToolTimeoutMs()).toBe(DEFAULT_MCP_TIMEOUT_SECONDS * 1000)
+    expect(resolveMcpToolTimeoutMs()).toBe(10000)
+  })
+
+  it('传入整数秒时只转换一次', () => {
+    expect(resolveMcpToolTimeoutMs(3)).toBe(3000)
+  })
+
+  it('传入小数秒时返回对应整数毫秒', () => {
+    expect(resolveMcpToolTimeoutMs(0.5)).toBe(500)
+  })
+})

--- a/packages/mcp-client-hub/src/mcpClientHub.ts
+++ b/packages/mcp-client-hub/src/mcpClientHub.ts
@@ -9,7 +9,7 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 import { CallToolResultSchema, ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js'
 import deepEqual from 'fast-deep-equal'
 import * as packageJson from '../../../package.json'
-import { DEFAULT_MCP_TIMEOUT_SECONDS, DEFAULT_REQUEST_TIMEOUT_MS } from './schema'
+import { DEFAULT_REQUEST_TIMEOUT_MS, resolveMcpToolTimeoutMs } from './schema'
 import { getCurrentPlatform } from './utils'
 
 export type ITool = Pick<Tool, 'name' | 'description' | 'inputSchema'> & {
@@ -227,16 +227,19 @@ export class MCPClientHub {
       throw new Error(`Server "${serverName}" is disabled and cannot be used`)
     }
 
-    let timeout = secondsToMs(DEFAULT_MCP_TIMEOUT_SECONDS) // sdk expects ms
+    let timeoutSeconds: number | undefined
 
     try {
       const config = JSON.parse(connection.server.config)
       const parsedConfig = McpConfigSchema.parse(config)
-      timeout = secondsToMs(parsedConfig?.timeout || timeout)
+      timeoutSeconds = parsedConfig?.timeout
     }
     catch (error) {
       console.error(`Failed to parse timeout configuration for server ${serverName}: ${error}`)
     }
+
+    // 解析失败时回退到默认 10 秒；秒到毫秒只在此处转换一次
+    const timeout = resolveMcpToolTimeoutMs(timeoutSeconds)
 
     const result = await connection.client.request(
       {
@@ -282,10 +285,6 @@ export class MCPClientHub {
     for (const callback of this.onStatusChangeCallbacks)
       callback(name, status)
   }
-}
-
-function secondsToMs(seconds: number) {
-  return seconds * 1000
 }
 
 function mergePathEnv(path: string) {

--- a/packages/mcp-client-hub/src/schema.ts
+++ b/packages/mcp-client-hub/src/schema.ts
@@ -5,6 +5,15 @@ import { z } from 'zod'
 export const DEFAULT_REQUEST_TIMEOUT_MS = 5000
 export const DEFAULT_MCP_TIMEOUT_SECONDS = 10
 
+/**
+ * 把超时秒数转换成 MCP SDK 需要的毫秒。
+ * 用空值合并选择默认值，保证 0 之类的合法数值不会被改写。
+ * 秒到毫秒只转换一次，避免重复相乘导致默认值膨胀。
+ */
+export function resolveMcpToolTimeoutMs(timeoutSeconds?: number): number {
+  return (timeoutSeconds ?? DEFAULT_MCP_TIMEOUT_SECONDS) * 1000
+}
+
 export interface McpSettings {
   mcpServers: Record<string, McpConfigSchemaType>
 }

--- a/packages/mcp-client-hub/vitest.config.ts
+++ b/packages/mcp-client-hub/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.spec.{ts,tsx}'],
+    globals: true,
+  },
+})

--- a/packages/shared/src/interfaces/app-transport.ts
+++ b/packages/shared/src/interfaces/app-transport.ts
@@ -60,6 +60,7 @@ export interface AppTransport {
     addConversation: (conversation: AddConversationsSchema) => Promise<IConversations>
     updateConversation: (conversation: UpdateConversationsSchema) => Promise<IConversations>
     deleteConversation: (id: string) => Promise<null>
+    clearWorkspaceConversations: (workspacePath: string) => Promise<string[]>
     getMessagesByConvId: (convId: string) => Promise<IMessage[]>
     getMessageById: (id: string) => Promise<IMessage>
     addMessage: (message: IMessage) => Promise<IMessage>
@@ -169,6 +170,7 @@ export interface AppIpcServices {
     addConversation: (conversation: AddConversationsSchema) => Promise<IpcResponse<IConversations>>
     updateConversation: (conversation: UpdateConversationsSchema) => Promise<IpcResponse<IConversations>>
     deleteConversation: (id: string) => Promise<IpcResponse<null>>
+    clearWorkspaceConversations: (workspacePath: string) => Promise<IpcResponse<string[]>>
     getMessagesByConvId: (id: string) => Promise<IpcResponse<IMessage[]>>
     getMessageById: (id: string) => Promise<IpcResponse<IMessage>>
     addMessage: (message: IMessage) => Promise<IpcResponse<IMessage>>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -491,6 +491,9 @@ importers:
       tsdown:
         specifier: 'catalog:'
         version: 0.20.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(synckit@0.11.12)(typescript@5.9.3)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@26.1.0)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/shared:
     dependencies:


### PR DESCRIPTION
## 变更摘要

8 个 bug 修复，覆盖安全防护、数据一致性、连接管理三个维度。

### 安全与稳定性
- 移除 MCP 配置日志，避免敏感信息泄露 (`51d088c`)
- 限制 RPC 请求体大小，防止资源耗尽攻击 (`f7e2ff5`)
- 附件写入失败时保留旧文件，采用安全写入策略 (`3119971`)

### 数据一致性
- 代理设置的应用与持久化保持同步 (`dcd9f51`)
- 过期会话的异步响应不再覆盖当前消息 (`b361f30`)
- 工作区对话清空操作真实删除数据 (`6ff9e8c`)

### 连接与通信
- SSE 事件监听器在断开时正确释放，修复内存泄漏 (`fab068e`)
- MCP 工具调用默认超时配置修正 (`22f7db5`)

### 测试
新增/增强 4 个测试文件，覆盖事件总线、SQLite 仓库、消息 actions、本地服务器 RPC 限制等场景。

## 影响范围

涉及 `packages/local-server`、`packages/app-runtime`、`packages/mcp-client-hub`、`packages/shared`、`apps/web`、`apps/desktop` 共 30 个文件，无破坏性变更。