### PR TITLE
[codex] 重构消息发送链路

### DIFF
--- a/apps/web/src/__tests__/gui.spec.tsx
+++ b/apps/web/src/__tests__/gui.spec.tsx
@@ -339,6 +339,35 @@ describe('gui ui flow', () => {
     expect(await screen.findByText('目录检查完成。')).toBeInTheDocument()
   })
 
+  it('agent 启动失败时显示后端错误并保留当前会话状态', async () => {
+    mocks.provider.getAllAbvailableModels.mockResolvedValue([{
+      id: 'provider-1',
+      name: 'Provider',
+      models: [{
+        id: 'model-1',
+        model: 'mock-model',
+        name: 'Mock Model',
+        providerId: 'provider-1',
+        maxTokens: 1024,
+        temperature: 0,
+      }],
+    }])
+    mocks.agent.startTurn.mockRejectedValue(new Error('Provider API Key not found: xiaomi-token-plan-cn'))
+
+    renderGui('/chat')
+    await waitFor(() => expect(screen.getByText('Mock Model')).toBeInTheDocument())
+
+    const input = screen.getByTestId('chat-input') as HTMLTextAreaElement
+    fireEvent.change(input, {
+      target: { value: '检查当前目录' },
+    })
+    fireEvent.click(screen.getByTestId('chat-submit'))
+
+    expect(await screen.findByText('Provider API Key not found: xiaomi-token-plan-cn')).toBeInTheDocument()
+    expect(useMessagesStore.getState().activeConversationsId).toBe('')
+    expect(input.value).toBe('检查当前目录')
+  })
+
   it('agent 审批卡片支持批准和拒绝', async () => {
     seedActiveConversation('conv-approval')
     useAgentStore.setState({

--- a/apps/web/src/components/Chat/Chat.tsx
+++ b/apps/web/src/components/Chat/Chat.tsx
@@ -3,12 +3,10 @@ import { Skeleton } from '@workspace/ui/components/skeleton'
 import { lazy, Suspense } from 'react'
 import { toast } from 'sonner'
 import { AgentApprovalCard, AgentSecretRequestCard } from '@/components/Agent'
-import { DEFAULT_TITLE } from '@/constants'
 import { useChatSettingsContext } from '@/contexts/chatSettings'
 import { useBuiltinCommandSubmit } from '@/hooks/useBuiltinCommandSubmit'
 import { approveAgentActionWithWhitelist, injectSteeringAction, rejectAgentAction, rejectSecretRequestAction, resolveSecretRequestAction, startAgentTurn, useAgentStore } from '@/store/agent'
 import {
-  initConversationsTitle,
   upsertConversationAction,
   useConversationsStore,
 } from '@/store/conversation'
@@ -73,27 +71,26 @@ export default function Chat() {
 
     // Regular agent turn
     const prompt = draftText
-    const isNewConversation = !activeConversationsId
-    const result = await startAgentTurn({
-      conversationId: activeConversationsId || undefined,
-      prompt,
-      content,
-      referencedFiles,
-      selectedSkill,
-      mode: agentMode,
-      workspacePath: currentWorkspacePath || undefined,
-      modelConfig: {
-        ...settings,
-        features,
-      },
-    })
-    upsertConversationAction(result.conversation)
-    await setActiveConversationsId(result.conversationId)
-
-    if (currentConversations?.title === DEFAULT_TITLE || isNewConversation) {
-      setTimeout(() => {
-        void initConversationsTitle(result.conversationId)
-      }, 1000)
+    try {
+      const result = await startAgentTurn({
+        conversationId: activeConversationsId || undefined,
+        prompt,
+        content,
+        referencedFiles,
+        selectedSkill,
+        mode: agentMode,
+        workspacePath: currentWorkspacePath || undefined,
+        modelConfig: {
+          ...settings,
+          features,
+        },
+      })
+      upsertConversationAction(result.conversation)
+      await setActiveConversationsId(result.conversationId)
+    }
+    catch (error) {
+      toast.error(error instanceof Error ? error.message : '发送消息失败')
+      throw error
     }
   }
 

--- a/packages/agent-core/src/__tests__/AgentRuntime.spec.ts
+++ b/packages/agent-core/src/__tests__/AgentRuntime.spec.ts
@@ -3,7 +3,7 @@ import { AgentRuntime } from '../AgentRuntime'
 import { runAgentLoop } from '../loop/agentLoop'
 import { taskStore } from '../taskStore'
 import { ToolRegistry } from '../tools/toolRegistry'
-import type { AgentRuntimeConfig, IAgentEventEmitter, ILogger, ISessionStore } from '@ant-chat/shared'
+import type { AgentRuntimeConfig, AgentRuntimeStartTaskOptions, IAgentEventEmitter, ILogger, ISessionStore } from '@ant-chat/shared'
 import type { RuntimeStartInput } from '../session/types'
 
 // Mock the agentLoop so startTask doesn't actually run the loop
@@ -52,13 +52,22 @@ function createSessionStore(overrides: Partial<ISessionStore> = {}): ISessionSto
       maxTokens: 1024,
     },
   }
+  const userMessage = {
+    id: 'user-msg-1',
+    convId: conversation.id,
+    createdAt: 2,
+    role: 'user' as const,
+    status: 'success' as const,
+    content: [{ type: 'text' as const, text: 'inspect project' }],
+    turnId: undefined,
+  }
   return {
     getConversation: vi.fn(async () => conversation),
     getConversationById: vi.fn(async () => conversation),
     createConversation: vi.fn(async () => conversation),
     updateConversation: vi.fn(async () => conversation),
     listConversations: vi.fn(async () => [conversation]),
-    getMessages: vi.fn(async () => []),
+    getMessages: vi.fn(async () => [userMessage]),
     getMessagesByConvId: vi.fn(async () => []),
     createUserMessage: vi.fn(async data => ({
       id: data.id ?? 'user-msg-1',
@@ -174,6 +183,30 @@ function createValidStartInput(overrides: Partial<RuntimeStartInput> = {}): Runt
   }
 }
 
+function createValidSessionStartInput(overrides: Partial<AgentRuntimeStartTaskOptions> = {}): AgentRuntimeStartTaskOptions {
+  return {
+    conversationId: 'conv-session',
+    userMessageId: 'user-msg-1',
+    prompt: 'inspect project',
+    modelId: 'model-1',
+    workspacePath: '/workspace',
+    mode: 'hybrid',
+    ...overrides,
+  }
+}
+
+function createPersistedUserMessage(text: string, id = 'user-msg-1') {
+  return {
+    id,
+    convId: 'conv-session',
+    createdAt: 10,
+    role: 'user' as const,
+    status: 'success' as const,
+    content: [{ type: 'text' as const, text }],
+    turnId: undefined,
+  }
+}
+
 // Clean up taskStore between tests
 function cleanupTasks(ids: string[]) {
   for (const id of ids) {
@@ -267,32 +300,23 @@ describe('agentRuntime 行为', () => {
       cleanupTasks([result1.taskId])
     })
 
-    it('通过高层 task 参数创建 session 状态并启动 loop', async () => {
+    it('通过高层 task 参数读取 session 状态并启动 loop', async () => {
       const store = createSessionStore()
       const config = createSessionConfig({ sessionStore: store })
       const runtime = new AgentRuntime(config)
 
-      const result = await runtime.startTask({
+      const result = await runtime.startTask(createValidSessionStartInput({
         prompt: ' inspect project ',
-        modelId: 'model-1',
-        workspacePath: '/workspace',
-        mode: 'hybrid',
         modelSettings: {
           systemPrompt: '',
           temperature: 0.7,
           maxTokens: 1024,
         },
-      })
+      }))
 
-      expect(store.createConversation).toHaveBeenCalledWith(expect.objectContaining({
-        title: 'Untitled',
-        workspacePath: '/workspace',
-      }))
-      expect(store.createUserMessage).toHaveBeenCalledWith(expect.objectContaining({
-        convId: 'conv-session',
-        role: 'user',
-        content: [{ type: 'text', text: 'inspect project' }],
-      }))
+      expect(store.getConversation).toHaveBeenCalledWith('conv-session')
+      expect(store.createConversation).not.toHaveBeenCalled()
+      expect(store.createUserMessage).not.toHaveBeenCalled()
       expect(result).toEqual(expect.objectContaining({
         conversationId: 'conv-session',
         userMessageId: 'user-msg-1',
@@ -305,12 +329,9 @@ describe('agentRuntime 行为', () => {
       const store = createSessionStore()
       const runtime = new AgentRuntime(createSessionConfig({ sessionStore: store }))
 
-      await expect(runtime.startTask({
-        prompt: 'inspect project',
+      await expect(runtime.startTask(createValidSessionStartInput({
         modelId: '',
-        workspacePath: '/workspace',
-        mode: 'hybrid',
-      })).rejects.toThrow('missing modelId')
+      }))).rejects.toThrow('missing modelId')
       expect(store.createUserMessage).not.toHaveBeenCalled()
     })
 
@@ -318,12 +339,9 @@ describe('agentRuntime 行为', () => {
       const store = createSessionStore()
       const runtime = new AgentRuntime(createSessionConfig({ sessionStore: store }))
 
-      await expect(runtime.startTask({
-        prompt: 'inspect project',
-        modelId: 'model-1',
+      await expect(runtime.startTask(createValidSessionStartInput({
         workspacePath: '',
-        mode: 'hybrid',
-      })).rejects.toThrow('missing workspacePath')
+      }))).rejects.toThrow('missing workspacePath')
       expect(store.createUserMessage).not.toHaveBeenCalled()
     })
 
@@ -337,12 +355,9 @@ describe('agentRuntime 行为', () => {
         },
       }))
 
-      await expect(runtime.startTask({
-        prompt: 'inspect project',
+      await expect(runtime.startTask(createValidSessionStartInput({
         modelId: 'missing-model',
-        workspacePath: '/workspace',
-        mode: 'hybrid',
-      })).rejects.toThrow('Model not found: missing-model')
+      }))).rejects.toThrow('Model not found: missing-model')
       expect(store.createUserMessage).not.toHaveBeenCalled()
     })
 
@@ -362,12 +377,7 @@ describe('agentRuntime 行为', () => {
         },
       }))
 
-      await expect(runtime.startTask({
-        prompt: 'inspect project',
-        modelId: 'model-1',
-        workspacePath: '/workspace',
-        mode: 'hybrid',
-      })).rejects.toThrow('Provider not found for model: test-model')
+      await expect(runtime.startTask(createValidSessionStartInput())).rejects.toThrow('Provider not found for model: test-model')
       expect(store.createUserMessage).not.toHaveBeenCalled()
     })
 
@@ -387,12 +397,7 @@ describe('agentRuntime 行为', () => {
       })
       const runtime = new AgentRuntime(config)
 
-      const result = await runtime.startTask({
-        prompt: 'inspect project',
-        modelId: 'model-1',
-        workspacePath: '/workspace',
-        mode: 'hybrid',
-      })
+      const result = await runtime.startTask(createValidSessionStartInput())
 
       expect(runAgentLoop).toHaveBeenCalledWith(expect.objectContaining({
         options: expect.objectContaining({
@@ -449,13 +454,9 @@ describe('agentRuntime 行为', () => {
 
       userMarkdown = '§Prefer verbose English.'
       memoryMarkdown = '§Use npm test.'
-      const secondResult = await runtime.startTask({
-        conversationId: 'conv-session',
+      const secondResult = await runtime.startTask(createValidSessionStartInput({
         prompt: 'inspect project again',
-        modelId: 'model-1',
-        workspacePath: '/workspace',
-        mode: 'hybrid',
-      })
+      }))
 
       const secondCalls = vi.mocked(runAgentLoop).mock.calls
       const secondCall = secondCalls[secondCalls.length - 1]
@@ -466,7 +467,7 @@ describe('agentRuntime 行为', () => {
       cleanupTasks([secondResult.taskId])
     })
 
-    it('写入新用户消息前压缩持久化历史并刷新 memory', async () => {
+    it('启动 loop 前压缩持久化历史并刷新 memory', async () => {
       const conversation = {
         id: 'conv-session',
         title: 'Untitled',
@@ -481,7 +482,9 @@ describe('agentRuntime 行为', () => {
           compaction: { enabled: true, thresholdPercent: 70, keepRecentTokens: 16 },
         },
       }
-      let historyMessages: Awaited<ReturnType<ISessionStore['getMessages']>> = []
+      let historyMessages: Awaited<ReturnType<ISessionStore['getMessages']>> = [
+        createPersistedUserMessage('inspect project first'),
+      ]
       const store = createSessionStore({
         getConversation: vi.fn(async () => conversation),
         getConversationById: vi.fn(async () => conversation),
@@ -529,13 +532,9 @@ describe('agentRuntime 行为', () => {
       })
       const runtime = new AgentRuntime(config)
 
-      const firstResult = await runtime.startTask({
-        conversationId: 'conv-session',
+      const firstResult = await runtime.startTask(createValidSessionStartInput({
         prompt: 'inspect project first',
-        modelId: 'model-1',
-        workspacePath: '/workspace',
-        mode: 'hybrid',
-      })
+      }))
       cleanupTasks([firstResult.taskId])
 
       memoryMarkdown = '§Updated memory after compaction.'
@@ -544,15 +543,12 @@ describe('agentRuntime 行为', () => {
         { id: 'a1', convId: 'conv-session', createdAt: 2, role: 'assistant', status: 'success', content: [{ type: 'text', text: 'previous answer' }] },
         { id: 'u2', convId: 'conv-session', createdAt: 3, role: 'user', status: 'success', content: [{ type: 'text', text: 'recent request' }] },
         { id: 'a2', convId: 'conv-session', createdAt: 4, role: 'assistant', status: 'success', content: [{ type: 'text', text: 'recent answer' }] },
+        createPersistedUserMessage('inspect project again'),
       ]
 
-      const secondResult = await runtime.startTask({
-        conversationId: 'conv-session',
+      const secondResult = await runtime.startTask(createValidSessionStartInput({
         prompt: 'inspect project again',
-        modelId: 'model-1',
-        workspacePath: '/workspace',
-        mode: 'hybrid',
-      })
+      }))
 
       const loopCalls = vi.mocked(runAgentLoop).mock.calls
       const loopCall = loopCalls[loopCalls.length - 1]
@@ -602,10 +598,6 @@ describe('agentRuntime 行为', () => {
           totalTokens: 12300,
         },
       })
-      expect(vi.mocked(store.createEventMessage).mock.invocationCallOrder[0])
-        .toBeLessThan(vi.mocked(store.createUserMessage).mock.invocationCallOrder[1])
-      expect(vi.mocked(store.updateEventMessage).mock.invocationCallOrder[0])
-        .toBeLessThan(vi.mocked(store.createUserMessage).mock.invocationCallOrder[1])
       expect(readMemory).toHaveBeenCalledTimes(2)
       expect(readUserMemory).toHaveBeenCalledTimes(2)
       cleanupTasks([secondResult.taskId])
@@ -638,6 +630,7 @@ describe('agentRuntime 行为', () => {
           usage: { totalTokens: 6900 },
         },
         { id: 'u2', convId: 'conv-session', createdAt: 3, role: 'user', status: 'success', content: [{ type: 'text', text: 'recent request' }] },
+        createPersistedUserMessage('x'.repeat(400)),
       ]
       const store = createSessionStore({
         getConversation: vi.fn(async () => conversation),
@@ -672,13 +665,9 @@ describe('agentRuntime 行为', () => {
       })
 
       const runtime = new AgentRuntime(config)
-      const result = await runtime.startTask({
-        conversationId: 'conv-session',
+      const result = await runtime.startTask(createValidSessionStartInput({
         prompt: 'x'.repeat(400),
-        modelId: 'model-1',
-        workspacePath: '/workspace',
-        mode: 'hybrid',
-      })
+      }))
 
       expect(store.createEventMessage).toHaveBeenCalledOnce()
       expect(store.updateEventMessage).toHaveBeenCalledWith('event-msg-1', expect.objectContaining({
@@ -707,6 +696,7 @@ describe('agentRuntime 行为', () => {
         { id: 'u1', convId: 'conv-session', createdAt: 1, role: 'user', status: 'success', content: [{ type: 'text', text: 'x'.repeat(60_000) }] },
         { id: 'a1', convId: 'conv-session', createdAt: 2, role: 'assistant', status: 'success', content: [{ type: 'text', text: 'previous answer' }] },
         { id: 'u2', convId: 'conv-session', createdAt: 3, role: 'user', status: 'success', content: [{ type: 'text', text: 'recent request' }] },
+        createPersistedUserMessage('inspect project'),
       ]
       const store = createSessionStore({
         getConversation: vi.fn(async () => conversation),
@@ -743,13 +733,7 @@ describe('agentRuntime 行为', () => {
       })
 
       const runtime = new AgentRuntime(config)
-      const result = await runtime.startTask({
-        conversationId: 'conv-session',
-        prompt: 'inspect project',
-        modelId: 'model-1',
-        workspacePath: '/workspace',
-        mode: 'hybrid',
-      })
+      const result = await runtime.startTask(createValidSessionStartInput())
 
       expect(store.createEventMessage).toHaveBeenCalledWith({
         convId: 'conv-session',
@@ -770,8 +754,6 @@ describe('agentRuntime 行为', () => {
         },
         usage: undefined,
       })
-      expect(vi.mocked(store.updateEventMessage).mock.invocationCallOrder[0])
-        .toBeLessThan(vi.mocked(store.createUserMessage).mock.invocationCallOrder[0])
       cleanupTasks([result.taskId])
     })
 
@@ -812,6 +794,7 @@ describe('agentRuntime 行为', () => {
         },
         { id: 'u2', convId: 'conv-session', createdAt: 3, role: 'user', status: 'success', content: [{ type: 'text', text: 'recent request' }] },
         { id: 'a2', convId: 'conv-session', createdAt: 4, role: 'assistant', status: 'success', content: [{ type: 'text', text: 'recent answer' }] },
+        createPersistedUserMessage('inspect project'),
       ]
       const store = createSessionStore({
         getConversation: vi.fn(async () => conversation),
@@ -846,13 +829,7 @@ describe('agentRuntime 行为', () => {
       })
 
       const runtime = new AgentRuntime(config)
-      const result = await runtime.startTask({
-        conversationId: 'conv-session',
-        prompt: 'inspect project',
-        modelId: 'model-1',
-        workspacePath: '/workspace',
-        mode: 'hybrid',
-      })
+      const result = await runtime.startTask(createValidSessionStartInput())
 
       expect(store.createEventMessage).not.toHaveBeenCalled()
       expect(store.updateEventMessage).not.toHaveBeenCalled()
@@ -865,13 +842,9 @@ describe('agentRuntime 行为', () => {
       const runtime = new AgentRuntime(config)
       const running = await runtime.startTask(createValidStartInput({ conversationId: 'conv-session' }))
 
-      await expect(runtime.startTask({
-        conversationId: 'conv-session',
+      await expect(runtime.startTask(createValidSessionStartInput({
         prompt: 'run it',
-        modelId: 'model-1',
-        workspacePath: '/workspace',
-        mode: 'hybrid',
-      })).rejects.toThrow('AGENT_TASK_ALREADY_RUNNING')
+      }))).rejects.toThrow('AGENT_TASK_ALREADY_RUNNING')
 
       expect(store.createUserMessage).not.toHaveBeenCalled()
       cleanupTasks([running.taskId])
@@ -883,13 +856,7 @@ describe('agentRuntime 行为', () => {
       const store = createSessionStore()
       const eventEmitter = createMockEmitter()
       const runtime = new AgentRuntime(createSessionConfig({ eventEmitter, sessionStore: store }))
-      const running = await runtime.startTask({
-        conversationId: 'conv-session',
-        prompt: 'inspect project',
-        modelId: 'model-1',
-        workspacePath: '/workspace',
-        mode: 'hybrid',
-      })
+      const running = await runtime.startTask(createValidSessionStartInput())
 
       // Record calls from startTask so we can ignore them
       const callsBefore = (store.createUserMessage as ReturnType<typeof vi.fn>).mock.calls.length

--- a/packages/agent-core/src/native-tools/pathPolicy.ts
+++ b/packages/agent-core/src/native-tools/pathPolicy.ts
@@ -79,14 +79,15 @@ export class PathPolicy {
     if (!this.enforceWorkspaceBoundary) {
       return true
     }
+    const normalizedCandidatePath = normalizeCandidateForBoundary(candidatePath)
     const workspaceRealPath = fs.realpathSync.native(this.workspacePath)
-    if (isInsideDir(workspaceRealPath, candidatePath)) {
+    if (isInsideDir(workspaceRealPath, normalizedCandidatePath)) {
       return true
     }
     for (const trustedPath of this.trustedPaths) {
       try {
         const trustedRealPath = fs.realpathSync.native(trustedPath)
-        if (isInsideDir(trustedRealPath, candidatePath)) {
+        if (isInsideDir(trustedRealPath, normalizedCandidatePath)) {
           return true
         }
       }
@@ -126,6 +127,16 @@ function resolveWorkspaceRoot(workspacePath: string): string {
   return fs.existsSync(workspacePath)
     ? fs.realpathSync.native(workspacePath)
     : path.resolve(workspacePath)
+}
+
+function normalizeCandidateForBoundary(candidatePath: string): string {
+  if (fs.existsSync(candidatePath)) {
+    return fs.realpathSync.native(candidatePath)
+  }
+
+  const ancestor = findExistingAncestor(candidatePath)
+  const ancestorRealPath = fs.realpathSync.native(ancestor)
+  return path.join(ancestorRealPath, path.relative(ancestor, candidatePath))
 }
 
 function isInsideDir(dirPath: string, candidatePath: string): boolean {

--- a/packages/agent-core/src/session/SessionRuntime.ts
+++ b/packages/agent-core/src/session/SessionRuntime.ts
@@ -34,7 +34,6 @@ import { ToolRegistry } from '../tools/toolRegistry'
 import { contentBlocksToLoopMessageContent } from '../utils/attachmentUtils'
 import { buildPromptWithTurnContext } from './turnContext'
 
-const DEFAULT_CONVERSATION_TITLE = 'Untitled'
 const STREAM_UPDATE_INTERVAL_MS = 80
 
 export class SessionRuntime {
@@ -67,23 +66,16 @@ export class SessionRuntime {
     if (!options.workspacePath.trim()) {
       throw new Error('invalid start task options: missing workspacePath')
     }
+    if (!options.conversationId?.trim()) {
+      throw new Error('invalid start task options: missing conversationId')
+    }
+    if (!options.userMessageId?.trim()) {
+      throw new Error('invalid start task options: missing userMessageId')
+    }
 
     const modelCatalog = requireConfig(this.config.modelCatalog, 'modelCatalog')
 
-    const conversation = options.conversationId
-      ? await getExistingConversation(store, options.conversationId)
-      : await store.createConversation({
-          title: DEFAULT_CONVERSATION_TITLE,
-          createdAt: Date.now(),
-          updatedAt: Date.now(),
-          workspacePath: options.workspacePath,
-          settings: {
-            modelId: options.modelId,
-            systemPrompt: options.modelSettings?.systemPrompt ?? '',
-            temperature: options.modelSettings?.temperature ?? 0.7,
-            maxTokens: options.modelSettings?.maxTokens ?? 4096,
-          },
-        })
+    const conversation = await getExistingConversation(store, options.conversationId)
 
     if (this.listActiveTasks(conversation.id).length > 0) {
       throw new Error('AGENT_TASK_ALREADY_RUNNING')
@@ -99,10 +91,15 @@ export class SessionRuntime {
     }
     const loadFileData = createCachedLoadFileData(this.config.loadFileData)
 
-    const aiProvider = this.config.aiProviderFactory
+    const aiProvider = options.aiProvider ?? (this.config.aiProviderFactory
       ? await this.config.aiProviderFactory({ model, provider })
-      : await createProvider(provider)
+      : await createProvider(provider))
     const currentConversation = await store.getConversation(conversation.id)
+    const allMessages = await store.getMessages(conversation.id)
+    const userMessage = allMessages.find(message => message.id === options.userMessageId && message.role === 'user')
+    if (!userMessage) {
+      throw new Error(`User message not found: ${options.userMessageId}`)
+    }
 
     const enrichedPrompt = buildPromptWithTurnContext({
       prompt,
@@ -112,9 +109,9 @@ export class SessionRuntime {
 
     // Build user content.
     let userContent: LoopMessage['content']
-    if (options.content && options.content.length > 0) {
-      // Preserve content blocks while replacing the visible user prompt text.
-      const contentWithEnrichedPrompt = options.content.map((block) => {
+    if (userMessage.content.length > 0) {
+      // 保留附件块，同时让 agent 上下文使用带引用信息的提示词。
+      const contentWithEnrichedPrompt = userMessage.content.map((block) => {
         if (block.type === 'text') {
           return { ...block, text: enrichedPrompt }
         }
@@ -126,7 +123,7 @@ export class SessionRuntime {
       userContent = [{ type: 'text', text: enrichedPrompt }]
     }
 
-    const historyMessages = await store.getMessages(conversation.id)
+    const historyMessages = allMessages.filter(message => message.id !== userMessage.id)
     const contextEntries = await buildConversationContextEntries(
       historyMessages,
       undefined,
@@ -155,14 +152,6 @@ export class SessionRuntime {
     if (preTurnCompaction.compacted) {
       this.promptMemorySnapshots.delete(conversation.id)
     }
-
-    const userMessage = await store.createUserMessage({
-      convId: conversation.id,
-      role: 'user',
-      status: 'success',
-      content: options.content ?? [{ type: 'text', text: prompt }],
-      turnId: undefined,
-    })
 
     const messages: LoopMessage[] = [
       ...preTurnCompaction.messages,

--- a/packages/agent-runtime/src/__tests__/agentService.spec.ts
+++ b/packages/agent-runtime/src/__tests__/agentService.spec.ts
@@ -15,9 +15,67 @@ const runtime = {
   getTask: vi.fn(),
 } as unknown as AgentRuntime
 
+const model = {
+  id: 'model-1',
+  model: 'mock-model',
+  name: 'Mock Model',
+  providerId: 'provider-1',
+  contextLength: 128_000,
+}
+const provider = {
+  id: 'provider-1',
+  name: 'Provider',
+  apiMode: 'openai' as const,
+  apiKey: 'test-key',
+  baseUrl: 'https://example.com',
+  isOfficial: false,
+  isEnabled: true,
+  createdAt: 1,
+  updatedAt: 1,
+}
+const conversation = {
+  id: 'c1',
+  title: 'Untitled',
+  workspacePath: '/workspace',
+  createdAt: 1,
+  updatedAt: 1,
+  settings: {
+    modelId: 'model-1',
+    systemPrompt: 'custom',
+    temperature: 0.2,
+    maxTokens: 2048,
+  },
+}
+const userMessage = {
+  id: 'm1',
+  convId: 'c1',
+  createdAt: 2,
+  role: 'user' as const,
+  status: 'success' as const,
+  content: [{ type: 'text' as const, text: 'inspect project' }],
+}
+const aiProvider = {
+  streamModel: vi.fn(),
+  complete: vi.fn(),
+}
+const aiProviderFactory = vi.fn(async () => aiProvider)
+
 const appDataContext = {
   workspaceService: {
     getCurrentWorkspacePath: vi.fn(() => '/workspace'),
+  },
+  modelCatalog: {
+    getModelById: vi.fn(async () => model),
+    getProviderById: vi.fn(async () => provider),
+  },
+  conversationRepository: {
+    create: vi.fn(async () => conversation),
+    getById: vi.fn(async () => conversation),
+    delete: vi.fn(async () => true),
+  },
+  messageRepository: {
+    create: vi.fn(async () => userMessage),
+    delete: vi.fn(async () => true),
   },
   toolApprovalWhitelistRepository: {
     add: vi.fn(),
@@ -31,12 +89,12 @@ describe('createAgentRuntimeController 行为', () => {
       taskId: 't1',
       conversationId: 'c1',
       userMessageId: 'm1',
-      conversation: { id: 'c1' },
+      conversation,
     })
   })
 
-  it('将应用层 turn 参数映射为 runtime start 参数', async () => {
-    const service = createAgentRuntimeController(runtime, appDataContext)
+  it('新会话先完成验证，再创建 conversation 和 user message 后启动 runtime', async () => {
+    const service = createAgentRuntimeController(runtime, appDataContext, { aiProviderFactory })
 
     await service.startTurn({
       prompt: 'inspect project',
@@ -51,11 +109,37 @@ describe('createAgentRuntimeController 行为', () => {
       },
     })
 
+    expect(appDataContext.modelCatalog.getModelById).toHaveBeenCalledWith('model-1')
+    expect(appDataContext.modelCatalog.getProviderById).toHaveBeenCalledWith('provider-1')
+    expect(aiProviderFactory).toHaveBeenCalledWith({ model, provider })
+    expect(appDataContext.conversationRepository.create).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'Untitled',
+      workspacePath: '/workspace',
+      settings: {
+        modelId: 'model-1',
+        systemPrompt: 'custom',
+        temperature: 0.2,
+        maxTokens: 2048,
+      },
+    }))
+    expect(appDataContext.messageRepository.create).toHaveBeenCalledWith({
+      convId: 'c1',
+      role: 'user',
+      status: 'success',
+      content: [{ type: 'text', text: 'inspect project' }],
+      turnId: undefined,
+    })
     expect(startTask).toHaveBeenCalledWith({
       prompt: 'inspect project',
+      conversationId: 'c1',
+      userMessageId: 'm1',
       modelId: 'model-1',
       workspacePath: '/workspace',
+      aiProvider,
       mode: 'hybrid',
+      content: undefined,
+      referencedFiles: undefined,
+      selectedSkill: undefined,
       modelSettings: {
         systemPrompt: 'custom',
         temperature: 0.2,
@@ -65,7 +149,7 @@ describe('createAgentRuntimeController 行为', () => {
   })
 
   it('保留显式传入的 turn 上下文字段', async () => {
-    const service = createAgentRuntimeController(runtime, appDataContext)
+    const service = createAgentRuntimeController(runtime, appDataContext, { aiProviderFactory })
 
     await service.startTurn({
       conversationId: 'c1',
@@ -92,6 +176,7 @@ describe('createAgentRuntimeController 行为', () => {
 
     expect(startTask).toHaveBeenCalledWith(expect.objectContaining({
       conversationId: 'c1',
+      userMessageId: 'm1',
       workspacePath: '/explicit-workspace',
       mode: 'strict',
       referencedFiles: ['src/main.ts'],
@@ -102,6 +187,60 @@ describe('createAgentRuntimeController 行为', () => {
         { type: 'document', source: { type: 'file_id', file_id: 'file-1' }, name: 'a.txt', media_type: 'text/plain', size: 1 },
       ],
     }))
+    expect(appDataContext.conversationRepository.create).not.toHaveBeenCalled()
+    expect(appDataContext.conversationRepository.getById).toHaveBeenCalledWith('c1')
+  })
+
+  it('aPI Key 验证失败时不创建 conversation 或 user message', async () => {
+    aiProviderFactory.mockRejectedValueOnce(new Error('missing api key'))
+    const service = createAgentRuntimeController(runtime, appDataContext, { aiProviderFactory })
+
+    await expect(service.startTurn({
+      prompt: 'inspect project',
+      modelConfig: {
+        modelId: 'model-1',
+        systemPrompt: 'custom',
+        temperature: 0.2,
+        maxTokens: 2048,
+        features: {
+          enableMCP: false,
+        },
+      },
+    })).rejects.toThrow('missing api key')
+
+    expect(appDataContext.conversationRepository.create).not.toHaveBeenCalled()
+    expect(appDataContext.messageRepository.create).not.toHaveBeenCalled()
+    expect(startTask).not.toHaveBeenCalled()
+  })
+
+  it('成功启动新会话后异步初始化标题并发出 conversation 更新', async () => {
+    const titledConversation = { ...conversation, title: '项目检查' }
+    const titleGenerator = {
+      updateTitle: vi.fn(async () => titledConversation),
+    }
+    const emitConversationUpdated = vi.fn()
+    const service = createAgentRuntimeController(runtime, appDataContext, {
+      aiProviderFactory,
+      titleGenerator,
+      emitConversationUpdated,
+    })
+
+    await service.startTurn({
+      prompt: 'inspect project',
+      modelConfig: {
+        modelId: 'model-1',
+        systemPrompt: 'custom',
+        temperature: 0.2,
+        maxTokens: 2048,
+        features: {
+          enableMCP: false,
+        },
+      },
+    })
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(titleGenerator.updateTitle).toHaveBeenCalledWith('c1', 'model-1')
+    expect(emitConversationUpdated).toHaveBeenCalledWith(titledConversation)
   })
 
   it('记住审批时写入工具白名单后再批准 pending action', () => {

--- a/packages/agent-runtime/src/agentRuntimeController.ts
+++ b/packages/agent-runtime/src/agentRuntimeController.ts
@@ -1,7 +1,8 @@
 import type { AgentRuntime } from '@ant-chat/agent-core'
 import type { AppDataContext } from '@ant-chat/app-data'
-import type { AgentRuntimeStartTaskOptions, AgentRuntimeStartTaskResult, ApprovePendingActionOptions, CancelTaskOptions, IMessage, RejectPendingActionOptions, StartAgentTurnOptions } from '@ant-chat/shared'
-import process from 'node:process'
+import type { AgentRuntimeStartTaskResult, ApprovePendingActionOptions, CancelTaskOptions, IMessage, RejectPendingActionOptions, StartAgentTurnOptions } from '@ant-chat/shared'
+import type { AgentTurnServiceDeps } from './agentTurnService'
+import { createAgentTurnService } from './agentTurnService'
 
 export interface AgentRuntimeController {
   startTurn: (options: StartAgentTurnOptions) => Promise<AgentRuntimeStartTaskResult>
@@ -13,10 +14,20 @@ export interface AgentRuntimeController {
   approvePendingActionWithWhitelist: (options: ApprovePendingActionOptions & { remember: boolean, workspacePath?: string }) => null
 }
 
-export function createAgentRuntimeController(runtime: AgentRuntime, appDataContext: AppDataContext): AgentRuntimeController {
+export function createAgentRuntimeController(
+  runtime: AgentRuntime,
+  appDataContext: AppDataContext,
+  turnServiceDeps: Omit<AgentTurnServiceDeps, 'runtime' | 'appDataContext'> = {},
+): AgentRuntimeController {
+  const turnService = createAgentTurnService({
+    runtime,
+    appDataContext,
+    ...turnServiceDeps,
+  })
+
   return {
     async startTurn(options) {
-      return await runtime.startTask(toRuntimeStartOptions(options, appDataContext))
+      return await turnService.startTurn(options)
     },
     approvePendingAction(options) {
       runtime.approvePendingAction(options)
@@ -54,36 +65,4 @@ export function createAgentRuntimeController(runtime: AgentRuntime, appDataConte
       return null
     },
   }
-}
-
-function toRuntimeStartOptions(
-  options: StartAgentTurnOptions,
-  appDataContext: AppDataContext,
-): AgentRuntimeStartTaskOptions {
-  const workspacePath = options.workspacePath
-    ?? appDataContext.workspaceService.getCurrentWorkspacePath()
-    ?? process.cwd()
-
-  const startOptions: AgentRuntimeStartTaskOptions = {
-    prompt: options.prompt,
-    modelId: options.modelConfig.modelId,
-    workspacePath,
-    mode: options.mode ?? 'hybrid',
-    modelSettings: {
-      systemPrompt: options.modelConfig.systemPrompt,
-      temperature: options.modelConfig.temperature,
-      maxTokens: options.modelConfig.maxTokens,
-    },
-  }
-
-  if (options.conversationId)
-    startOptions.conversationId = options.conversationId
-  if (options.content)
-    startOptions.content = options.content
-  if (options.referencedFiles)
-    startOptions.referencedFiles = options.referencedFiles
-  if (options.selectedSkill)
-    startOptions.selectedSkill = options.selectedSkill
-
-  return startOptions
 }

--- a/packages/agent-runtime/src/agentTurnService.ts
+++ b/packages/agent-runtime/src/agentTurnService.ts
@@ -1,0 +1,181 @@
+import type { AgentRuntime } from '@ant-chat/agent-core'
+import type { AppDataContext } from '@ant-chat/app-data'
+import type {
+  AgentRuntimeStartTaskResult,
+  AIProviderFactory,
+  ILogger,
+  IMessageContent,
+  StartAgentTurnOptions,
+} from '@ant-chat/shared'
+import type { ConversationTitleGenerator } from './conversationTitleGenerator'
+import process from 'node:process'
+
+const DEFAULT_TITLE = 'Untitled'
+
+export interface AgentTurnServiceDeps {
+  runtime: AgentRuntime
+  appDataContext: AppDataContext
+  aiProviderFactory?: AIProviderFactory
+  titleGenerator?: ConversationTitleGenerator
+  emitConversationUpdated?: (conversation: AgentRuntimeStartTaskResult['conversation']) => void
+  logger?: ILogger
+}
+
+export interface AgentTurnService {
+  startTurn: (options: StartAgentTurnOptions) => Promise<AgentRuntimeStartTaskResult>
+}
+
+export function createAgentTurnService(deps: AgentTurnServiceDeps): AgentTurnService {
+  const { runtime, appDataContext, aiProviderFactory, titleGenerator, emitConversationUpdated, logger } = deps
+
+  return {
+    async startTurn(options) {
+      const prompt = options.prompt.trim()
+      if (!prompt) {
+        throw new Error('invalid start turn options: missing prompt')
+      }
+
+      const workspacePath = options.workspacePath
+        ?? appDataContext.workspaceService.getCurrentWorkspacePath()
+        ?? process.cwd()
+
+      const model = await appDataContext.modelCatalog.getModelById(options.modelConfig.modelId)
+      if (!model) {
+        throw new Error(`Model not found: ${options.modelConfig.modelId}`)
+      }
+
+      const provider = await appDataContext.modelCatalog.getProviderById(model.providerId)
+      if (!provider) {
+        throw new Error(`Provider not found for model: ${model.model}`)
+      }
+
+      const aiProvider = aiProviderFactory
+        ? await aiProviderFactory({ model, provider })
+        : undefined
+
+      const conversationState = options.conversationId
+        ? {
+            conversation: await appDataContext.conversationRepository.getById(options.conversationId),
+            created: false,
+          }
+        : {
+            conversation: await appDataContext.conversationRepository.create({
+              title: DEFAULT_TITLE,
+              createdAt: Date.now(),
+              updatedAt: Date.now(),
+              workspacePath,
+              settings: {
+                modelId: options.modelConfig.modelId,
+                systemPrompt: options.modelConfig.systemPrompt ?? '',
+                temperature: options.modelConfig.temperature ?? 0.7,
+                maxTokens: options.modelConfig.maxTokens ?? 4096,
+              },
+            }),
+            created: true,
+          }
+
+      const { conversation } = conversationState
+      if (runtime.listActiveTasks(conversation.id).length > 0) {
+        throw new Error('AGENT_TASK_ALREADY_RUNNING')
+      }
+
+      const userMessage = await appDataContext.messageRepository.create({
+        convId: conversation.id,
+        role: 'user',
+        status: 'success',
+        content: resolveUserMessageContent(options.content, prompt),
+        turnId: undefined,
+      })
+
+      try {
+        const result = await runtime.startTask({
+          prompt,
+          conversationId: conversation.id,
+          userMessageId: userMessage.id,
+          modelId: options.modelConfig.modelId,
+          workspacePath,
+          aiProvider,
+          mode: options.mode ?? 'hybrid',
+          content: options.content,
+          referencedFiles: options.referencedFiles,
+          selectedSkill: options.selectedSkill,
+          modelSettings: {
+            systemPrompt: options.modelConfig.systemPrompt,
+            temperature: options.modelConfig.temperature,
+            maxTokens: options.modelConfig.maxTokens,
+          },
+        })
+
+        scheduleTitleInitialization({
+          conversationId: result.conversationId,
+          modelId: options.modelConfig.modelId,
+          shouldInitializeTitle: conversationState.created || conversation.title === DEFAULT_TITLE,
+          titleGenerator,
+          emitConversationUpdated,
+          logger,
+        })
+
+        return result
+      }
+      catch (error) {
+        await rollbackStartedTurn({
+          appDataContext,
+          conversationId: conversation.id,
+          userMessageId: userMessage.id,
+          createdConversation: conversationState.created,
+          logger,
+        })
+        throw error
+      }
+    },
+  }
+}
+
+function resolveUserMessageContent(content: IMessageContent | undefined, prompt: string): IMessageContent {
+  return content && content.length > 0
+    ? content
+    : [{ type: 'text', text: prompt }]
+}
+
+function scheduleTitleInitialization(params: {
+  conversationId: string
+  modelId: string
+  shouldInitializeTitle: boolean
+  titleGenerator?: ConversationTitleGenerator
+  emitConversationUpdated?: AgentTurnServiceDeps['emitConversationUpdated']
+  logger?: ILogger
+}) {
+  const { conversationId, modelId, shouldInitializeTitle, titleGenerator, emitConversationUpdated, logger } = params
+  if (!shouldInitializeTitle || !titleGenerator) {
+    return
+  }
+
+  void titleGenerator.updateTitle(conversationId, modelId)
+    .then((conversation) => {
+      emitConversationUpdated?.(conversation)
+    })
+    .catch((error) => {
+      logger?.warn('初始化会话标题失败', error)
+    })
+}
+
+async function rollbackStartedTurn(params: {
+  appDataContext: AppDataContext
+  conversationId: string
+  userMessageId: string
+  createdConversation: boolean
+  logger?: ILogger
+}) {
+  const { appDataContext, conversationId, userMessageId, createdConversation, logger } = params
+  try {
+    if (createdConversation) {
+      await appDataContext.conversationRepository.delete(conversationId)
+      return
+    }
+
+    await appDataContext.messageRepository.delete(userMessageId)
+  }
+  catch (rollbackError) {
+    logger?.warn('回滚发送会话失败', rollbackError)
+  }
+}

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -1,5 +1,7 @@
 export { createAgentRuntimeController } from './agentRuntimeController'
 export type { AgentRuntimeController } from './agentRuntimeController'
+export { createAgentTurnService } from './agentTurnService'
+export type { AgentTurnService, AgentTurnServiceDeps } from './agentTurnService'
 export { createCommandController } from './commandController'
 export type { CommandController, CommandControllerDeps } from './commandController'
 export { createConversationTitleGenerator, formatMessagesForContext } from './conversationTitleGenerator'

--- a/packages/app-runtime/src/appRuntime.ts
+++ b/packages/app-runtime/src/appRuntime.ts
@@ -107,19 +107,24 @@ export function createAppRuntime(options: CreateAppRuntimeOptions) {
     },
     overrides: { logger, aiProviderFactory },
   })
-  const agentController = createAgentRuntimeController(agentRuntime, context)
+  const titleGenerator = createConversationTitleGenerator({
+    providerSettingsRepository: context.providerSettingsRepository,
+    messageRepository: context.messageRepository,
+    conversationRepository: context.conversationRepository,
+    aiProviderFactory,
+  })
+  const agentController = createAgentRuntimeController(agentRuntime, context, {
+    aiProviderFactory,
+    titleGenerator,
+    emitConversationUpdated: conversation => events.emit('conversation:updated', { conversation }),
+    logger,
+  })
   const commandController = createCommandController({
     appDataContext: context,
     eventEmitter: agentEventEmitter,
     logger,
     aiProviderFactory,
     listActiveTasks: conversationId => agentRuntime.listActiveTasks(conversationId),
-  })
-  const titleGenerator = createConversationTitleGenerator({
-    providerSettingsRepository: context.providerSettingsRepository,
-    messageRepository: context.messageRepository,
-    conversationRepository: context.conversationRepository,
-    aiProviderFactory,
   })
   const modelsDevImporter = createModelsDevImporter(context)
   let initialized = false

--- a/packages/shared/src/interfaces/agent-runtime-interfaces.ts
+++ b/packages/shared/src/interfaces/agent-runtime-interfaces.ts
@@ -295,9 +295,11 @@ export interface AgentRuntimeConfig extends AgentRuntimeOverrides {
 
 export interface AgentRuntimeStartTaskOptions {
   prompt: string
-  conversationId?: string
+  conversationId: string
+  userMessageId: string
   modelId: string
   workspacePath: string
+  aiProvider?: IAIProvider
   mode?: AgentMode
   content?: IMessageContent
   referencedFiles?: string[]

--- a/packages/ui/src/components/sonner.tsx
+++ b/packages/ui/src/components/sonner.tsx
@@ -38,6 +38,7 @@ function Toaster({ ...props }: ToasterProps) {
       toastOptions={{
         classNames: {
           toast: 'cn-toast',
+          error: 'border-destructive/30 bg-destructive/10 text-destructive shadow-[0_18px_48px_-28px_var(--destructive)] dark:border-destructive/40 dark:bg-destructive/20 [&_[data-icon]]:text-destructive',
         },
       }}
       {...props}


### PR DESCRIPTION
## Background

本 PR 收敛消息发送链路，把创建 conversation、创建 user message、API Key 验证和会话标题初始化统一到后端发送入口，减少前端和 core runtime 的职责耦合。

## Changes

- 新增 `AgentTurnService.startTurn`，统一处理 model/provider/API Key 验证、conversation 创建、user message 创建、runtime 启动和标题初始化调度。
- 调整 `SessionRuntime.startTask`，只消费已存在的 `conversationId` / `userMessageId`，继续负责上下文、附件转换、压缩和 agent loop 启动。
- 前端发送失败时展示后端错误 toast，并重新抛出异常以保留输入草稿。
- 强化 error toast 的 danger 样式。
- 修复 `/var` 与 `/private/var` realpath 差异导致工作区绝对路径误判 outside workspace 的问题。
- 补充发送失败、标题初始化、API Key 失败不落库、路径权限链路等回归测试。

## Validation

- `pnpm -F @ant-chat/agent-core test -- AgentRuntime.spec.ts`
- `pnpm -F @ant-chat/agent-runtime test -- agentService.spec.ts agentFullChainPermissions.spec.ts`
- `pnpm -F @ant-chat/web test -- gui.spec.tsx`
- `pnpm -F @ant-chat/app-runtime test -- appRuntime.spec.ts`
- `pnpm type-check`
- `pnpm check`

`pnpm check` 通过；当前仓库仍有 19 个既有 lint warning，无 error。

## Note

当前分支基于已有提交 `feat: 实现敏感信息引用存储链路`，本次新提交为 `refactor: 收敛消息发送链路`。
