### PR TITLE
refactor(skills): 迁移到 Agent Skills 标准，去掉 manifest.json

### DIFF
--- a/packages/agent-core/src/tools/toolRegistry.ts
+++ b/packages/agent-core/src/tools/toolRegistry.ts
@@ -391,7 +391,7 @@ async function listSkillFiles(skillsRoot: string, name: string): Promise<string[
   const skillPath = path.join(skillsRoot, name)
   const entries = await fs.promises.readdir(skillPath, { recursive: true, withFileTypes: true })
   return entries
-    .filter(e => e.isFile() && e.name !== 'manifest.json' && e.name !== '.index.json')
+    .filter(e => e.isFile() && e.name !== '.index.json')
     .map(e => path.join(e.parentPath ?? skillPath, e.name))
     .sort()
 }

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -29,9 +29,11 @@
     "@ant-chat/agent-core": "workspace:^",
     "@ant-chat/app-data": "workspace:^",
     "@ant-chat/shared": "workspace:^",
-    "fflate": "^0.8.2"
+    "fflate": "^0.8.2",
+    "js-yaml": "^4.1.0"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
     "tsdown": "catalog:",
     "vitest": "catalog:"
   }

--- a/packages/agent-runtime/src/skills/__tests__/skillManagementService.spec.ts
+++ b/packages/agent-runtime/src/skills/__tests__/skillManagementService.spec.ts
@@ -9,7 +9,7 @@ const VALID_SKILL_ZIP = 'UEsDBBQAAAAIAK1YnlxVUSklIgAAACQAAAAIAAAAU0tJTEwubWRTVgg
 const UNSAFE_SKILL_ZIP = 'UEsDBBQAAAAIAK9Ynly7JMeZCgAAAAgAAAALAAAALi4vU0tJTEwubWRTVgjNK05MSwUAUEsBAhQAFAAAAAgAr1ieXLskx5kKAAAACAAAAAsAAAAAAAAAAAAAAAAAAAAAAC4uL1NLSUxMLm1kUEsFBgAAAAABAAEAOQAAADMAAAAAAA=='
 const FRONTMATTER_SKILL_ZIP = 'UEsDBBQAAAAAAHx8plzIj6ltcwAAAHMAAAAIAAAAU0tJTEwubWQtLS0KbmFtZToga2FtaQpkZXNjcmlwdGlvbjogVHlwZXNldCBwcm9mZXNzaW9uYWwgZG9jdW1lbnRzLgotLS0KCiMga2FtaSDCtyDntJkKCldyaXRlIHByb2Zlc3Npb25hbCBQREZzIHdpdGgga2FtaS4KUEsBAhQDFAAAAAAAfHymXMiPqW1zAAAAcwAAAAgAAAAAAAAAAAAAAIABAAAAAFNLSUxMLm1kUEsFBgAAAAABAAEANgAAAJkAAAAAAA=='
 
-describe('skillFsReader 行为', () => {
+describe('skillManagementService', () => {
   let homeDir: string
   let skillsRoot: string
   let reader: SkillManagementService
@@ -24,17 +24,40 @@ describe('skillFsReader 行为', () => {
     await fs.promises.rm(homeDir, { recursive: true, force: true })
   })
 
-  it('初始化内置 skill-installer 并重建索引', async () => {
+  it('初始化内置 skill-installer 并从 frontmatter 读取元数据', async () => {
     const index = await reader.listSkills()
 
     expect(index.rootPath).toBe(skillsRoot)
     expect(index.skills).toHaveLength(1)
     expect(index.skills[0]).toMatchObject({
       name: 'skill-installer',
+      description: 'Install skills from GitHub into Ant Chat.',
       source: 'builtin',
       enabled: true,
       builtin: true,
     })
+  })
+
+  it('内置 skill-installer 的 SKILL.md 包含正确的 YAML frontmatter', async () => {
+    await reader.ensureInitialized()
+
+    const skillFile = path.join(skillsRoot, 'skill-installer', 'SKILL.md')
+    const content = await fs.promises.readFile(skillFile, 'utf8')
+
+    expect(content).toMatch(/^---\n/)
+    expect(content).toContain('name: skill-installer')
+    expect(content).toContain('description: Install skills from GitHub into Ant Chat.')
+    expect(content).toContain('# Skill Installer')
+  })
+
+  it('导入 skill zip 后不创建 manifest.json', async () => {
+    const zipPath = path.join(homeDir, 'writer.zip')
+    await fs.promises.writeFile(zipPath, Buffer.from(VALID_SKILL_ZIP, 'base64'))
+
+    await reader.importFromZip(zipPath)
+
+    const manifestPath = path.join(skillsRoot, 'writer', 'manifest.json')
+    expect(fs.existsSync(manifestPath)).toBe(false)
   })
 
   it('导入 skill zip 并读取已安装 markdown', async () => {
@@ -49,7 +72,6 @@ describe('skillFsReader 行为', () => {
       name: 'writer',
       source: 'zip',
       enabled: true,
-      description: 'Write short release notes.',
     })
     expect(index.skills.map(item => item.name)).toEqual(['skill-installer', 'writer'])
     expect(markdown).toContain('Write short release notes.')
@@ -62,16 +84,116 @@ describe('skillFsReader 行为', () => {
     await expect(reader.importFromZip(zipPath)).rejects.toThrow('unsafe zip path')
   })
 
-  it('没有 manifest.json 时使用 SKILL.md frontmatter name 而不是标题', async () => {
+  it('使用 SKILL.md frontmatter 作为元数据来源', async () => {
     const zipPath = path.join(homeDir, 'kami-test.zip')
     await fs.promises.writeFile(zipPath, Buffer.from(FRONTMATTER_SKILL_ZIP, 'base64'))
 
     const manifest = await reader.importFromZip(zipPath)
 
+    // name 会被规范化为与目录名一致
     expect(manifest.name).toBe('kami')
     expect(manifest.description).toBe('Typeset professional documents.')
 
     const markdown = await reader.readSkillMarkdown('kami')
     expect(markdown).toContain('# kami · 紙')
+  })
+
+  it('setEnabled 更新 .index.json 而不修改 SKILL.md', async () => {
+    const zipPath = path.join(homeDir, 'writer.zip')
+    await fs.promises.writeFile(zipPath, Buffer.from(VALID_SKILL_ZIP, 'base64'))
+    await reader.importFromZip(zipPath)
+
+    const skillFile = path.join(skillsRoot, 'writer', 'SKILL.md')
+    const before = await fs.promises.readFile(skillFile, 'utf8')
+
+    await reader.setEnabled('writer', false)
+
+    const after = await fs.promises.readFile(skillFile, 'utf8')
+    expect(before).toBe(after)
+
+    const index = await reader.listSkills()
+    const writer = index.skills.find(s => s.name === 'writer')!
+    expect(writer.enabled).toBe(false)
+  })
+
+  it('deleteSkill 删除目录并从 .index.json 移除', async () => {
+    const zipPath = path.join(homeDir, 'writer.zip')
+    await fs.promises.writeFile(zipPath, Buffer.from(VALID_SKILL_ZIP, 'base64'))
+    await reader.importFromZip(zipPath)
+
+    await reader.deleteSkill('writer')
+
+    expect(fs.existsSync(path.join(skillsRoot, 'writer'))).toBe(false)
+    const index = await reader.listSkills()
+    expect(index.skills).toHaveLength(1)
+    expect(index.skills[0].name).toBe('skill-installer')
+  })
+
+  it('.index.json 使用新版格式（version: 1, skills map）', async () => {
+    await reader.listSkills()
+
+    const indexPath = path.join(skillsRoot, '.index.json')
+    const data = JSON.parse(await fs.promises.readFile(indexPath, 'utf8'))
+
+    expect(data.version).toBe(1)
+    expect(data.skills).toBeDefined()
+    expect(data.skills['skill-installer']).toMatchObject({
+      enabled: true,
+      builtin: true,
+      source: 'builtin',
+    })
+  })
+
+  it('从旧版 manifest.json 格式迁移', async () => {
+    // 创建旧格式的 skill 目录
+    const skillDir = path.join(skillsRoot, 'old-skill')
+    await fs.promises.mkdir(skillDir, { recursive: true })
+    await fs.promises.writeFile(path.join(skillDir, 'SKILL.md'), '---\nname: old-skill\ndescription: An old skill.\n---\n\n# Old Skill\n')
+    await fs.promises.writeFile(path.join(skillDir, 'manifest.json'), JSON.stringify({
+      name: 'old-skill',
+      description: 'An old skill.',
+      source: 'github',
+      sourceUrl: 'https://github.com/test/old-skill',
+      enabled: true,
+      builtin: false,
+      installedAt: 1000,
+      updatedAt: 2000,
+    }))
+    // 写旧格式 .index.json（数组）
+    await fs.promises.writeFile(path.join(skillsRoot, '.index.json'), JSON.stringify([]))
+
+    // 触发迁移
+    const index = await reader.listSkills()
+
+    // manifest.json 应被删除
+    expect(fs.existsSync(path.join(skillDir, 'manifest.json'))).toBe(false)
+
+    // 旧 skill 数据应被迁移
+    const oldSkill = index.skills.find(s => s.name === 'old-skill')
+    expect(oldSkill).toBeDefined()
+    expect(oldSkill!.source).toBe('github')
+    expect(oldSkill!.sourceUrl).toBe('https://github.com/test/old-skill')
+    expect(oldSkill!.description).toBe('An old skill.')
+    expect(oldSkill!.installedAt).toBe(1000)
+
+    // .index.json 应为新版格式
+    const newIndex = JSON.parse(await fs.promises.readFile(path.join(skillsRoot, '.index.json'), 'utf8'))
+    expect(newIndex.version).toBe(1)
+    expect(newIndex.skills['old-skill']).toBeDefined()
+  })
+
+  it('rebuildIndex 发现手动添加的 skill 目录', async () => {
+    // 手动创建一个 skill 目录（不通过 importFromZip）
+    const skillDir = path.join(skillsRoot, 'manual-skill')
+    await fs.promises.mkdir(skillDir, { recursive: true })
+    await fs.promises.writeFile(path.join(skillDir, 'SKILL.md'), '---\nname: manual-skill\ndescription: Manually added.\n---\n\n# Manual\n')
+
+    const skills = await reader.rebuildIndex()
+
+    const manual = skills.find(s => s.name === 'manual-skill')
+    expect(manual).toBeDefined()
+    expect(manual!.description).toBe('Manually added.')
+    expect(manual!.enabled).toBe(true)
+    expect(manual!.source).toBe('zip')
   })
 })

--- a/packages/agent-runtime/src/skills/skillManagementService.ts
+++ b/packages/agent-runtime/src/skills/skillManagementService.ts
@@ -1,23 +1,25 @@
-import type { ImportSkillFromGithubOptions, SkillIndex, SkillManifest } from '@ant-chat/shared'
+import type { ImportSkillFromGithubOptions, SkillAppState, SkillFrontmatter, SkillIndex, SkillIndexFile, SkillManifest } from '@ant-chat/shared'
 import { Buffer } from 'node:buffer'
 import { randomUUID } from 'node:crypto'
 import fs from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { unzipSync } from 'fflate'
+import yaml from 'js-yaml'
 
 const INDEX_FILE = '.index.json'
 const SKILL_NAME_PATTERN = /^[\w.-]+$/
 const BUILTIN_SKILL_INSTALLER = 'skill-installer'
 
-function createBuiltinSkillInstallerMarkdown(skillsRoot: string): string {
-  return `# Skill Installer
+const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---/
+
+/** 内置 skill-installer 的 SKILL.md 正文（不含 frontmatter） */
+const BUILTIN_SKILL_INSTALLER_BODY = `# Skill Installer
 
 Install skills from GitHub into the Ant Chat skills directory.
 
-Use this skill when the user asks to install, list, or manage skills from GitHub. Prefer the built-in install_skill_from_github tool for installation. Installed skills are stored under ${skillsRoot}.
+Use this skill when the user asks to install, list, or manage skills from GitHub. Prefer the built-in install_skill_from_github tool for installation. Installed skills are stored under {skillsRoot}.
 `
-}
 
 export interface SkillManagementServiceOptions {
   skillsRoot: string
@@ -36,13 +38,39 @@ export class SkillManagementService {
 
   async ensureInitialized(): Promise<void> {
     await fs.promises.mkdir(this.skillsRoot, { recursive: true })
+    await this.migrateFromManifestJson()
     await this.ensureBuiltinSkillInstaller()
-    await this.rebuildIndex()
   }
 
   async listSkills(): Promise<SkillIndex> {
     await this.ensureInitialized()
-    const skills = await this.readIndexOrRebuild()
+    const appState = await this.readAppState()
+    const entries = await fs.promises.readdir(this.skillsRoot, { withFileTypes: true })
+    const skills: SkillManifest[] = []
+    let dirty = false
+
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name.startsWith('.')) {
+        continue
+      }
+      const skill = await this.loadSkill(entry.name, appState[entry.name])
+      if (!skill) {
+        continue
+      }
+      // 发现新 skill 目录但 .index.json 中无记录时，追加默认 appState
+      if (!appState[entry.name]) {
+        appState[entry.name] = createDefaultAppState('zip')
+        dirty = true
+      }
+      skills.push(skill)
+    }
+
+    skills.sort((a, b) => a.name.localeCompare(b.name, 'en'))
+
+    if (dirty) {
+      await this.writeAppState(appState)
+    }
+
     return { rootPath: this.skillsRoot, skills }
   }
 
@@ -88,26 +116,37 @@ export class SkillManagementService {
     await this.ensureInitialized()
     assertSkillName(name)
     const skillPath = path.join(this.skillsRoot, name)
-    const manifest = await this.readManifest(skillPath)
-    if (manifest.builtin && !enabled) {
+    const frontmatter = await this.readFrontmatter(skillPath)
+    const appState = await this.readAppState()
+    const state = appState[name]
+    if (!state) {
+      throw new Error('AGENT_SKILL_NOT_FOUND')
+    }
+    if (state.builtin && !enabled) {
       throw new Error('BUILTIN_SKILL_CANNOT_BE_DISABLED')
     }
-    const updated = { ...manifest, enabled, updatedAt: Date.now() }
-    await this.writeManifest(skillPath, updated)
-    await this.rebuildIndex()
-    return updated
+    state.enabled = enabled
+    state.updatedAt = Date.now()
+    appState[name] = state
+    await this.writeAppState(appState)
+    return { ...frontmatter, ...state }
   }
 
   async deleteSkill(name: string): Promise<void> {
     await this.ensureInitialized()
     assertSkillName(name)
     const skillPath = path.join(this.skillsRoot, name)
-    const manifest = await this.readManifest(skillPath)
-    if (manifest.builtin) {
+    const appState = await this.readAppState()
+    const state = appState[name]
+    if (!state) {
+      throw new Error('AGENT_SKILL_NOT_FOUND')
+    }
+    if (state.builtin) {
       throw new Error('BUILTIN_SKILL_CANNOT_BE_DELETED')
     }
     await removePath(skillPath)
-    await this.rebuildIndex()
+    delete appState[name]
+    await this.writeAppState(appState)
   }
 
   async getEnabledSkills(): Promise<SkillManifest[]> {
@@ -117,58 +156,127 @@ export class SkillManagementService {
 
   async readSkillMarkdown(name: string): Promise<string> {
     assertSkillName(name)
-    const skillPath = path.join(this.skillsRoot, name)
-    const manifest = await this.readManifest(skillPath)
-    if (!manifest.enabled) {
+    const appState = await this.readAppState()
+    const state = appState[name]
+    if (!state || !state.enabled) {
       throw new Error('AGENT_SKILL_INVALID')
     }
-    const skillFile = path.join(skillPath, 'SKILL.md')
+    const skillFile = path.join(this.skillsRoot, name, 'SKILL.md')
     return fs.promises.readFile(skillFile, 'utf8')
   }
 
   async rebuildIndex(): Promise<SkillManifest[]> {
     await fs.promises.mkdir(this.skillsRoot, { recursive: true })
+    const appState = await this.readAppState()
     const entries = await fs.promises.readdir(this.skillsRoot, { withFileTypes: true })
     const skills: SkillManifest[] = []
+    const activeNames = new Set<string>()
+
     for (const entry of entries) {
       if (!entry.isDirectory() || entry.name.startsWith('.')) {
         continue
       }
-      try {
-        const manifest = await this.readManifest(path.join(this.skillsRoot, entry.name))
-        if (manifest.name !== entry.name) {
-          manifest.name = entry.name
-          await this.writeManifest(path.join(this.skillsRoot, entry.name), manifest)
-        }
-        skills.push(manifest)
+      const skill = await this.loadSkill(entry.name, appState[entry.name])
+      if (!skill) {
+        continue
       }
-      catch {
-        // Fallback: if manifest.json is missing, build one from SKILL.md frontmatter
-        try {
-          const skillPath = path.join(this.skillsRoot, entry.name)
-          const skillFile = path.join(skillPath, 'SKILL.md')
-          if (fs.existsSync(skillFile)) {
-            const metadata = await readSkillMetadata(skillPath)
-            const now = Date.now()
-            const manifest: SkillManifest = {
-              name: metadata.name || entry.name,
-              version: metadata.version,
-              description: metadata.description,
-              source: 'zip',
-              enabled: true,
-              installedAt: now,
-              updatedAt: now,
-            }
-            await this.writeManifest(skillPath, manifest)
-            skills.push(manifest)
-          }
-        }
-        catch {}
+      activeNames.add(entry.name)
+      if (!appState[entry.name]) {
+        appState[entry.name] = createDefaultAppState('zip')
+      }
+      skills.push(skill)
+    }
+
+    // 清理已删除目录的 appState 条目
+    for (const name of Object.keys(appState)) {
+      if (!activeNames.has(name)) {
+        delete appState[name]
       }
     }
+
     skills.sort((a, b) => a.name.localeCompare(b.name, 'en'))
-    await fs.promises.writeFile(path.join(this.skillsRoot, INDEX_FILE), JSON.stringify(skills, null, 2), 'utf8')
+    await this.writeAppState(appState)
     return skills
+  }
+
+  // ── 私有方法 ──────────────────────────────────────────────
+
+  /**
+   * 从 SKILL.md 的 YAML frontmatter 读取标准元数据。
+   * frontmatter 缺失时用目录名兜底 name，description 留空。
+   */
+  private async readFrontmatter(skillPath: string): Promise<SkillFrontmatter> {
+    const skillFile = path.join(skillPath, 'SKILL.md')
+    const content = await fs.promises.readFile(skillFile, 'utf8')
+    const match = content.match(FRONTMATTER_RE)
+    if (match) {
+      try {
+        const parsed = yaml.load(match[1]) as Record<string, unknown>
+        if (parsed && typeof parsed === 'object') {
+          const name = typeof parsed.name === 'string' ? parsed.name : path.basename(skillPath)
+          const description = typeof parsed.description === 'string' ? parsed.description : ''
+          const frontmatter: SkillFrontmatter = { name, description }
+          if (typeof parsed.version === 'string') {
+            frontmatter.version = parsed.version
+          }
+          if (typeof parsed.license === 'string') {
+            frontmatter.license = parsed.license
+          }
+          if (typeof parsed.compatibility === 'string') {
+            frontmatter.compatibility = parsed.compatibility
+          }
+          if (parsed.metadata && typeof parsed.metadata === 'object' && !Array.isArray(parsed.metadata)) {
+            frontmatter.metadata = parsed.metadata as Record<string, string>
+          }
+          if (typeof parsed['allowed-tools'] === 'string') {
+            frontmatter.allowedTools = parsed['allowed-tools']
+          }
+          return frontmatter
+        }
+      }
+      catch {}
+    }
+    // 无 frontmatter 时，尝试从 # heading 提取 name
+    const headingName = this.extractHeadingName(content)
+    return { name: headingName ?? path.basename(skillPath), description: '' }
+  }
+
+  /** 合并 frontmatter + appState 为完整的 SkillManifest */
+  private async loadSkill(dirName: string, state?: SkillAppState): Promise<SkillManifest | null> {
+    try {
+      const skillPath = path.join(this.skillsRoot, dirName)
+      const frontmatter = await this.readFrontmatter(skillPath)
+      // 确保 name 与目录名一致
+      if (frontmatter.name !== dirName) {
+        frontmatter.name = dirName
+      }
+      const appState = state ?? createDefaultAppState('zip')
+      return { ...frontmatter, ...appState }
+    }
+    catch {
+      return null
+    }
+  }
+
+  private async readAppState(): Promise<Record<string, SkillAppState>> {
+    try {
+      const content = await fs.promises.readFile(path.join(this.skillsRoot, INDEX_FILE), 'utf8')
+      const data = JSON.parse(content) as SkillIndexFile
+      if (data && typeof data === 'object' && data.version === 1 && data.skills) {
+        return data.skills
+      }
+    }
+    catch {}
+    return {}
+  }
+
+  private async writeAppState(skills: Record<string, SkillAppState>): Promise<void> {
+    const data: SkillIndexFile = { version: 1, skills }
+    await fs.promises.writeFile(
+      path.join(this.skillsRoot, INDEX_FILE),
+      JSON.stringify(data, null, 2),
+      'utf8',
+    )
   }
 
   private async importFromDirectory(
@@ -176,8 +284,8 @@ export class SkillManagementService {
     options: { source: SkillManifest['source'], sourceUrl?: string, name?: string },
   ): Promise<SkillManifest> {
     await validateSkillDirectory(sourcePath)
-    const metadata = await readSkillMetadata(sourcePath)
-    const name = options.name ?? metadata.name
+    const frontmatter = await this.readFrontmatter(sourcePath)
+    const name = options.name ?? normalizeSkillName(frontmatter.name)
     assertSkillName(name)
     const targetPath = path.join(this.skillsRoot, name)
     if (fs.existsSync(targetPath)) {
@@ -185,68 +293,174 @@ export class SkillManagementService {
     }
 
     const now = Date.now()
-    const manifest: SkillManifest = {
-      name,
-      version: metadata.version,
-      description: metadata.description,
+    const appState: SkillAppState = {
       source: options.source,
       sourceUrl: options.sourceUrl,
       enabled: true,
+      builtin: false,
       installedAt: now,
       updatedAt: now,
     }
 
     await fs.promises.cp(sourcePath, targetPath, { recursive: true, errorOnExist: true })
-    await this.writeManifest(targetPath, manifest)
-    await this.rebuildIndex()
-    return manifest
+
+    // 确保导入的 SKILL.md frontmatter 中 name 与目录名一致
+    await this.ensureFrontmatterName(targetPath, name)
+
+    const allState = await this.readAppState()
+    allState[name] = appState
+    await this.writeAppState(allState)
+
+    return { ...frontmatter, name, ...appState }
   }
 
-  private async readIndexOrRebuild(): Promise<SkillManifest[]> {
+  /**
+   * 从 SKILL.md 正文中提取第一个 heading 作为兜底 name。
+   * 仅在无 frontmatter 时使用。
+   */
+  private extractHeadingName(content: string): string | undefined {
+    const match = content.match(/^# ([^\n]+)$/m)
+    return match ? match[1].trim() : undefined
+  }
+
+  /** 如果 SKILL.md frontmatter 的 name 与目录名不一致，修正它 */
+  private async ensureFrontmatterName(skillPath: string, dirName: string): Promise<void> {
+    const skillFile = path.join(skillPath, 'SKILL.md')
+    const content = await fs.promises.readFile(skillFile, 'utf8')
+    const match = content.match(FRONTMATTER_RE)
+    if (!match) {
+      return
+    }
     try {
-      const content = await fs.promises.readFile(path.join(this.skillsRoot, INDEX_FILE), 'utf8')
-      const data = JSON.parse(content)
-      if (Array.isArray(data)) {
-        return data.map(normalizeManifest)
+      const parsed = yaml.load(match[1]) as Record<string, unknown>
+      if (parsed && typeof parsed === 'object' && typeof parsed.name === 'string' && parsed.name !== dirName) {
+        parsed.name = dirName
+        const newFrontmatter = `---\n${yaml.dump(parsed, { lineWidth: -1 }).trim()}\n---`
+        const newContent = content.replace(FRONTMATTER_RE, newFrontmatter)
+        await fs.promises.writeFile(skillFile, newContent, 'utf8')
       }
     }
     catch {}
-    return this.rebuildIndex()
-  }
-
-  private async readManifest(skillPath: string): Promise<SkillManifest> {
-    const manifestPath = path.join(skillPath, 'manifest.json')
-    const content = await fs.promises.readFile(manifestPath, 'utf8')
-    return normalizeManifest(JSON.parse(content))
-  }
-
-  private writeManifest(skillPath: string, manifest: SkillManifest): Promise<void> {
-    return fs.promises.writeFile(path.join(skillPath, 'manifest.json'), JSON.stringify(manifest, null, 2), 'utf8')
   }
 
   private async ensureBuiltinSkillInstaller(): Promise<void> {
     const skillPath = path.join(this.skillsRoot, BUILTIN_SKILL_INSTALLER)
-    const now = Date.now()
     await fs.promises.mkdir(skillPath, { recursive: true })
+
+    // 生成带 frontmatter 的 SKILL.md
     const skillFile = path.join(skillPath, 'SKILL.md')
-    await fs.promises.writeFile(skillFile, createBuiltinSkillInstallerMarkdown(this.skillsRoot), 'utf8')
-    const manifestPath = path.join(skillPath, 'manifest.json')
-    if (!fs.existsSync(manifestPath)) {
-      await this.writeManifest(skillPath, {
-        name: BUILTIN_SKILL_INSTALLER,
-        description: 'Install skills from GitHub into Ant Chat.',
-        source: 'builtin',
+    const frontmatter = yaml.dump({
+      name: BUILTIN_SKILL_INSTALLER,
+      description: 'Install skills from GitHub into Ant Chat.',
+    }, { lineWidth: -1 }).trim()
+    const body = BUILTIN_SKILL_INSTALLER_BODY.replace('{skillsRoot}', this.skillsRoot)
+    const content = `---\n${frontmatter}\n---\n\n${body}`
+    await fs.promises.writeFile(skillFile, content, 'utf8')
+
+    // 确保 appState 中有记录
+    const appState = await this.readAppState()
+    if (!appState[BUILTIN_SKILL_INSTALLER]) {
+      const now = Date.now()
+      appState[BUILTIN_SKILL_INSTALLER] = {
         enabled: true,
         builtin: true,
+        source: 'builtin',
         installedAt: now,
         updatedAt: now,
-      })
+      }
+      await this.writeAppState(appState)
     }
+  }
+
+  /**
+   * 迁移旧版 manifest.json 格式到新格式。
+   * 检测条件：旧 .index.json 是数组，或 skill 目录下存在 manifest.json。
+   */
+  private async migrateFromManifestJson(): Promise<void> {
+    const indexPath = path.join(this.skillsRoot, INDEX_FILE)
+    let needsMigration = false
+
+    // 检测旧格式 .index.json
+    try {
+      const content = await fs.promises.readFile(indexPath, 'utf8')
+      const data = JSON.parse(content)
+      if (Array.isArray(data) || (data && typeof data === 'object' && !data.version)) {
+        needsMigration = true
+      }
+    }
+    catch {
+      // 文件不存在不算需要迁移
+    }
+
+    if (!needsMigration) {
+      // 检查是否有遗留的 manifest.json
+      try {
+        const entries = await fs.promises.readdir(this.skillsRoot, { withFileTypes: true })
+        for (const entry of entries) {
+          if (entry.isDirectory() && !entry.name.startsWith('.')) {
+            const manifestPath = path.join(this.skillsRoot, entry.name, 'manifest.json')
+            if (fs.existsSync(manifestPath)) {
+              needsMigration = true
+              break
+            }
+          }
+        }
+      }
+      catch {}
+    }
+
+    if (!needsMigration) {
+      return
+    }
+
+    const appState: Record<string, SkillAppState> = {}
+
+    try {
+      const entries = await fs.promises.readdir(this.skillsRoot, { withFileTypes: true })
+      for (const entry of entries) {
+        if (!entry.isDirectory() || entry.name.startsWith('.')) {
+          continue
+        }
+        const skillDir = path.join(this.skillsRoot, entry.name)
+        const manifestPath = path.join(skillDir, 'manifest.json')
+
+        // 尝试从旧 manifest.json 提取 appState
+        if (fs.existsSync(manifestPath)) {
+          try {
+            const oldManifest = JSON.parse(await fs.promises.readFile(manifestPath, 'utf8'))
+            appState[entry.name] = {
+              enabled: oldManifest.enabled !== false,
+              builtin: oldManifest.builtin === true,
+              source: oldManifest.source === 'github' || oldManifest.source === 'builtin' ? oldManifest.source : 'zip',
+              sourceUrl: typeof oldManifest.sourceUrl === 'string' ? oldManifest.sourceUrl : undefined,
+              installedAt: typeof oldManifest.installedAt === 'number' ? oldManifest.installedAt : Date.now(),
+              updatedAt: typeof oldManifest.updatedAt === 'number' ? oldManifest.updatedAt : Date.now(),
+            }
+          }
+          catch {}
+          // 删除旧 manifest.json
+          await removePath(manifestPath)
+        }
+        else {
+          appState[entry.name] = createDefaultAppState('zip')
+        }
+      }
+    }
+    catch {}
+
+    await this.writeAppState(appState)
   }
 
   private createTempDir(): Promise<string> {
     return fs.promises.mkdtemp(path.join(tmpdir(), `ant-chat-skill-${randomUUID()}-`))
   }
+}
+
+// ── 工具函数 ─────────────────────────────────────────────────
+
+function createDefaultAppState(source: 'zip' | 'github' | 'builtin'): SkillAppState {
+  const now = Date.now()
+  return { enabled: true, builtin: false, source, installedAt: now, updatedAt: now }
 }
 
 async function validateSkillDirectory(skillPath: string): Promise<void> {
@@ -257,77 +471,6 @@ async function validateSkillDirectory(skillPath: string): Promise<void> {
   const skillFile = path.join(skillPath, 'SKILL.md')
   if (!fs.existsSync(skillFile)) {
     throw new Error('AGENT_SKILL_INVALID: missing SKILL.md')
-  }
-}
-
-async function readSkillMetadata(skillPath: string): Promise<Pick<SkillManifest, 'name' | 'version' | 'description'>> {
-  const manifestPath = path.join(skillPath, 'manifest.json')
-  if (fs.existsSync(manifestPath)) {
-    const parsed = JSON.parse(await fs.promises.readFile(manifestPath, 'utf8'))
-    return {
-      name: normalizeSkillName(String(parsed.name || path.basename(skillPath))),
-      version: typeof parsed.version === 'string' ? parsed.version : undefined,
-      description: typeof parsed.description === 'string' ? parsed.description : undefined,
-    }
-  }
-
-  const markdown = await fs.promises.readFile(path.join(skillPath, 'SKILL.md'), 'utf8')
-
-  const frontmatter = parseFrontmatter(markdown)
-  const title = frontmatter?.name || markdown
-    .split('\n')
-    .find(line => line.startsWith('# '))
-    ?.slice(2)
-    .trim()
-  const description = frontmatter?.description
-    || extractBodyDescription(markdown)
-  return {
-    name: normalizeSkillName(title || path.basename(skillPath)),
-    version: undefined,
-    description,
-  }
-}
-
-function parseFrontmatter(markdown: string): { name?: string, description?: string } | null {
-  const match = markdown.match(/^---\n([\s\S]*?\n)---/)
-  if (!match)
-    return null
-  const nameMatch = match[1].match(/^name:\s+(\S.*)$/m)
-  const descMatch = match[1].match(/^description:\s+(\S.*)$/m)
-  return {
-    name: nameMatch ? nameMatch[1].trim() : undefined,
-    description: descMatch ? descMatch[1].trim() : undefined,
-  }
-}
-
-function extractBodyDescription(markdown: string): string | undefined {
-  const bodyStart = markdown.startsWith('---\n')
-    ? markdown.indexOf('\n---\n')
-    : -1
-  const body = bodyStart > 0 ? markdown.slice(bodyStart + 5) : markdown
-  return body
-    .split('\n')
-    .map(line => line.trim())
-    .find(line => line && !line.startsWith('#'))
-}
-
-function normalizeManifest(value: unknown): SkillManifest {
-  if (!value || typeof value !== 'object') {
-    throw new Error('AGENT_SKILL_INVALID')
-  }
-  const data = value as Record<string, unknown>
-  const name = String(data.name || '')
-  assertSkillName(name)
-  return {
-    name,
-    version: typeof data.version === 'string' ? data.version : undefined,
-    description: typeof data.description === 'string' ? data.description : undefined,
-    source: data.source === 'github' || data.source === 'builtin' ? data.source : 'zip',
-    sourceUrl: typeof data.sourceUrl === 'string' ? data.sourceUrl : undefined,
-    enabled: data.builtin === true ? true : data.enabled !== false,
-    builtin: data.builtin === true,
-    installedAt: typeof data.installedAt === 'number' ? data.installedAt : Date.now(),
-    updatedAt: typeof data.updatedAt === 'number' ? data.updatedAt : Date.now(),
   }
 }
 

--- a/packages/shared/src/interfaces/skill.ts
+++ b/packages/shared/src/interfaces/skill.ts
@@ -1,17 +1,36 @@
+/** Agent Skills 标准 frontmatter 字段（来源：SKILL.md YAML frontmatter） */
+export interface SkillFrontmatter {
+  name: string
+  description: string
+  version?: string
+  license?: string
+  compatibility?: string
+  metadata?: Record<string, string>
+  allowedTools?: string
+}
+
 export type SkillSource = 'zip' | 'github' | 'builtin'
 
-export interface SkillManifest {
-  name: string
-  version?: string
-  description?: string
+/** 应用层可变状态（仅持久化在 .index.json 中） */
+export interface SkillAppState {
+  enabled: boolean
+  builtin: boolean
   source: SkillSource
   sourceUrl?: string
-  enabled: boolean
-  builtin?: boolean
   installedAt: number
   updatedAt: number
 }
 
+/** 组合视图，保持 UI/IPC 层向后兼容 */
+export interface SkillManifest extends SkillFrontmatter, SkillAppState {}
+
+/** .index.json 磁盘结构 */
+export interface SkillIndexFile {
+  version: 1
+  skills: Record<string, SkillAppState>
+}
+
+/** listSkills() 返回值 */
 export interface SkillIndex {
   rootPath: string
   skills: SkillManifest[]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -390,7 +390,13 @@ importers:
       fflate:
         specifier: ^0.8.2
         version: 0.8.3
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.2.0
     devDependencies:
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       tsdown:
         specifier: 'catalog:'
         version: 0.20.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(synckit@0.11.12)(typescript@5.9.3)
@@ -3771,6 +3777,9 @@ packages:
   '@types/js-cookie@3.0.6':
     resolution: {integrity: sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==}
 
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
   '@types/jsesc@2.5.1':
     resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
 
@@ -6312,6 +6321,10 @@ packages:
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   jsdoc-type-pratt-parser@4.8.0:
@@ -9458,7 +9471,7 @@ snapshots:
   '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -10077,7 +10090,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -12147,6 +12160,8 @@ snapshots:
 
   '@types/js-cookie@3.0.6': {}
 
+  '@types/js-yaml@4.0.9': {}
+
   '@types/jsesc@2.5.1': {}
 
   '@types/json-schema@7.0.15': {}
@@ -12645,7 +12660,7 @@ snapshots:
       hosted-git-info: 4.1.0
       isbinaryfile: 5.0.7
       jiti: 2.7.0
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       json5: 2.2.3
       lazy-val: 1.0.5
       minimatch: 10.2.5
@@ -12847,7 +12862,7 @@ snapshots:
       fs-extra: 10.1.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       sanitize-filename: 1.6.4
       source-map-support: 0.5.21
       stat-mode: 1.0.0
@@ -13135,7 +13150,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -13145,7 +13160,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -13495,7 +13510,7 @@ snapshots:
       builder-util: 26.9.0
       fs-extra: 10.1.0
       iconv-lite: 0.6.3
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
     optionalDependencies:
       dmg-license: 1.0.11
     transitivePeerDependencies:
@@ -15132,6 +15147,10 @@ snapshots:
       esprima: 4.0.1
 
   js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
## Summary

将 skills 系统从自定义 `manifest.json` 迁移到符合 [Agent Skills 标准](https://agentskills.io/specification) 的方式：

- 元数据（name/description/version/license/compatibility/metadata/allowed-tools）从 SKILL.md YAML frontmatter 读取
- 应用层状态（enabled/builtin/source/sourceUrl/installedAt/updatedAt）存入 .index.json
- .index.json 从数组改为 `{ version: 1, skills: { [name]: SkillAppState } }` map 结构

## 改动

| 文件 | 改动 |
|------|------|
| `packages/agent-runtime/package.json` | 添加 js-yaml 依赖 |
| `packages/shared/src/interfaces/skill.ts` | 拆分 SkillFrontmatter / SkillAppState / SkillIndexFile，SkillManifest 改为组合 |
| `packages/agent-runtime/src/skills/skillManagementService.ts` | 核心重写：去掉 manifest.json 读写，新增 readFrontmatter/readAppState/writeAppState；内置 skill SKILL.md 加 frontmatter；含旧格式迁移逻辑 |
| `packages/agent-core/src/tools/toolRegistry.ts` | 去掉 manifest.json 文件过滤 |
| `packages/agent-runtime/src/skills/__tests__/skillManagementService.spec.ts` | 新增 frontmatter 解析、迁移、rebuildIndex 等测试（11 个） |

## 兼容性

- `SkillManifest` 类型保持向后兼容，UI/IPC 层无需改动
- 旧版 manifest.json + 数组格式 .index.json 首次启动时自动迁移，迁移后删除 manifest.json