### PR TITLE
refactor: 将 Model 引用从 modelId 拆分为 (providerId, modelId)

### DIFF
--- a/apps/web/src/api/chatApi.ts
+++ b/apps/web/src/api/chatApi.ts
@@ -3,10 +3,11 @@ import { createIpcResponse } from '@ant-chat/shared'
 import { useGeneralSettingsStore } from '@/store/generalSettings'
 import { getAppRpcClient } from './transports/appRpc'
 
-async function initConversationsTitle(conversationsId: string, modelId?: string): Promise<IpcResponse<IConversations>> {
-  const { assistantModelId } = useGeneralSettingsStore.getState()
+async function initConversationsTitle(conversationsId: string, modelId?: string, providerId?: string): Promise<IpcResponse<IConversations>> {
+  const { assistantModelId, assistantProviderId } = useGeneralSettingsStore.getState()
   const finalModelId = modelId || assistantModelId
-  const conversation = await getAppRpcClient().call('chat.createConversationsTitle', { modelId: finalModelId, conversationsId })
+  const finalProviderId = providerId || assistantProviderId
+  const conversation = await getAppRpcClient().call('chat.createConversationsTitle', { modelId: finalModelId, providerId: finalProviderId, conversationsId })
   return createIpcResponse(true, conversation)
 }
 

--- a/apps/web/src/api/providerApi.ts
+++ b/apps/web/src/api/providerApi.ts
@@ -29,8 +29,8 @@ export const providerApi = {
     return getAppRpcClient().call('provider.getProviderById', { id })
   },
 
-  getProviderByModelId: async (id: string): Promise<ProviderConfigSchema> => {
-    return getAppRpcClient().call('provider.getProviderByModelId', { id })
+  getModelInfoById: async (modelId: string, providerId: string): Promise<ProviderConfigModelSchema> => {
+    return getAppRpcClient().call('provider.getModel', { providerId, modelId })
   },
 
   getAllAbvailableModels: async (): Promise<AllAvailableModelsSchema[]> => {
@@ -57,10 +57,6 @@ export const providerApi = {
     const result = await getAppRpcClient().call('provider.deleteProviderModel', { id })
     emitProviderChanged()
     return result
-  },
-
-  getModelInfoById: async (id: string): Promise<ProviderConfigModelSchema> => {
-    return getAppRpcClient().call('provider.getModelById', { id })
   },
 
   getModelsDevProviders: async (): Promise<ModelsDevProvider[]> => {

--- a/apps/web/src/components/Chat/Chat.tsx
+++ b/apps/web/src/components/Chat/Chat.tsx
@@ -36,6 +36,7 @@ export default function Chat() {
   const { commandRunning, submitCommand, cancelCommand } = useBuiltinCommandSubmit({
     settings: {
       modelId: settings.modelId || '',
+      providerId: settings.providerId || '',
       systemPrompt: settings.systemPrompt,
       temperature: settings.temperature,
       maxTokens: settings.maxTokens,
@@ -151,10 +152,9 @@ export default function Chat() {
           disabled={commandRunning}
           actions={(
             <ModelControlPanel
-              value={settings.modelId}
-              onChange={(modelInfo) => {
-                const { id: modelId, maxTokens, temperature } = modelInfo
-                updateSettings({ modelId, maxTokens, temperature })
+              value={{ modelId: settings.modelId, providerId: settings.providerId }}
+              onChange={({ modelId, providerId }) => {
+                updateSettings({ modelId, providerId })
               }}
             />
           )}

--- a/apps/web/src/components/Chat/Chat.tsx
+++ b/apps/web/src/components/Chat/Chat.tsx
@@ -153,8 +153,8 @@ export default function Chat() {
           actions={(
             <ModelControlPanel
               value={{ modelId: settings.modelId, providerId: settings.providerId }}
-              onChange={({ modelId, providerId }) => {
-                updateSettings({ modelId, providerId })
+              onChange={({ modelId, providerId, maxTokens, temperature }) => {
+                updateSettings({ modelId, providerId, maxTokens, temperature })
               }}
             />
           )}

--- a/apps/web/src/components/GeneralSettings/SelectModel.tsx
+++ b/apps/web/src/components/GeneralSettings/SelectModel.tsx
@@ -1,14 +1,28 @@
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger, SelectValue } from '@workspace/ui/components/select'
 import { useAllAvailableModels } from '@/hooks/useAllAvailableModels'
-import { setAssistantModelId, useGeneralSettingsStore } from '@/store/generalSettings'
+import { setAssistantModel, useGeneralSettingsStore } from '@/store/generalSettings'
 
 export function SelectModel() {
   const { data: providers } = useAllAvailableModels()
 
   const assistantModelId = useGeneralSettingsStore(state => state.assistantModelId)
+  const assistantProviderId = useGeneralSettingsStore(state => state.assistantProviderId)
+
+  const currentValue = assistantModelId ? `${assistantProviderId}|${assistantModelId}` : '__default__'
 
   return (
-    <Select value={assistantModelId || '__default__'} onValueChange={value => setAssistantModelId(value === '__default__' ? '' : value)}>
+    <Select
+      value={currentValue}
+      onValueChange={(value) => {
+        if (value === '__default__') {
+          setAssistantModel('', '')
+        }
+        else {
+          const [providerId, modelId] = value.split('|')
+          setAssistantModel(modelId, providerId)
+        }
+      }}
+    >
       <SelectTrigger className="min-w-50">
         <SelectValue placeholder="选择模型" />
       </SelectTrigger>
@@ -18,7 +32,7 @@ export function SelectModel() {
           <SelectGroup key={item.name}>
             <SelectLabel>{item.name}</SelectLabel>
             {item.models.map(model => (
-              <SelectItem key={model.id} value={model.id}>
+              <SelectItem key={`${item.id}|${model.id}`} value={`${item.id}|${model.id}`}>
                 {model.name}
               </SelectItem>
             ))}

--- a/apps/web/src/components/Sender/ModelParameterSettingsPanel.tsx
+++ b/apps/web/src/components/Sender/ModelParameterSettingsPanel.tsx
@@ -17,11 +17,15 @@ export function ModelParameterSettingsPanel() {
 
   useEffect(() => {
     const fetchModelInfo = async () => {
-      const info = await providerApi.getModelInfoById(settings.modelId)
+      if (!settings.modelId || !settings.providerId) {
+        setModelInfo(null)
+        return
+      }
+      const info = await providerApi.getModelInfoById(settings.modelId, settings.providerId)
       setModelInfo(info)
     }
     fetchModelInfo()
-  }, [settings.modelId])
+  }, [settings.modelId, settings.providerId])
 
   function updateCompaction(partial: Partial<CompactionSettingsSchema>) {
     updateSettings({ compaction: { ...compaction, ...partial } })

--- a/apps/web/src/components/Sender/PickerModel.tsx
+++ b/apps/web/src/components/Sender/PickerModel.tsx
@@ -14,8 +14,8 @@ import { ProviderLogoDisplay } from './renderProviderLogo'
 import { SelectModel } from './SelectModel'
 
 interface ModelControlPanelProps {
-  value: string
-  onChange?: (modelInfo: AllAvailableModelsSchema['models'][number]) => void
+  value: { modelId: string, providerId: string }
+  onChange?: (info: { modelId: string, providerId: string }) => void
 }
 
 export function ModelControlPanel({ value, onChange }: ModelControlPanelProps) {
@@ -33,12 +33,13 @@ export function ModelControlPanel({ value, onChange }: ModelControlPanelProps) {
     }
   }, [refresh])
 
-  const activeProviderServiceInfo = !value ? data?.[0] : data?.find(item => item.models.some(model => model.id === value))
-  const currentModelInfo = activeProviderServiceInfo?.models.find(model => model.id === value)
+  const activeProviderServiceInfo = !value.modelId ? data?.[0] : data?.find(item => item.id === value.providerId)
+  const currentModelInfo = activeProviderServiceInfo?.models.find(model => model.id === value.modelId)
 
   React.useEffect(() => {
-    if (!value && activeProviderServiceInfo?.models.length) {
-      onChange?.(activeProviderServiceInfo?.models[0])
+    if (!value.modelId && activeProviderServiceInfo?.models.length) {
+      const firstModel = activeProviderServiceInfo.models[0]
+      onChange?.({ modelId: firstModel.id, providerId: firstModel.providerId })
     }
   }, [activeProviderServiceInfo, onChange, value])
 
@@ -110,8 +111,8 @@ export function ModelControlPanel({ value, onChange }: ModelControlPanelProps) {
           ? (
               <SelectModel
                 value={value}
-                onChange={(nextModel) => {
-                  onChange?.(nextModel)
+                onChange={(nextInfo) => {
+                  onChange?.(nextInfo)
                   setOpenPopover(false)
                 }}
                 options={data}

--- a/apps/web/src/components/Sender/PickerModel.tsx
+++ b/apps/web/src/components/Sender/PickerModel.tsx
@@ -15,7 +15,7 @@ import { SelectModel } from './SelectModel'
 
 interface ModelControlPanelProps {
   value: { modelId: string, providerId: string }
-  onChange?: (info: { modelId: string, providerId: string }) => void
+  onChange?: (info: { modelId: string, providerId: string, maxTokens: number, temperature: number }) => void
 }
 
 export function ModelControlPanel({ value, onChange }: ModelControlPanelProps) {
@@ -39,7 +39,7 @@ export function ModelControlPanel({ value, onChange }: ModelControlPanelProps) {
   React.useEffect(() => {
     if (!value.modelId && activeProviderServiceInfo?.models.length) {
       const firstModel = activeProviderServiceInfo.models[0]
-      onChange?.({ modelId: firstModel.id, providerId: firstModel.providerId })
+      onChange?.({ modelId: firstModel.id, providerId: firstModel.providerId, maxTokens: firstModel.maxTokens, temperature: firstModel.temperature })
     }
   }, [activeProviderServiceInfo, onChange, value])
 

--- a/apps/web/src/components/Sender/SelectModel.tsx
+++ b/apps/web/src/components/Sender/SelectModel.tsx
@@ -5,7 +5,7 @@ import { ProviderLogoDisplay } from './renderProviderLogo'
 
 export interface SelectModelProps {
   value: { modelId: string, providerId: string }
-  onChange?: (info: { modelId: string, providerId: string }) => void
+  onChange?: (info: { modelId: string, providerId: string, maxTokens: number, temperature: number }) => void
   options?: AllAvailableModelsSchema[]
 }
 
@@ -40,13 +40,13 @@ export function SelectModel({ value, onChange, options }: SelectModelProps) {
                             hover:bg-(--hover-bg-color)
                           `}
                           onClick={() => {
-                            onChange?.({ modelId: model.id, providerId: model.providerId })
+                            onChange?.({ modelId: model.id, providerId: model.providerId, maxTokens: model.maxTokens, temperature: model.temperature })
                             setKeyword('')
                           }}
                           onKeyDown={(e) => {
                             if (e.key === 'Enter' || e.key === ' ') {
                               e.preventDefault()
-                              onChange?.({ modelId: model.id, providerId: model.providerId })
+                              onChange?.({ modelId: model.id, providerId: model.providerId, maxTokens: model.maxTokens, temperature: model.temperature })
                               setKeyword('')
                             }
                           }}

--- a/apps/web/src/components/Sender/SelectModel.tsx
+++ b/apps/web/src/components/Sender/SelectModel.tsx
@@ -4,8 +4,8 @@ import React from 'react'
 import { ProviderLogoDisplay } from './renderProviderLogo'
 
 export interface SelectModelProps {
-  value: string
-  onChange?: (value: AllAvailableModelsSchema['models'][number]) => void
+  value: { modelId: string, providerId: string }
+  onChange?: (info: { modelId: string, providerId: string }) => void
   options?: AllAvailableModelsSchema[]
 }
 
@@ -32,7 +32,7 @@ export function SelectModel({ value, onChange, options }: SelectModelProps) {
                     <div>
                       {item.models.filter(model => model.name.includes(keyword)).map(model => (
                         <div
-                          key={model.id}
+                          key={`${item.id}-${model.id}`}
                           role="button"
                           tabIndex={0}
                           className={`
@@ -40,13 +40,13 @@ export function SelectModel({ value, onChange, options }: SelectModelProps) {
                             hover:bg-(--hover-bg-color)
                           `}
                           onClick={() => {
-                            onChange?.(model)
+                            onChange?.({ modelId: model.id, providerId: model.providerId })
                             setKeyword('')
                           }}
                           onKeyDown={(e) => {
                             if (e.key === 'Enter' || e.key === ' ') {
                               e.preventDefault()
-                              onChange?.(model)
+                              onChange?.({ modelId: model.id, providerId: model.providerId })
                               setKeyword('')
                             }
                           }}
@@ -58,7 +58,7 @@ export function SelectModel({ value, onChange, options }: SelectModelProps) {
                             </span>
                           </div>
                           <div>
-                            {value === model.id ? <span>✓</span> : null}
+                            {value.modelId === model.id && value.providerId === item.id ? <span>✓</span> : null}
                           </div>
                         </div>
                       ))}

--- a/apps/web/src/components/Sender/Sender.tsx
+++ b/apps/web/src/components/Sender/Sender.tsx
@@ -348,10 +348,10 @@ function Sender({ disabled = false, actions, ...props }: SenderProps) {
   const { settings } = useChatSettingsContext()
 
   useEffect(() => {
-    if (!settings.modelId)
+    if (!settings.modelId || !settings.providerId)
       return
-    providerApi.getModelInfoById(settings.modelId).then(setCurrentModelInfo)
-  }, [settings.modelId])
+    providerApi.getModelInfoById(settings.modelId, settings.providerId).then(setCurrentModelInfo)
+  }, [settings.modelId, settings.providerId])
 
   const fileAccept = useMemo(
     () => buildAcceptFromModalities(currentModelInfo?.capabilities?.inputModalities ?? []),

--- a/apps/web/src/components/Sender/__tests__/Sender.spec.tsx
+++ b/apps/web/src/components/Sender/__tests__/Sender.spec.tsx
@@ -63,7 +63,7 @@ function renderSender(onSubmit = vi.fn()) {
     <TooltipProvider>
       <ChatSettingsContext
         value={{
-          settings: { ...DEFAULT_SETTINGS, modelId: 'test-model' },
+          settings: { ...DEFAULT_SETTINGS, modelId: 'test-model', providerId: 'test-provider' },
           updateSettings: vi.fn(),
         }}
       >

--- a/apps/web/src/contexts/chatSettings/context.ts
+++ b/apps/web/src/contexts/chatSettings/context.ts
@@ -4,6 +4,7 @@ import { createContext } from 'react'
 
 export const DEFAULT_SETTINGS: ConversationsSettingsSchema = {
   modelId: '',
+  providerId: '',
   systemPrompt: '',
   temperature: 0.7,
   maxTokens: 1000,

--- a/apps/web/src/hooks/__tests__/useConversationSettings.spec.ts
+++ b/apps/web/src/hooks/__tests__/useConversationSettings.spec.ts
@@ -39,6 +39,7 @@ describe('useConversationSettings', () => {
     const { result } = renderHook(() => useConversationSettings())
     expect(result.current.settings).toEqual({
       modelId: '',
+      providerId: '',
       systemPrompt: '',
       temperature: 0.7,
       maxTokens: 1000,
@@ -55,6 +56,7 @@ describe('useConversationSettings', () => {
       updatedAt: Date.now(),
       settings: {
         modelId: 'gpt-3',
+        providerId: '',
         systemPrompt: 'You are a bot',
         temperature: 0.5,
         maxTokens: 500,
@@ -64,6 +66,7 @@ describe('useConversationSettings', () => {
     const { result } = renderHook(() => useConversationSettings())
     expect(result.current.settings).toEqual({
       modelId: 'gpt-3',
+      providerId: '',
       systemPrompt: 'You are a bot',
       temperature: 0.5,
       maxTokens: 500,
@@ -80,6 +83,7 @@ describe('useConversationSettings', () => {
       updatedAt: Date.now(),
       settings: {
         modelId: 'gpt-3',
+        providerId: '',
         systemPrompt: 'You are a bot',
         temperature: 0.5,
         maxTokens: 500,
@@ -113,6 +117,7 @@ describe('useConversationSettings', () => {
       updatedAt: Date.now(),
       settings: {
         modelId: 'gpt-3',
+        providerId: '',
         systemPrompt: '',
         temperature: 0.7,
         maxTokens: 4096,
@@ -160,6 +165,7 @@ describe('useConversationSettings', () => {
           updatedAt: Date.now(),
           settings: {
             modelId: 'gpt-3',
+            providerId: '',
             systemPrompt: 'Prompt',
             temperature: 0.6,
             maxTokens: 800,
@@ -177,6 +183,7 @@ describe('useConversationSettings', () => {
     rerender()
     expect(result.current.settings).toEqual({
       modelId: '',
+      providerId: '',
       systemPrompt: '',
       temperature: 0.7,
       maxTokens: 1000,

--- a/apps/web/src/hooks/useBuiltinCommandSubmit.ts
+++ b/apps/web/src/hooks/useBuiltinCommandSubmit.ts
@@ -9,6 +9,7 @@ import { setActiveConversationsId, useMessagesStore } from '@/store/messages'
 interface UseBuiltinCommandSubmitOptions {
   settings: {
     modelId: string
+    providerId?: string
     systemPrompt?: string
     temperature?: number
     maxTokens?: number
@@ -45,6 +46,7 @@ export function useBuiltinCommandSubmit(options: UseBuiltinCommandSubmitOptions)
         argument: command.argument,
         modelConfig: {
           modelId: options.settings.modelId,
+          providerId: options.settings.providerId || '',
           systemPrompt: options.settings.systemPrompt || '',
           temperature: options.settings.temperature || 0.7,
           maxTokens: options.settings.maxTokens || 4096,

--- a/apps/web/src/hooks/useConversationSettings.ts
+++ b/apps/web/src/hooks/useConversationSettings.ts
@@ -8,6 +8,7 @@ import { useMessagesStore } from '@/store/messages'
 
 const DEFAULT_SETTINGS: ConversationsSettingsSchema = {
   modelId: '',
+  providerId: '',
   systemPrompt: '',
   temperature: 0.7,
   maxTokens: 1000,
@@ -25,6 +26,9 @@ export function useConversationSettings() {
 
     if (has(options, 'modelId')) {
       updatedSettings.modelId = options.modelId || ''
+    }
+    if (has(options, 'providerId')) {
+      updatedSettings.providerId = options.providerId || ''
     }
     if (has(options, 'systemPrompt')) {
       updatedSettings.systemPrompt = options.systemPrompt
@@ -56,6 +60,7 @@ export function useConversationSettings() {
     _updateSettings((draft) => {
       if (conversations?.settings) {
         draft.modelId = conversations.settings.modelId || ''
+        draft.providerId = conversations.settings.providerId || ''
         draft.systemPrompt = conversations.settings.systemPrompt || ''
         draft.temperature = conversations.settings.temperature || 0.7
         draft.maxTokens = conversations.settings.maxTokens || 1000
@@ -63,6 +68,7 @@ export function useConversationSettings() {
       }
       else {
         draft.modelId = ''
+        draft.providerId = ''
         draft.systemPrompt = ''
         draft.temperature = 0.7
         draft.maxTokens = 1000

--- a/apps/web/src/store/agent/__tests__/actions.spec.ts
+++ b/apps/web/src/store/agent/__tests__/actions.spec.ts
@@ -34,6 +34,7 @@ describe('agent store actions', () => {
       prompt: 'p',
       modelConfig: {
         modelId: 'model-1',
+        providerId: 'provider-1',
         systemPrompt: '',
         temperature: 0.7,
         maxTokens: 1024,

--- a/apps/web/src/store/conversation/actions.ts
+++ b/apps/web/src/store/conversation/actions.ts
@@ -195,12 +195,14 @@ export async function nextPageConversationsAction() {
 }
 
 export async function initConversationsTitle(conversationsId: string) {
-  const { assistantModelId } = useGeneralSettingsStore.getState()
+  const { assistantModelId, assistantProviderId } = useGeneralSettingsStore.getState()
   let modelId = assistantModelId
+  let providerId = assistantProviderId
 
   if (!modelId) {
     const conversation = getConversationByIdAction(conversationsId)
     modelId = conversation?.settings?.modelId || ''
+    providerId = conversation?.settings?.providerId || ''
   }
 
   if (!modelId) {
@@ -208,7 +210,7 @@ export async function initConversationsTitle(conversationsId: string) {
     return
   }
 
-  const resp = await chatApi.initConversationsTitle(conversationsId, modelId)
+  const resp = await chatApi.initConversationsTitle(conversationsId, modelId, providerId)
 
   if (!resp.success) {
     console.error('initConversationsTitle fail. id => ', conversationsId)

--- a/apps/web/src/store/generalSettings/actions.ts
+++ b/apps/web/src/store/generalSettings/actions.ts
@@ -19,6 +19,38 @@ export async function setAssistantModelId(id: string) {
   }
 }
 
+export async function setAssistantProviderId(providerId: string) {
+  useGeneralSettingsStore.setState(produce((state) => {
+    state.isLoading = true
+  }))
+  try {
+    const updates = { assistantProviderId: providerId }
+    const newSettings = await generalSettingsApi.updateSettings(updates)
+    useGeneralSettingsStore.setState(newSettings)
+  }
+  finally {
+    useGeneralSettingsStore.setState(produce((state) => {
+      state.isLoading = false
+    }))
+  }
+}
+
+export async function setAssistantModel(modelId: string, providerId: string) {
+  useGeneralSettingsStore.setState(produce((state) => {
+    state.isLoading = true
+  }))
+  try {
+    const updates = { assistantModelId: modelId, assistantProviderId: providerId }
+    const newSettings = await generalSettingsApi.updateSettings(updates)
+    useGeneralSettingsStore.setState(newSettings)
+  }
+  finally {
+    useGeneralSettingsStore.setState(produce((state) => {
+      state.isLoading = false
+    }))
+  }
+}
+
 export async function updateProxySettings(proxySettingsUpdates: Partial<ProxySettings>) {
   useGeneralSettingsStore.setState(produce((state) => {
     state.isLoading = true

--- a/apps/web/src/store/generalSettings/store.ts
+++ b/apps/web/src/store/generalSettings/store.ts
@@ -8,6 +8,7 @@ interface GeneralSettingsStoreState extends GeneralSettingsState {
 
 const DEFAULT_SETTINGS: GeneralSettingsState = {
   assistantModelId: '',
+  assistantProviderId: '',
   proxySettings: {
     mode: 'none',
     customProxyUrl: '',

--- a/docs/superpowers/specs/2026-06-21-model-ref-design.md
+++ b/docs/superpowers/specs/2026-06-21-model-ref-design.md
@@ -1,0 +1,228 @@
+# Model 引用重构：从扁平 modelId 到 (providerId, modelId) 分字段
+
+## 背景
+
+当前系统使用扁平字符串 `modelId` 作为 Conversation 和 AppSettings 中模型的引用标识。由于历史迁移和 models.dev 导入，同一 `modelId` 可能出现在多个 provider 中（如 `deepseek-v4-flash` 同时存在于 deepseek 和 opencode-go），导致 `getModelById()` 线性扫描返回错误 provider。
+
+## 问题分析
+
+`getModelById()` 遍历所有 provider 的 `models` 字典，返回第一个匹配。当跨 provider 存在同名 modelId 时，查找结果不确定。所有调用方在拿到 model 后立即 `getProviderById()`，说明**没有任何调用方只需 model 而不需 provider**。
+
+## 设计变更
+
+### 核心概念
+
+Model 在业务域中不独立存在，它永远属于一个 Provider。存储和传输时应始终携带 `(providerId, modelId)` 对，而非扁平字符串。
+
+### 类型定义
+
+```typescript
+// 引用类型（存储/传输）
+interface ModelRef {
+  providerId: string
+  modelId: string
+}
+
+// 解析结果（一次查询出 model + provider）
+interface ResolvedModel {
+  model: AgentModel
+  provider: ProviderConfig
+}
+```
+
+### IModelCatalog 接口重设计
+
+```typescript
+interface IModelCatalog {
+  // ① 一次性解析 model + provider（用于 runtime 启动）
+  resolveModel(ref: ModelRef): Promise<ResolvedModel | null>
+
+  // ② 纯查询（用于 UI 展示，调用方已知 providerId）
+  getModel(providerId: string, modelId: string): Promise<AgentModel | null>
+  getProvider(providerId: string): Promise<ProviderConfig | null>
+}
+```
+
+删除：`getModelById()`、`getProviderByModelId()`（不再需要）
+
+### 存储层 Schema 变更
+
+```typescript
+// ConversationsSettingsSchema
+{
+  modelId: string,     // 保持，"deepseek-v4-flash"
+  providerId: string,  // 新增，"deepseek"
+}
+
+// AppSettingsSchema
+{
+  assistantModelId: string,      // "deepseek-v4-flash"
+  assistantProviderId: string,   // "deepseek"
+}
+```
+
+### ProviderSettingsRepository 变更
+
+```typescript
+// 新增
+getModel(providerId: string, modelId: string): ProviderConfigModelSchema | null {
+  const provider = this.store.read().providers.find(p => p.id === providerId)
+  const model = provider?.models[modelId]
+  return model ? toProviderConfigModel(providerId, modelId, model) : null
+}
+
+resolveModel(providerId: string, modelId: string): { model: ProviderConfigModelSchema, provider: ProviderConfigSchema } | null {
+  const provider = this.store.read().providers.find(p => p.id === providerId)
+  if (!provider) return null
+  const model = provider.models[modelId]
+  if (!model) return null
+  return {
+    model: toProviderConfigModel(providerId, modelId, model),
+    provider: toProviderConfig(provider),
+  }
+}
+
+// 删除
+getModelById()       // 被 getModel() + resolveModel() 替代
+getProviderByModelId() // 不再需要
+```
+
+### Runtime 链路变化
+
+```
+Before:
+  agentTurnService:
+    model = catalog.getModelById(modelId)     // 有歧义
+    provider = catalog.getProviderById(model.providerId)
+    aiProvider = createProvider(provider)
+    runtime.startTask({ modelId, aiProvider })  // 传 raw string
+    └─ SessionRuntime:
+         model = catalog.getModelById(modelId) // 重复查找
+         provider = catalog.getProviderById(model.providerId)
+         aiProvider = options.aiProvider ?? createProvider(provider) // 条件创建
+
+After:
+  agentTurnService:
+    resolved = catalog.resolveModel({ providerId, modelId })
+    aiProvider = createProvider(resolved.provider)
+    runtime.startTask({
+      model: resolved.model,        // 已解析
+      provider: resolved.provider,  // 已解析
+      aiProvider,                   // 已创建
+    })
+    └─ SessionRuntime:
+         // 直接用 options.model + options.provider + options.aiProvider
+         // 不再调用 modelCatalog
+```
+
+### AgentRuntimeStartTaskOptions 变更
+
+```typescript
+interface AgentRuntimeStartTaskOptions {
+  // 删除
+  modelId: string
+
+  // 新增
+  model: AgentModel
+  provider: ProviderConfig
+  aiProvider?: IAIProvider  // 保留
+  // ...
+}
+```
+
+### 前端变更
+
+Conversation settings 存储和传输改为分字段：
+
+```typescript
+// useConversationSettings / chatSettings context
+{
+  modelId: string,
+  providerId: string,
+  systemPrompt: string,
+  temperature: number,
+  maxTokens: number,
+}
+
+// 选模型 onChange 时传
+onChange?.({ ...model, providerId: activeProvider.id })
+```
+
+PickerModel / SelectModel 比对逻辑：
+
+```typescript
+// 选中判定
+const [activeProviderId, activeModelId] = [settings.providerId, settings.modelId]
+const activeProvider = data?.find(item => item.id === activeProviderId)
+const currentModelInfo = activeProvider?.models.find(model => model.id === activeModelId)
+```
+
+### GeneralSettings 变更
+
+```typescript
+interface GeneralSettingsState {
+  assistantModelId: string
+  assistantProviderId: string
+  proxySettings: ProxySettings
+}
+```
+
+## 受影响的文件清单
+
+### Schema / Interface 层（6 文件）
+
+| 文件 | 变更 |
+|---|---|
+| `packages/shared/src/schemas/conversations.ts` | ConversationsSettingsSchema 新增 `providerId` |
+| `packages/shared/src/schemas/appSettings.ts` | AppSettingsSchema 新增 `assistantProviderId` |
+| `packages/shared/src/interfaces/generalSettings.ts` | GeneralSettingsSchema 映射新增 |
+| `packages/shared/src/interfaces/agent-runtime-electron.ts` | StartAgentTurnOptions 新增 `providerId` |
+| `packages/shared/src/interfaces/agent-runtime-interfaces.ts` | IModelCatalog 重设计；AgentRuntimeStartTaskOptions 替换为 model+provider |
+| `packages/shared/src/interfaces/app-rpc.ts` | RPC 方法名更新 |
+
+### 后端核心层（6 文件）
+
+| 文件 | 变更 |
+|---|---|
+| `packages/app-data/src/settings/providerSettingsRepository.ts` | 新增 `getModel()`、`resolveModel()`；删除 `getModelById()`、`getProviderByModelId()` |
+| `packages/app-data/src/settings/modelCatalog.ts` | 适配新接口 |
+| `packages/agent-runtime/src/agentTurnService.ts` | 用 resolveModel，传 `model+provider` 给 runtime |
+| `packages/agent-core/src/session/SessionRuntime.ts` | 直接用 `options.model/provider`，移除 modelCatalog 调用 |
+| `packages/agent-runtime/src/conversationTitleGenerator.ts` | 接收 `ResolvedModel` 或 resolveModel |
+| `packages/agent-runtime/src/compactCommand.ts` | 改用 resolveModel |
+
+### AppRuntime 层（2 文件）
+
+| 文件 | 变更 |
+|---|---|
+| `packages/app-runtime/src/appRuntime.ts` | RPC handlers 更新 |
+| `packages/app-runtime/src/rpcHandlers.ts` | 方法名/参数更新 |
+
+### 前端核心层（10 文件）
+
+| 文件 | 变更 |
+|---|---|
+| `apps/web/src/components/Sender/PickerModel.tsx` | 比对/传参基于 `providerId+modelId` |
+| `apps/web/src/components/Sender/SelectModel.tsx` | value 改为按 provider 分组比对 |
+| `apps/web/src/components/Sender/Sender.tsx` | `settings.providerId` 传参 |
+| `apps/web/src/components/Sender/ModelParameterSettingsPanel.tsx` | 传 `{providerId, modelId}` 查询 model 元数据 |
+| `apps/web/src/components/Chat/Chat.tsx` | `modelConfig` 传 `providerId` |
+| `apps/web/src/components/GeneralSettings/SelectModel.tsx` | `assistantProviderId` 传参 |
+| `apps/web/src/contexts/chatSettings/context.ts` | DEFAULT_SETTINGS 新增 `providerId` |
+| `apps/web/src/hooks/useConversationSettings.ts` | 读写 `providerId` |
+| `apps/web/src/store/generalSettings/store.ts` | `assistantProviderId` |
+| `apps/web/src/store/generalSettings/actions.ts` | `assistantProviderId` |
+| `apps/web/src/store/conversation/actions.ts` | `providerId` 传参 |
+| `apps/web/src/api/chatApi.ts` | `providerId` + `modelId` 传参 |
+| `apps/web/src/api/providerApi.ts` | `getModel` 和 `getProviderByModelId` 更新 |
+
+### 测试文件（~16 文件）
+
+Mocks 和入参同步更新。
+
+## 注意事项
+
+1. **无后向兼容**：历史数据中的纯 `modelId`（不含 provider 上下文）将无法解析，用户需要重新选择模型
+2. **ModelInfo（消息记录）**：`ModelInfoSchema` 已有 `providerId` 字段，无需变更
+3. **`setModelEnabledStatus` / `deleteProviderModel`**：这些方法通过 modelId（provider 内唯一 key）操作，调用方已知 provider 上下文，无需变更
+4. **前端 RPC `getModelById` → `getModel`**：参数从 `{ id: string }` 变为 `{ providerId: string, modelId: string }`

--- a/packages/agent-core/src/AgentRuntime.ts
+++ b/packages/agent-core/src/AgentRuntime.ts
@@ -169,7 +169,7 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
 function isSessionStartOptions(
   options: RuntimeStartInput | AgentRuntimeStartTaskOptions,
 ): options is AgentRuntimeStartTaskOptions {
-  return 'modelId' in options
+  return 'model' in options
 }
 
 function requireSessionStore(config: AgentRuntimeConfig) {

--- a/packages/agent-core/src/__tests__/AgentRuntime.spec.ts
+++ b/packages/agent-core/src/__tests__/AgentRuntime.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { AgentRuntime } from '../AgentRuntime'
 import { runAgentLoop } from '../loop/agentLoop'
 import { taskStore } from '../taskStore'
@@ -47,6 +47,7 @@ function createSessionStore(overrides: Partial<ISessionStore> = {}): ISessionSto
     updatedAt: 1,
     settings: {
       modelId: 'model-1',
+      providerId: 'provider-1',
       systemPrompt: '',
       temperature: 0.7,
       maxTokens: 1024,
@@ -136,14 +137,34 @@ function createSessionConfig(overrides: Partial<AgentRuntimeConfig> = {}): Agent
     ...createConfig(),
     sessionStore: createSessionStore(),
     modelCatalog: {
-      getModelById: vi.fn(async () => ({
+      resolveModel: vi.fn(async () => ({
+        model: {
+          id: 'model-1',
+          model: 'test-model',
+          name: 'Test Model',
+          providerId: 'provider-1',
+          contextLength: 128_000,
+        },
+        provider: {
+          id: 'provider-1',
+          name: 'provider',
+          apiMode: 'openai' as const,
+          apiKey: 'test-key',
+          baseUrl: 'https://example.com',
+          isOfficial: false,
+          isEnabled: true,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      })),
+      getModel: vi.fn(async () => ({
         id: 'model-1',
         model: 'test-model',
         name: 'Test Model',
         providerId: 'provider-1',
         contextLength: 128_000,
       })),
-      getProviderById: vi.fn(async () => ({
+      getProvider: vi.fn(async () => ({
         id: 'provider-1',
         name: 'provider',
         apiMode: 'openai' as const,
@@ -188,7 +209,8 @@ function createValidSessionStartInput(overrides: Partial<AgentRuntimeStartTaskOp
     conversationId: 'conv-session',
     userMessageId: 'user-msg-1',
     prompt: 'inspect project',
-    modelId: 'model-1',
+    model: { id: 'model-1', model: 'gpt-4', name: 'GPT-4', providerId: 'provider-1', contextLength: 128_000 },
+    provider: { id: 'provider-1', name: 'Provider 1', apiMode: 'openai', baseUrl: 'https://api.example.com', isOfficial: true, isEnabled: true, hasApiKey: true, createdAt: 0, updatedAt: 0 },
     workspacePath: '/workspace',
     mode: 'hybrid',
     ...overrides,
@@ -222,6 +244,10 @@ function cleanupTasks(ids: string[]) {
 }
 
 describe('agentRuntime 行为', () => {
+  afterEach(() => {
+    taskStore.clear()
+  })
+
   describe('startTask 行为', () => {
     it('返回 taskId 并在 store 中创建任务', async () => {
       const config = createConfig()
@@ -333,7 +359,8 @@ describe('agentRuntime 行为', () => {
         prompt: 'inspect project',
         conversationId: 'conv-session',
         userMessageId: 'user-msg-1',
-        modelId: 'model-1',
+        model: { id: 'model-1', model: 'gpt-4', name: 'GPT-4', providerId: 'provider-1', contextLength: 128_000 },
+        provider: { id: 'provider-1', name: 'Provider 1', apiMode: 'openai', baseUrl: 'https://api.example.com', isOfficial: true, isEnabled: true, hasApiKey: true, createdAt: 0, updatedAt: 0 },
         workspacePath: '/workspace',
         mode: 'hybrid',
       })
@@ -368,13 +395,13 @@ describe('agentRuntime 行为', () => {
       cleanupTasks([result.taskId])
     })
 
-    it('高层 task 参数缺少 modelId 时拒绝启动', async () => {
+    it('高层 task 参数缺少 model 时拒绝启动', async () => {
       const store = createSessionStore()
       const runtime = new AgentRuntime(createSessionConfig({ sessionStore: store }))
 
       await expect(runtime.startTask(createValidSessionStartInput({
-        modelId: '',
-      }))).rejects.toThrow('missing modelId')
+        model: { id: '', model: '', name: '', providerId: '', contextLength: 0 },
+      }))).rejects.toThrow('missing model')
       expect(store.createUserMessage).not.toHaveBeenCalled()
     })
 
@@ -388,39 +415,27 @@ describe('agentRuntime 行为', () => {
       expect(store.createUserMessage).not.toHaveBeenCalled()
     })
 
-    it('找不到模型时不创建用户消息', async () => {
-      const store = createSessionStore()
+    it('找不到会话时不创建用户消息', async () => {
+      const store = createSessionStore({
+        getConversation: vi.fn(async () => null),
+      })
       const runtime = new AgentRuntime(createSessionConfig({
         sessionStore: store,
-        modelCatalog: {
-          getModelById: vi.fn(async () => null),
-          getProviderById: vi.fn(),
-        },
       }))
 
-      await expect(runtime.startTask(createValidSessionStartInput({
-        modelId: 'missing-model',
-      }))).rejects.toThrow('Model not found: missing-model')
+      await expect(runtime.startTask(createValidSessionStartInput())).rejects.toThrow('Conversation not found: conv-session')
       expect(store.createUserMessage).not.toHaveBeenCalled()
     })
 
-    it('找不到模型 provider 时不创建用户消息', async () => {
-      const store = createSessionStore()
+    it('找不到用户消息时不创建用户消息', async () => {
+      const store = createSessionStore({
+        getMessages: vi.fn(async () => []),
+      })
       const runtime = new AgentRuntime(createSessionConfig({
         sessionStore: store,
-        modelCatalog: {
-          getModelById: vi.fn(async () => ({
-            id: 'model-1',
-            model: 'test-model',
-            name: 'Test Model',
-            providerId: 'missing-provider',
-            contextLength: 128_000,
-          })),
-          getProviderById: vi.fn(async () => null),
-        },
       }))
 
-      await expect(runtime.startTask(createValidSessionStartInput())).rejects.toThrow('Provider not found for model: test-model')
+      await expect(runtime.startTask(createValidSessionStartInput())).rejects.toThrow('User message not found: user-msg-1')
       expect(store.createUserMessage).not.toHaveBeenCalled()
     })
 
@@ -519,6 +534,7 @@ describe('agentRuntime 行为', () => {
         updatedAt: 1,
         settings: {
           modelId: 'model-1',
+          providerId: 'provider-1',
           systemPrompt: '',
           temperature: 0.7,
           maxTokens: 1024,
@@ -540,24 +556,9 @@ describe('agentRuntime 行为', () => {
       const config = createSessionConfig({
         sessionStore: store,
         modelCatalog: {
-          getModelById: vi.fn(async () => ({
-            id: 'model-1',
-            model: 'test-model',
-            name: 'Test Model',
-            providerId: 'provider-1',
-            contextLength: 20_000,
-          })),
-          getProviderById: vi.fn(async () => ({
-            id: 'provider-1',
-            name: 'provider',
-            apiMode: 'openai' as const,
-            apiKey: 'test-key',
-            baseUrl: 'https://example.com',
-            isOfficial: false,
-            isEnabled: true,
-            createdAt: 1,
-            updatedAt: 1,
-          })),
+          resolveModel: vi.fn(),
+          getModel: vi.fn(),
+          getProvider: vi.fn(),
         },
         compactionStrategy: {
           summarize: vi.fn(async () => ({
@@ -577,6 +578,7 @@ describe('agentRuntime 行为', () => {
 
       const firstResult = await runtime.startTask(createValidSessionStartInput({
         prompt: 'inspect project first',
+        model: { id: 'model-1', model: 'gpt-4', name: 'GPT-4', providerId: 'provider-1', contextLength: 20_000 },
       }))
       cleanupTasks([firstResult.taskId])
 
@@ -591,6 +593,7 @@ describe('agentRuntime 行为', () => {
 
       const secondResult = await runtime.startTask(createValidSessionStartInput({
         prompt: 'inspect project again',
+        model: { id: 'model-1', model: 'gpt-4', name: 'GPT-4', providerId: 'provider-1', contextLength: 20_000 },
       }))
 
       const loopCalls = vi.mocked(runAgentLoop).mock.calls
@@ -631,9 +634,9 @@ describe('agentRuntime 行为', () => {
         eventType: 'compaction',
         compactedThroughMessageId: 'a1',
         modelInfo: {
-          provider: 'provider',
+          provider: 'Provider 1',
           providerId: 'provider-1',
-          model: 'test-model',
+          model: 'gpt-4',
         },
         usage: {
           inputTokens: 12000,
@@ -655,6 +658,7 @@ describe('agentRuntime 行为', () => {
         updatedAt: 1,
         settings: {
           modelId: 'model-1',
+          providerId: 'provider-1',
           systemPrompt: '',
           temperature: 0.7,
           maxTokens: 1024,
@@ -683,24 +687,9 @@ describe('agentRuntime 行为', () => {
       const config = createSessionConfig({
         sessionStore: store,
         modelCatalog: {
-          getModelById: vi.fn(async () => ({
-            id: 'model-1',
-            model: 'test-model',
-            name: 'Test Model',
-            providerId: 'provider-1',
-            contextLength: 10_000,
-          })),
-          getProviderById: vi.fn(async () => ({
-            id: 'provider-1',
-            name: 'provider',
-            apiMode: 'openai' as const,
-            apiKey: 'test-key',
-            baseUrl: 'https://example.com',
-            isOfficial: false,
-            isEnabled: true,
-            createdAt: 1,
-            updatedAt: 1,
-          })),
+          resolveModel: vi.fn(),
+          getModel: vi.fn(),
+          getProvider: vi.fn(),
         },
         compactionStrategy: {
           summarize: vi.fn(async () => ({ text: 'usage-based summary' })),
@@ -710,6 +699,7 @@ describe('agentRuntime 行为', () => {
       const runtime = new AgentRuntime(config)
       const result = await runtime.startTask(createValidSessionStartInput({
         prompt: 'x'.repeat(400),
+        model: { id: 'model-1', model: 'gpt-4', name: 'GPT-4', providerId: 'provider-1', contextLength: 10_000 },
       }))
 
       expect(store.createEventMessage).toHaveBeenCalledOnce()
@@ -729,6 +719,7 @@ describe('agentRuntime 行为', () => {
         updatedAt: 1,
         settings: {
           modelId: 'model-1',
+          providerId: 'provider-1',
           systemPrompt: '',
           temperature: 0.7,
           maxTokens: 1024,
@@ -749,24 +740,9 @@ describe('agentRuntime 行为', () => {
       const config = createSessionConfig({
         sessionStore: store,
         modelCatalog: {
-          getModelById: vi.fn(async () => ({
-            id: 'model-1',
-            model: 'test-model',
-            name: 'Test Model',
-            providerId: 'provider-1',
-            contextLength: 20_000,
-          })),
-          getProviderById: vi.fn(async () => ({
-            id: 'provider-1',
-            name: 'provider',
-            apiMode: 'openai' as const,
-            apiKey: 'test-key',
-            baseUrl: 'https://example.com',
-            isOfficial: false,
-            isEnabled: true,
-            createdAt: 1,
-            updatedAt: 1,
-          })),
+          resolveModel: vi.fn(),
+          getModel: vi.fn(),
+          getProvider: vi.fn(),
         },
         compactionStrategy: {
           summarize: vi.fn(async () => {
@@ -776,7 +752,9 @@ describe('agentRuntime 行为', () => {
       })
 
       const runtime = new AgentRuntime(config)
-      const result = await runtime.startTask(createValidSessionStartInput())
+      const result = await runtime.startTask(createValidSessionStartInput({
+        model: { id: 'model-1', model: 'gpt-4', name: 'GPT-4', providerId: 'provider-1', contextLength: 20_000 },
+      }))
 
       expect(store.createEventMessage).toHaveBeenCalledWith({
         convId: 'conv-session',
@@ -791,9 +769,9 @@ describe('agentRuntime 行为', () => {
         content: [{ type: 'text', text: 'summary provider failed' }],
         eventType: 'compaction',
         modelInfo: {
-          provider: 'provider',
+          provider: 'Provider 1',
           providerId: 'provider-1',
-          model: 'test-model',
+          model: 'gpt-4',
         },
         usage: undefined,
       })
@@ -809,6 +787,7 @@ describe('agentRuntime 行为', () => {
         updatedAt: 1,
         settings: {
           modelId: 'model-1',
+          providerId: 'provider-1',
           systemPrompt: '',
           temperature: 0.7,
           maxTokens: 1024,
@@ -847,24 +826,9 @@ describe('agentRuntime 行为', () => {
       const config = createSessionConfig({
         sessionStore: store,
         modelCatalog: {
-          getModelById: vi.fn(async () => ({
-            id: 'model-1',
-            model: 'test-model',
-            name: 'Test Model',
-            providerId: 'provider-1',
-            contextLength: 10_000,
-          })),
-          getProviderById: vi.fn(async () => ({
-            id: 'provider-1',
-            name: 'provider',
-            apiMode: 'openai' as const,
-            apiKey: 'test-key',
-            baseUrl: 'https://example.com',
-            isOfficial: false,
-            isEnabled: true,
-            createdAt: 1,
-            updatedAt: 1,
-          })),
+          resolveModel: vi.fn(),
+          getModel: vi.fn(),
+          getProvider: vi.fn(),
         },
         compactionStrategy: {
           summarize: vi.fn(async () => ({ text: 'unused summary' })),
@@ -872,7 +836,9 @@ describe('agentRuntime 行为', () => {
       })
 
       const runtime = new AgentRuntime(config)
-      const result = await runtime.startTask(createValidSessionStartInput())
+      const result = await runtime.startTask(createValidSessionStartInput({
+        model: { id: 'model-1', model: 'gpt-4', name: 'GPT-4', providerId: 'provider-1', contextLength: 10_000 },
+      }))
 
       expect(store.createEventMessage).not.toHaveBeenCalled()
       expect(store.updateEventMessage).not.toHaveBeenCalled()

--- a/packages/agent-core/src/session/SessionRuntime.ts
+++ b/packages/agent-core/src/session/SessionRuntime.ts
@@ -61,8 +61,11 @@ export class SessionRuntime {
     if (!prompt) {
       throw new Error('invalid start task options: missing prompt')
     }
-    if (!options.modelId.trim()) {
-      throw new Error('invalid start task options: missing modelId')
+    if (!options.model?.id.trim()) {
+      throw new Error('invalid start task options: missing model')
+    }
+    if (!options.provider?.id.trim()) {
+      throw new Error('invalid start task options: missing provider')
     }
     if (!options.workspacePath.trim()) {
       throw new Error('invalid start task options: missing workspacePath')
@@ -74,23 +77,10 @@ export class SessionRuntime {
       throw new Error('invalid start task options: missing userMessageId')
     }
 
-    const modelCatalog = requireConfig(this.config.modelCatalog, 'modelCatalog')
+    const { model, provider } = options
+    const loadFileData = createCachedLoadFileData(this.config.loadFileData)
 
     const conversation = await getExistingConversation(store, options.conversationId)
-
-    if (this.listActiveTasks(conversation.id).length > 0) {
-      throw new Error('AGENT_TASK_ALREADY_RUNNING')
-    }
-
-    const model = await modelCatalog.getModelById(options.modelId)
-    if (!model) {
-      throw new Error(`Model not found: ${options.modelId}`)
-    }
-    const provider = await modelCatalog.getProviderById(model.providerId)
-    if (!provider) {
-      throw new Error(`Provider not found for model: ${model.model}`)
-    }
-    const loadFileData = createCachedLoadFileData(this.config.loadFileData)
 
     const aiProvider = options.aiProvider ?? (this.config.aiProviderFactory
       ? await this.config.aiProviderFactory({ model, provider })

--- a/packages/agent-core/src/taskStore.ts
+++ b/packages/agent-core/src/taskStore.ts
@@ -73,6 +73,12 @@ export class TaskStore {
     this.activeByConversation.delete(task.snapshot.conversationId)
     this.tasks.delete(taskId)
   }
+
+  /** Clear all tasks. Used in tests for isolation. */
+  clear(): void {
+    this.tasks.clear()
+    this.activeByConversation.clear()
+  }
 }
 
 export const taskStore = new TaskStore()

--- a/packages/agent-runtime/src/__tests__/agentFullChainPermissions.spec.ts
+++ b/packages/agent-runtime/src/__tests__/agentFullChainPermissions.spec.ts
@@ -319,6 +319,7 @@ function createHarness(): AgentRuntimeHarness {
         mode,
         modelConfig: {
           modelId: TEST_MODEL_ID,
+          providerId: 'mock-provider',
           systemPrompt: '',
           temperature: 0,
           maxTokens: 4096,

--- a/packages/agent-runtime/src/__tests__/agentService.spec.ts
+++ b/packages/agent-runtime/src/__tests__/agentService.spec.ts
@@ -41,6 +41,7 @@ const conversation = {
   updatedAt: 1,
   settings: {
     modelId: 'model-1',
+    providerId: 'provider-1',
     systemPrompt: 'custom',
     temperature: 0.2,
     maxTokens: 2048,
@@ -65,8 +66,9 @@ const appDataContext = {
     getCurrentWorkspacePath: vi.fn(() => '/workspace'),
   },
   modelCatalog: {
-    getModelById: vi.fn(async () => model),
-    getProviderById: vi.fn(async () => provider),
+    resolveModel: vi.fn(async () => ({ model, provider })),
+    getModel: vi.fn(async () => model),
+    getProvider: vi.fn(async () => provider),
   },
   conversationRepository: {
     create: vi.fn(async () => conversation),
@@ -81,7 +83,7 @@ const appDataContext = {
     add: vi.fn(),
   },
   settingsRepository: {
-    getGeneralSettings: vi.fn(async () => ({ assistantModelId: '', proxySettings: { mode: 'none', customProxyUrl: '' } })),
+    getGeneralSettings: vi.fn(async () => ({ assistantModelId: '', assistantProviderId: '', proxySettings: { mode: 'none', customProxyUrl: '' } })),
   },
 } as unknown as AppDataContext
 
@@ -103,6 +105,7 @@ describe('createAgentRuntimeController 行为', () => {
       prompt: 'inspect project',
       modelConfig: {
         modelId: 'model-1',
+        providerId: 'provider-1',
         systemPrompt: 'custom',
         temperature: 0.2,
         maxTokens: 2048,
@@ -112,14 +115,14 @@ describe('createAgentRuntimeController 行为', () => {
       },
     })
 
-    expect(appDataContext.modelCatalog.getModelById).toHaveBeenCalledWith('model-1')
-    expect(appDataContext.modelCatalog.getProviderById).toHaveBeenCalledWith('provider-1')
+    expect(appDataContext.modelCatalog.resolveModel).toHaveBeenCalledWith({ providerId: 'provider-1', modelId: 'model-1' })
     expect(aiProviderFactory).toHaveBeenCalledWith({ model, provider })
     expect(appDataContext.conversationRepository.create).toHaveBeenCalledWith(expect.objectContaining({
       title: 'Untitled',
       workspacePath: '/workspace',
       settings: {
         modelId: 'model-1',
+        providerId: 'provider-1',
         systemPrompt: 'custom',
         temperature: 0.2,
         maxTokens: 2048,
@@ -136,7 +139,8 @@ describe('createAgentRuntimeController 行为', () => {
       prompt: 'inspect project',
       conversationId: 'c1',
       userMessageId: 'm1',
-      modelId: 'model-1',
+      model,
+      provider,
       workspacePath: '/workspace',
       aiProvider,
       mode: 'hybrid',
@@ -168,6 +172,7 @@ describe('createAgentRuntimeController 行为', () => {
       ],
       modelConfig: {
         modelId: 'model-1',
+        providerId: 'provider-1',
         systemPrompt: 'custom',
         temperature: 0.2,
         maxTokens: 2048,
@@ -202,6 +207,7 @@ describe('createAgentRuntimeController 行为', () => {
       prompt: 'inspect project',
       modelConfig: {
         modelId: 'model-1',
+        providerId: 'provider-1',
         systemPrompt: 'custom',
         temperature: 0.2,
         maxTokens: 2048,
@@ -232,6 +238,7 @@ describe('createAgentRuntimeController 行为', () => {
       prompt: 'inspect project',
       modelConfig: {
         modelId: 'model-1',
+        providerId: 'provider-1',
         systemPrompt: 'custom',
         temperature: 0.2,
         maxTokens: 2048,
@@ -242,13 +249,14 @@ describe('createAgentRuntimeController 行为', () => {
     })
     await new Promise(resolve => setTimeout(resolve, 0))
 
-    expect(titleGenerator.updateTitle).toHaveBeenCalledWith('c1', 'model-1')
+    expect(titleGenerator.updateTitle).toHaveBeenCalledWith('c1', { providerId: 'provider-1', modelId: 'model-1' })
     expect(emitConversationUpdated).toHaveBeenCalledWith(titledConversation)
   })
 
   it('初始化标题优先使用设置页面配置的助手模型', async () => {
     vi.mocked(appDataContext.settingsRepository.getGeneralSettings).mockResolvedValueOnce({
       assistantModelId: 'assistant-model-9',
+      assistantProviderId: 'provider-1',
       proxySettings: { mode: 'none', customProxyUrl: '' },
     })
     const titledConversation = { ...conversation, title: '项目检查' }
@@ -266,6 +274,7 @@ describe('createAgentRuntimeController 行为', () => {
       prompt: 'inspect project',
       modelConfig: {
         modelId: 'model-1',
+        providerId: 'provider-1',
         systemPrompt: 'custom',
         temperature: 0.2,
         maxTokens: 2048,
@@ -277,7 +286,7 @@ describe('createAgentRuntimeController 行为', () => {
     await new Promise(resolve => setTimeout(resolve, 0))
 
     expect(appDataContext.settingsRepository.getGeneralSettings).toHaveBeenCalled()
-    expect(titleGenerator.updateTitle).toHaveBeenCalledWith('c1', 'assistant-model-9')
+    expect(titleGenerator.updateTitle).toHaveBeenCalledWith('c1', { providerId: 'provider-1', modelId: 'assistant-model-9' })
   })
 
   it('读取助手模型设置失败时回退到当前对话模型生成标题', async () => {
@@ -297,6 +306,7 @@ describe('createAgentRuntimeController 行为', () => {
       prompt: 'inspect project',
       modelConfig: {
         modelId: 'model-1',
+        providerId: 'provider-1',
         systemPrompt: 'custom',
         temperature: 0.2,
         maxTokens: 2048,
@@ -307,7 +317,7 @@ describe('createAgentRuntimeController 行为', () => {
     })
     await new Promise(resolve => setTimeout(resolve, 0))
 
-    expect(titleGenerator.updateTitle).toHaveBeenCalledWith('c1', 'model-1')
+    expect(titleGenerator.updateTitle).toHaveBeenCalledWith('c1', { providerId: 'provider-1', modelId: 'model-1' })
     expect(emitConversationUpdated).toHaveBeenCalledWith(titledConversation)
   })
 

--- a/packages/agent-runtime/src/agentTurnService.ts
+++ b/packages/agent-runtime/src/agentTurnService.ts
@@ -39,15 +39,15 @@ export function createAgentTurnService(deps: AgentTurnServiceDeps): AgentTurnSer
         ?? appDataContext.workspaceService.getCurrentWorkspacePath()
         ?? process.cwd()
 
-      const model = await appDataContext.modelCatalog.getModelById(options.modelConfig.modelId)
-      if (!model) {
-        throw new Error(`Model not found: ${options.modelConfig.modelId}`)
+      const resolved = await appDataContext.modelCatalog.resolveModel({
+        providerId: options.modelConfig.providerId,
+        modelId: options.modelConfig.modelId,
+      })
+      if (!resolved) {
+        throw new Error(`Model not found: ${options.modelConfig.providerId}/${options.modelConfig.modelId}`)
       }
 
-      const provider = await appDataContext.modelCatalog.getProviderById(model.providerId)
-      if (!provider) {
-        throw new Error(`Provider not found for model: ${model.model}`)
-      }
+      const { model, provider } = resolved
 
       const aiProvider = aiProviderFactory
         ? await aiProviderFactory({ model, provider })
@@ -66,6 +66,7 @@ export function createAgentTurnService(deps: AgentTurnServiceDeps): AgentTurnSer
               workspacePath,
               settings: {
                 modelId: options.modelConfig.modelId,
+                providerId: options.modelConfig.providerId,
                 systemPrompt: options.modelConfig.systemPrompt ?? '',
                 temperature: options.modelConfig.temperature ?? 0.7,
                 maxTokens: options.modelConfig.maxTokens ?? 4096,
@@ -92,7 +93,8 @@ export function createAgentTurnService(deps: AgentTurnServiceDeps): AgentTurnSer
           prompt,
           conversationId: conversation.id,
           userMessageId: userMessage.id,
-          modelId: options.modelConfig.modelId,
+          model,
+          provider,
           workspacePath,
           aiProvider,
           mode: options.mode ?? 'hybrid',
@@ -109,6 +111,7 @@ export function createAgentTurnService(deps: AgentTurnServiceDeps): AgentTurnSer
         scheduleTitleInitialization({
           conversationId: result.conversationId,
           fallbackModelId: options.modelConfig.modelId,
+          fallbackProviderId: options.modelConfig.providerId,
           appDataContext,
           shouldInitializeTitle: conversationState.created || conversation.title === DEFAULT_TITLE,
           titleGenerator,
@@ -141,6 +144,7 @@ function resolveUserMessageContent(content: IMessageContent | undefined, prompt:
 function scheduleTitleInitialization(params: {
   conversationId: string
   fallbackModelId: string
+  fallbackProviderId: string
   appDataContext: AppDataContext
   shouldInitializeTitle: boolean
   titleGenerator?: ConversationTitleGenerator
@@ -150,6 +154,7 @@ function scheduleTitleInitialization(params: {
   const {
     conversationId,
     fallbackModelId,
+    fallbackProviderId,
     appDataContext,
     shouldInitializeTitle,
     titleGenerator,
@@ -161,8 +166,8 @@ function scheduleTitleInitialization(params: {
   }
 
   // 优先使用设置页面配置的助手模型生成标题，未配置或读取失败时回退到当前对话模型
-  void resolveTitleModelId(appDataContext, fallbackModelId, logger)
-    .then(modelId => titleGenerator.updateTitle(conversationId, modelId))
+  void resolveTitleModelId(appDataContext, fallbackModelId, fallbackProviderId, logger)
+    .then(modelRef => titleGenerator.updateTitle(conversationId, modelRef))
     .then((conversation) => {
       emitConversationUpdated?.(conversation)
     })
@@ -172,23 +177,26 @@ function scheduleTitleInitialization(params: {
 }
 
 /**
- * 解析生成标题使用的模型 ID：
- * 优先返回设置页面配置的助手模型（assistantModelId），
+ * 解析生成标题使用的模型引用：
+ * 优先返回设置页面配置的助手模型（assistantModelId + assistantProviderId），
  * 未配置或读取设置失败时回退到当前对话使用的模型。
  */
 async function resolveTitleModelId(
   appDataContext: AppDataContext,
   fallbackModelId: string,
+  fallbackProviderId: string,
   logger?: ILogger,
-): Promise<string> {
+): Promise<{ providerId: string, modelId: string }> {
   try {
-    const { assistantModelId } = await appDataContext.settingsRepository.getGeneralSettings()
-    return assistantModelId || fallbackModelId
+    const { assistantModelId, assistantProviderId } = await appDataContext.settingsRepository.getGeneralSettings()
+    if (assistantModelId && assistantProviderId) {
+      return { providerId: assistantProviderId, modelId: assistantModelId }
+    }
   }
   catch (error) {
     logger?.warn('读取助手模型设置失败，回退到对话模型生成标题', error)
-    return fallbackModelId
   }
+  return { providerId: fallbackProviderId, modelId: fallbackModelId }
 }
 
 async function rollbackStartedTurn(params: {

--- a/packages/agent-runtime/src/commands/__tests__/commandController.spec.ts
+++ b/packages/agent-runtime/src/commands/__tests__/commandController.spec.ts
@@ -31,8 +31,9 @@ function mockDeps(overrides: { activeTasks?: Array<{ status: string }> } = {}) {
       delete: vi.fn(),
     },
     modelCatalog: {
-      getModelById: vi.fn(),
-      getProviderById: vi.fn(),
+      getModel: vi.fn(),
+      getProvider: vi.fn(),
+      resolveModel: vi.fn(),
     },
   }
   return {
@@ -66,7 +67,7 @@ describe('commandController 任务守卫', () => {
       cc.runBuiltinCommand({
         id: 'compact',
         conversationId: 'conv-1',
-        modelConfig: { modelId: '', systemPrompt: '', temperature: 0, maxTokens: 0 },
+        modelConfig: { modelId: '', providerId: '', systemPrompt: '', temperature: 0, maxTokens: 0 },
         workspacePath: '',
       }),
     ).rejects.toThrow('Agent task is running')
@@ -80,7 +81,7 @@ describe('commandController 任务守卫', () => {
       cc.runBuiltinCommand({
         id: 'fork',
         conversationId: 'conv-1',
-        modelConfig: { modelId: '', systemPrompt: '', temperature: 0, maxTokens: 0 },
+        modelConfig: { modelId: '', providerId: '', systemPrompt: '', temperature: 0, maxTokens: 0 },
         workspacePath: '',
       }),
     ).rejects.toThrow('Agent task is running')
@@ -93,7 +94,7 @@ describe('commandController 任务守卫', () => {
 
     const result = await cc.runBuiltinCommand({
       id: 'new',
-      modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0.7, maxTokens: 4096 },
+      modelConfig: { modelId: 'm1', providerId: 'test-provider', systemPrompt: '', temperature: 0.7, maxTokens: 4096 },
       workspacePath: '/ws',
     })
     expect(result.status).toBe('success')
@@ -113,12 +114,12 @@ describe('commandController 任务守卫', () => {
     const cc = createCommandController(deps as any)
 
     deps.appDataContext.messageRepository.create.mockResolvedValue({ id: 'event-1' })
-    deps.appDataContext.modelCatalog.getModelById.mockResolvedValue(null)
+    deps.appDataContext.modelCatalog.resolveModel.mockResolvedValue(null)
 
     const result = await cc.runBuiltinCommand({
       id: 'compact',
       conversationId: 'conv-1',
-      modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0, maxTokens: 0 },
+      modelConfig: { modelId: 'm1', providerId: 'test-provider', systemPrompt: '', temperature: 0, maxTokens: 0 },
       workspacePath: '',
     })
 
@@ -135,7 +136,7 @@ describe('commandController 任务守卫', () => {
     await expect(
       cc.runBuiltinCommand({
         id: 'unknown-cmd',
-        modelConfig: { modelId: '', systemPrompt: '', temperature: 0, maxTokens: 0 },
+        modelConfig: { modelId: '', providerId: '', systemPrompt: '', temperature: 0, maxTokens: 0 },
         workspacePath: '',
       }),
     ).rejects.toThrow('Unknown built-in command')
@@ -161,7 +162,7 @@ describe('commandController 命令并发', () => {
     const firstPromise = cc.runBuiltinCommand({
       id: 'compact',
       conversationId: 'conv-1',
-      modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0, maxTokens: 0 },
+      modelConfig: { modelId: 'm1', providerId: 'test-provider', systemPrompt: '', temperature: 0, maxTokens: 0 },
       workspacePath: '',
     })
 
@@ -171,7 +172,7 @@ describe('commandController 命令并发', () => {
       cc.runBuiltinCommand({
         id: 'compact',
         conversationId: 'conv-1',
-        modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0, maxTokens: 0 },
+        modelConfig: { modelId: 'm1', providerId: 'test-provider', systemPrompt: '', temperature: 0, maxTokens: 0 },
         workspacePath: '',
       }),
     ).rejects.toThrow('already running')
@@ -195,13 +196,13 @@ describe('commandController 命令并发', () => {
       cc.runBuiltinCommand({
         id: 'compact',
         conversationId: 'conv-1',
-        modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0, maxTokens: 0 },
+        modelConfig: { modelId: 'm1', providerId: 'test-provider', systemPrompt: '', temperature: 0, maxTokens: 0 },
         workspacePath: '',
       }),
       cc.runBuiltinCommand({
         id: 'compact',
         conversationId: 'conv-2',
-        modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0, maxTokens: 0 },
+        modelConfig: { modelId: 'm1', providerId: 'test-provider', systemPrompt: '', temperature: 0, maxTokens: 0 },
         workspacePath: '',
       }),
     ])
@@ -222,17 +223,19 @@ describe('compact 命令错误和取消', () => {
       settings: { compaction: { enabled: true, thresholdPercent: 70, keepRecentTokens: 16 } },
     })
     deps.appDataContext.messageRepository.listByConversation.mockResolvedValue(compressibleMessages())
-    deps.appDataContext.modelCatalog.getModelById.mockResolvedValue({ id: 'm1', model: 'test-model', providerId: 'provider-1' })
-    deps.appDataContext.modelCatalog.getProviderById.mockResolvedValue({
-      id: 'provider-1',
-      name: 'provider',
-      apiMode: 'openai',
-      apiKey: 'test-key',
-      baseUrl: 'https://example.com',
-      isOfficial: false,
-      isEnabled: true,
-      createdAt: 1,
-      updatedAt: 1,
+    deps.appDataContext.modelCatalog.resolveModel.mockResolvedValue({
+      model: { id: 'm1', model: 'test-model', providerId: 'provider-1' },
+      provider: {
+        id: 'provider-1',
+        name: 'provider',
+        apiMode: 'openai',
+        apiKey: 'test-key',
+        baseUrl: 'https://example.com',
+        isOfficial: false,
+        isEnabled: true,
+        createdAt: 1,
+        updatedAt: 1,
+      },
     })
 
     const loadingEvent = {
@@ -257,7 +260,7 @@ describe('compact 命令错误和取消', () => {
     const result = await cc.runBuiltinCommand({
       id: 'compact',
       conversationId: 'conv-1',
-      modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0, maxTokens: 0 },
+      modelConfig: { modelId: 'm1', providerId: 'test-provider', systemPrompt: '', temperature: 0, maxTokens: 0 },
       workspacePath: '',
     })
 
@@ -275,13 +278,13 @@ describe('compact 命令错误和取消', () => {
     })
     deps.appDataContext.messageRepository.listByConversation.mockResolvedValue(compressibleMessages())
     deps.appDataContext.messageRepository.create.mockResolvedValue({ id: 'event-1' })
-    deps.appDataContext.modelCatalog.getModelById.mockResolvedValue(null)
+    deps.appDataContext.modelCatalog.resolveModel.mockResolvedValue(null)
 
     const cc = createCommandController(deps as any)
     const result = await cc.runBuiltinCommand({
       id: 'compact',
       conversationId: 'conv-1',
-      modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0, maxTokens: 0 },
+      modelConfig: { modelId: 'm1', providerId: 'test-provider', systemPrompt: '', temperature: 0, maxTokens: 0 },
       workspacePath: '',
     })
 
@@ -306,13 +309,13 @@ describe('compact 命令错误和取消', () => {
     const result = await cc.runBuiltinCommand({
       id: 'compact',
       conversationId: 'conv-1',
-      modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0, maxTokens: 0 },
+      modelConfig: { modelId: 'm1', providerId: 'test-provider', systemPrompt: '', temperature: 0, maxTokens: 0 },
       workspacePath: '',
     })
 
     expect(result.status).toBe('success')
     expect(result.summaryText).toContain('无需压缩')
-    expect(deps.appDataContext.modelCatalog.getModelById).not.toHaveBeenCalled()
+    expect(deps.appDataContext.modelCatalog.resolveModel).not.toHaveBeenCalled()
     expect(deps.appDataContext.messageRepository.create).not.toHaveBeenCalled()
   })
 
@@ -334,7 +337,7 @@ describe('compact 命令错误和取消', () => {
     const result = await cc.runBuiltinCommand({
       id: 'compact',
       conversationId: 'conv-1',
-      modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0, maxTokens: 0 },
+      modelConfig: { modelId: 'm1', providerId: 'test-provider', systemPrompt: '', temperature: 0, maxTokens: 0 },
       workspacePath: '',
     })
 
@@ -342,7 +345,7 @@ describe('compact 命令错误和取消', () => {
       status: 'success',
       summaryText: '当前上下文不足，无需压缩。',
     })
-    expect(deps.appDataContext.modelCatalog.getModelById).not.toHaveBeenCalled()
+    expect(deps.appDataContext.modelCatalog.resolveModel).not.toHaveBeenCalled()
     expect(deps.appDataContext.messageRepository.create).not.toHaveBeenCalled()
   })
 
@@ -372,24 +375,26 @@ describe('compact 命令错误和取消', () => {
       { id: 'u2', convId: 'conv-1', role: 'user', status: 'success', content: [{ type: 'text', text: 'new user request' }], createdAt: 6 },
     ])
     deps.appDataContext.messageRepository.create.mockResolvedValue({ id: 'event-2' })
-    deps.appDataContext.modelCatalog.getModelById.mockResolvedValue({ id: 'm1', model: 'test-model', providerId: 'provider-1' })
-    deps.appDataContext.modelCatalog.getProviderById.mockResolvedValue({
-      id: 'provider-1',
-      name: 'provider',
-      apiMode: 'openai',
-      apiKey: 'test-key',
-      baseUrl: 'https://example.com',
-      isOfficial: false,
-      isEnabled: true,
-      createdAt: 1,
-      updatedAt: 1,
+    deps.appDataContext.modelCatalog.resolveModel.mockResolvedValue({
+      model: { id: 'm1', model: 'test-model', providerId: 'provider-1' },
+      provider: {
+        id: 'provider-1',
+        name: 'provider',
+        apiMode: 'openai',
+        apiKey: 'test-key',
+        baseUrl: 'https://example.com',
+        isOfficial: false,
+        isEnabled: true,
+        createdAt: 1,
+        updatedAt: 1,
+      },
     })
 
     const cc = createCommandController(deps as any)
     const result = await cc.runBuiltinCommand({
       id: 'compact',
       conversationId: 'conv-1',
-      modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0, maxTokens: 0 },
+      modelConfig: { modelId: 'm1', providerId: 'test-provider', systemPrompt: '', temperature: 0, maxTokens: 0 },
       workspacePath: '',
     })
 
@@ -425,7 +430,7 @@ describe('compact 命令错误和取消', () => {
     deps.appDataContext.messageRepository.create.mockResolvedValue({ id: 'event-1' })
 
     let rejectModelLookup: (reason?: unknown) => void
-    deps.appDataContext.modelCatalog.getModelById.mockReturnValue(new Promise((_, reject) => {
+    deps.appDataContext.modelCatalog.resolveModel.mockReturnValue(new Promise((_, reject) => {
       rejectModelLookup = reject
     }))
 
@@ -433,7 +438,7 @@ describe('compact 命令错误和取消', () => {
     const runPromise = cc.runBuiltinCommand({
       id: 'compact',
       conversationId: 'conv-1',
-      modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0, maxTokens: 0 },
+      modelConfig: { modelId: 'm1', providerId: 'test-provider', systemPrompt: '', temperature: 0, maxTokens: 0 },
       workspacePath: '',
     })
 
@@ -491,24 +496,26 @@ describe('compact 命令错误和取消', () => {
       eventType: 'compaction',
       createdAt: 6,
     })
-    deps.appDataContext.modelCatalog.getModelById.mockResolvedValue({ id: 'm1', model: 'test-model', providerId: 'provider-1' })
-    deps.appDataContext.modelCatalog.getProviderById.mockResolvedValue({
-      id: 'provider-1',
-      name: 'provider',
-      apiMode: 'openai',
-      apiKey: 'test-key',
-      baseUrl: 'https://example.com',
-      isOfficial: false,
-      isEnabled: true,
-      createdAt: 1,
-      updatedAt: 1,
+    deps.appDataContext.modelCatalog.resolveModel.mockResolvedValue({
+      model: { id: 'm1', model: 'test-model', providerId: 'provider-1' },
+      provider: {
+        id: 'provider-1',
+        name: 'provider',
+        apiMode: 'openai',
+        apiKey: 'test-key',
+        baseUrl: 'https://example.com',
+        isOfficial: false,
+        isEnabled: true,
+        createdAt: 1,
+        updatedAt: 1,
+      },
     })
 
     const cc = createCommandController(deps as any)
     const runPromise = cc.runBuiltinCommand({
       id: 'compact',
       conversationId: 'conv-1',
-      modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0, maxTokens: 0 },
+      modelConfig: { modelId: 'm1', providerId: 'test-provider', systemPrompt: '', temperature: 0, maxTokens: 0 },
       workspacePath: '',
     })
 
@@ -563,7 +570,7 @@ describe('fork 命令', () => {
     const result = await cc.runBuiltinCommand({
       id: 'fork',
       conversationId: 'conv-1',
-      modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0, maxTokens: 0 },
+      modelConfig: { modelId: 'm1', providerId: 'test-provider', systemPrompt: '', temperature: 0, maxTokens: 0 },
       workspacePath: '/ws',
     })
 
@@ -629,7 +636,7 @@ describe('fork 命令', () => {
     const result = await cc.runBuiltinCommand({
       id: 'fork',
       conversationId: 'conv-1',
-      modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0, maxTokens: 0 },
+      modelConfig: { modelId: 'm1', providerId: 'test-provider', systemPrompt: '', temperature: 0, maxTokens: 0 },
       workspacePath: '/ws',
     })
 
@@ -670,7 +677,7 @@ describe('fork 命令', () => {
     const firstPromise = cc.runBuiltinCommand({
       id: 'fork',
       conversationId: 'conv-1',
-      modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0, maxTokens: 0 },
+      modelConfig: { modelId: 'm1', providerId: 'test-provider', systemPrompt: '', temperature: 0, maxTokens: 0 },
       workspacePath: '/ws',
     })
 
@@ -680,7 +687,7 @@ describe('fork 命令', () => {
       cc.runBuiltinCommand({
         id: 'fork',
         conversationId: 'conv-1',
-        modelConfig: { modelId: 'm1', systemPrompt: '', temperature: 0, maxTokens: 0 },
+        modelConfig: { modelId: 'm1', providerId: 'test-provider', systemPrompt: '', temperature: 0, maxTokens: 0 },
         workspacePath: '/ws',
       }),
     ).rejects.toThrow('already running')

--- a/packages/agent-runtime/src/commands/compactCommand.ts
+++ b/packages/agent-runtime/src/commands/compactCommand.ts
@@ -52,19 +52,20 @@ export async function runCompact(params: {
     return { status: 'success', summaryText: '当前上下文不足，无需压缩。' }
   }
 
-  let modelInfo: Awaited<ReturnType<AppDataContext['modelCatalog']['getModelById']>>
-  let provider: Awaited<ReturnType<AppDataContext['modelCatalog']['getProviderById']>>
+  let resolved: Awaited<ReturnType<AppDataContext['modelCatalog']['resolveModel']>>
+  let modelInfo: NonNullable<typeof resolved>['model']
+  let provider: NonNullable<typeof resolved>['provider']
   try {
-    modelInfo = await appDataContext.modelCatalog.getModelById(modelConfig.modelId)
-    if (!modelInfo) {
+    resolved = await appDataContext.modelCatalog.resolveModel({
+      providerId: conversation.settings.providerId,
+      modelId: modelConfig.modelId,
+    })
+    if (!resolved) {
       throw new Error(`未找到压缩模型：${modelConfig.modelId}`)
     }
-    log(`model found: name=${modelInfo.model}, providerId=${modelInfo.providerId}`)
-
-    provider = await appDataContext.modelCatalog.getProviderById(modelInfo.providerId)
-    if (!provider) {
-      throw new Error(`未找到模型对应的 Provider：${modelInfo.providerId}`)
-    }
+    log(`model found: name=${resolved.model.model}, providerId=${resolved.model.providerId}`)
+    modelInfo = resolved.model
+    provider = resolved.provider
   }
   catch (err) {
     if (abortSignal?.aborted) {

--- a/packages/agent-runtime/src/commands/conversationCommands.ts
+++ b/packages/agent-runtime/src/commands/conversationCommands.ts
@@ -6,7 +6,7 @@ const DEFAULT_TITLE = 'Untitled'
 export async function runNew(params: {
   appDataContext: AppDataContext
   workspacePath: string
-  modelConfig: { modelId: string, systemPrompt: string, temperature: number, maxTokens: number }
+  modelConfig: { modelId: string, providerId: string, systemPrompt: string, temperature: number, maxTokens: number }
 }): Promise<RunBuiltinCommandResult> {
   const { appDataContext, workspacePath, modelConfig } = params
 
@@ -15,6 +15,7 @@ export async function runNew(params: {
     title: DEFAULT_TITLE,
     settings: {
       modelId: modelConfig.modelId,
+      providerId: modelConfig.providerId,
       systemPrompt: modelConfig.systemPrompt,
       temperature: modelConfig.temperature,
       maxTokens: modelConfig.maxTokens,

--- a/packages/agent-runtime/src/conversationTitleGenerator.ts
+++ b/packages/agent-runtime/src/conversationTitleGenerator.ts
@@ -21,7 +21,7 @@ The name is:
 `
 
 export interface ConversationTitleGenerator {
-  updateTitle: (conversationsId: string, modelId: string) => Promise<IConversations>
+  updateTitle: (conversationsId: string, modelRef: { providerId: string, modelId: string }) => Promise<IConversations>
 }
 
 export interface ConversationTitleGeneratorDependencies {
@@ -47,15 +47,16 @@ export function createConversationTitleGenerator(
   }
 
   return {
-    async updateTitle(conversationsId, modelId) {
-      const modelInfo = deps.providerSettingsRepository.getModelById(modelId)
+    async updateTitle(conversationsId, modelRef) {
+      const { providerId, modelId } = modelRef
+      const modelInfo = deps.providerSettingsRepository.getModel(providerId, modelId)
       if (!modelInfo) {
-        throw new Error(`Model not found for id: ${modelId}`)
+        throw new Error(`Model not found: ${providerId}/${modelId}`)
       }
 
-      const providerConfig = deps.providerSettingsRepository.getProviderByModelId(modelId)
+      const providerConfig = deps.providerSettingsRepository.getProviderById(providerId)
       if (!providerConfig) {
-        throw new Error(`ProviderConfig not found for modelId: ${modelId}`)
+        throw new Error(`ProviderConfig not found: ${providerId}`)
       }
 
       const messages = await deps.messageRepository.listByConversation(conversationsId)

--- a/packages/app-data/src/settings/__tests__/appSettingsStore.spec.ts
+++ b/packages/app-data/src/settings/__tests__/appSettingsStore.spec.ts
@@ -22,6 +22,7 @@ describe('appSettingsStore', () => {
       const filePath = path.join(dir, 'settings.json')
       const existingSettings: AppSettingsState = {
         assistantModelId: 'test-model',
+        assistantProviderId: '',
         proxySettings: { mode: 'none' },
         toolApprovalWhitelist: [],
         providers: [
@@ -63,6 +64,7 @@ describe('appSettingsStore', () => {
       const filePath = path.join(dir, 'settings.json')
       const existingSettings: AppSettingsState = {
         assistantModelId: 'test-model',
+        assistantProviderId: '',
         proxySettings: { mode: 'none' },
         toolApprovalWhitelist: [],
         providers: [
@@ -119,6 +121,7 @@ describe('appSettingsStore', () => {
       const filePath = path.join(dir, 'settings.json')
       const existingSettings: AppSettingsState = {
         assistantModelId: 'test-model',
+        assistantProviderId: '',
         proxySettings: { mode: 'none' },
         toolApprovalWhitelist: [],
         providers: [],

--- a/packages/app-data/src/settings/__tests__/generalSettingsRepository.spec.ts
+++ b/packages/app-data/src/settings/__tests__/generalSettingsRepository.spec.ts
@@ -22,12 +22,14 @@ describe('general settings repository', () => {
       filePath,
       initialSettings: {
         assistantModelId: 'model-1',
+        assistantProviderId: '',
         proxySettings: { mode: 'none', customProxyUrl: '' },
       },
     })
 
     await expect(repository.getGeneralSettings()).resolves.toEqual({
       assistantModelId: 'model-1',
+      assistantProviderId: '',
       proxySettings: { mode: 'none', customProxyUrl: '' },
     })
   })
@@ -37,6 +39,7 @@ describe('general settings repository', () => {
       filePath,
       initialSettings: {
         assistantModelId: 'model-1',
+        assistantProviderId: '',
         proxySettings: { mode: 'custom', customProxyUrl: 'http://localhost:7890' },
       },
     })
@@ -47,6 +50,7 @@ describe('general settings repository', () => {
 
     expect(settings).toEqual({
       assistantModelId: 'model-1',
+      assistantProviderId: '',
       proxySettings: { mode: 'system', customProxyUrl: 'http://localhost:7890' },
     })
   })

--- a/packages/app-data/src/settings/__tests__/providerSettingsRepository.spec.ts
+++ b/packages/app-data/src/settings/__tests__/providerSettingsRepository.spec.ts
@@ -12,6 +12,7 @@ describe('provider settings repository', () => {
 
   const initialSettings: AppSettingsState = {
     assistantModelId: '',
+    assistantProviderId: '',
     proxySettings: { mode: 'none', customProxyUrl: '' },
     toolApprovalWhitelist: [],
     providers: [

--- a/packages/app-data/src/settings/__tests__/providerSettingsRepository.spec.ts
+++ b/packages/app-data/src/settings/__tests__/providerSettingsRepository.spec.ts
@@ -102,6 +102,117 @@ describe('provider settings repository', () => {
     ]))
   })
 
+  it('旧 settings.json 仅缺 assistantProviderId 时不被重置为默认值', () => {
+    const filePath = path.join(dir, 'legacy-settings.json')
+    // 升级前的文件：字段齐全，仅缺少本 PR 新增的 assistantProviderId
+    const legacy = {
+      assistantModelId: 'gpt-4',
+      proxySettings: { mode: 'none' },
+      toolApprovalWhitelist: [],
+      providers: [
+        {
+          id: 'custom-provider',
+          name: 'Custom',
+          baseUrl: 'https://example.com',
+          apiKey: 'key',
+          apiMode: 'openai',
+          isOfficial: false,
+          isEnabled: true,
+          models: {
+            'gpt-4': { isEnabled: true, temperature: 0.7, name: 'GPT-4', maxTokens: 8192, contextLength: 32768, cost: { input: 0, output: 0 } },
+          },
+        },
+      ],
+    }
+    writeFileSync(filePath, JSON.stringify(legacy), 'utf8')
+
+    const store = new AppSettingsStore({ filePath, resetInvalidFile: true })
+    const settings = store.read()
+
+    // 用户自定义 provider 必须保留，不能被 DEFAULT_APP_SETTINGS 覆盖
+    expect(settings.providers).toContainEqual(
+      expect.objectContaining({ id: 'custom-provider', apiKey: 'key' }),
+    )
+    expect(settings.assistantModelId).toBe('gpt-4')
+    // 缺失字段以 schema 默认值补齐
+    expect(settings.assistantProviderId).toBe('')
+  })
+
+  describe('legacy 空 providerId 无歧义回退', () => {
+    const baseSettings: AppSettingsState = {
+      assistantModelId: '',
+      assistantProviderId: '',
+      proxySettings: { mode: 'none' },
+      toolApprovalWhitelist: [],
+      providers: [
+        {
+          id: 'provider-a',
+          name: 'A',
+          baseUrl: 'https://a.example.com',
+          apiKey: 'key-a',
+          apiMode: 'openai',
+          isOfficial: false,
+          isEnabled: true,
+          models: {
+            'shared-model': { isEnabled: true, temperature: 0.7, name: 'Shared', maxTokens: 4096, contextLength: 8192, cost: { input: 0, output: 0 } },
+            'a-only-model': { isEnabled: true, temperature: 0.7, name: 'A Only', maxTokens: 4096, contextLength: 8192, cost: { input: 0, output: 0 } },
+          },
+        },
+        {
+          id: 'provider-b',
+          name: 'B',
+          baseUrl: 'https://b.example.com',
+          apiKey: 'key-b',
+          apiMode: 'openai',
+          isOfficial: false,
+          isEnabled: true,
+          models: {
+            'shared-model': { isEnabled: true, temperature: 0.7, name: 'Shared', maxTokens: 4096, contextLength: 8192, cost: { input: 0, output: 0 } },
+          },
+        },
+      ],
+    }
+
+    function makeRepository(): ProviderSettingsRepository {
+      const tmpDir = mkdtempSync(path.join(tmpdir(), 'ant-chat-legacy-provider-'))
+      return new ProviderSettingsRepository(new AppSettingsStore({
+        filePath: path.join(tmpDir, 'settings.json'),
+        initialSettings: baseSettings,
+      }))
+    }
+
+    it('providerId 为空且 modelId 仅 1 个已启用 provider 拥有时命中回退', () => {
+      const repo = makeRepository()
+      const resolved = repo.resolveModel('', 'a-only-model')
+      expect(resolved).not.toBeNull()
+      expect(resolved?.provider.id).toBe('provider-a')
+      expect(resolved?.model.id).toBe('a-only-model')
+
+      const model = repo.getModel('', 'a-only-model')
+      expect(model).not.toBeNull()
+      expect(model?.providerId).toBe('provider-a')
+    })
+
+    it('providerId 为空且 modelId 在多个 provider 间有歧义时返回 null', () => {
+      const repo = makeRepository()
+      expect(repo.resolveModel('', 'shared-model')).toBeNull()
+      expect(repo.getModel('', 'shared-model')).toBeNull()
+    })
+
+    it('providerId 为空且 modelId 不存在时返回 null', () => {
+      const repo = makeRepository()
+      expect(repo.resolveModel('', 'no-such-model')).toBeNull()
+      expect(repo.getModel('', 'no-such-model')).toBeNull()
+    })
+
+    it('显式 providerId 仍走精确查找，不触发跨 provider 回退', () => {
+      const repo = makeRepository()
+      // provider-b 没有 a-only-model，即便 provider-a 有，也不应回退
+      expect(repo.resolveModel('provider-b', 'a-only-model')).toBeNull()
+      expect(repo.getModel('provider-b', 'a-only-model')).toBeNull()
+    })
+  })
+
   it('迁移明文 provider API Key 后删除配置里的 apiKey', async () => {
     const saved = new Map<string, string>()
     const secretStore: SecretStore = {

--- a/packages/app-data/src/settings/defaultAppSettings.ts
+++ b/packages/app-data/src/settings/defaultAppSettings.ts
@@ -2,6 +2,7 @@ import type { AppSettingsState } from '@ant-chat/shared'
 
 export const DEFAULT_APP_SETTINGS: AppSettingsState = {
   assistantModelId: '',
+  assistantProviderId: '',
   proxySettings: {
     mode: 'none',
     customProxyUrl: '',

--- a/packages/app-data/src/settings/generalSettingsRepository.ts
+++ b/packages/app-data/src/settings/generalSettingsRepository.ts
@@ -5,6 +5,7 @@ import { AppSettingsStore } from './appSettingsStore'
 
 export const DEFAULT_GENERAL_SETTINGS: GeneralSettingsState = {
   assistantModelId: '',
+  assistantProviderId: '',
   proxySettings: {
     mode: 'none',
     customProxyUrl: '',

--- a/packages/app-data/src/settings/modelCatalog.ts
+++ b/packages/app-data/src/settings/modelCatalog.ts
@@ -3,8 +3,24 @@ import type { ProviderSettingsRepository } from './providerSettingsRepository'
 
 export function createModelCatalog(repository: ProviderSettingsRepository): IModelCatalog {
   return {
-    getModelById: async (id) => {
-      const model = repository.getModelById(id)
+    resolveModel: async (ref) => {
+      const resolved = repository.resolveModel(ref.providerId, ref.modelId)
+      if (!resolved) {
+        return null
+      }
+      return {
+        model: {
+          id: resolved.model.id,
+          model: resolved.model.model,
+          name: resolved.model.name,
+          providerId: resolved.model.providerId,
+          contextLength: resolved.model.contextLength,
+        },
+        provider: resolved.provider,
+      }
+    },
+    getModel: async (providerId, modelId) => {
+      const model = repository.getModel(providerId, modelId)
       if (!model) {
         return null
       }
@@ -16,7 +32,7 @@ export function createModelCatalog(repository: ProviderSettingsRepository): IMod
         contextLength: model.contextLength,
       }
     },
-    getProviderById: async (id) => {
+    getProvider: async (id) => {
       const provider = repository.getProviderById(id)
       if (!provider) {
         return null

--- a/packages/app-data/src/settings/providerSettingsRepository.ts
+++ b/packages/app-data/src/settings/providerSettingsRepository.ts
@@ -108,9 +108,25 @@ export class ProviderSettingsRepository {
     return this.store.read().providers.find(provider => provider.id === id) ?? null
   }
 
-  getProviderByModelId(id: string): ProviderConfigSchema | null {
-    const provider = this.store.read().providers.find(provider => Boolean(provider.models[id]))
-    return provider ? toProviderConfig(provider) : null
+  getModel(providerId: string, modelId: string): ProviderConfigModelSchema | null {
+    const provider = this.store.read().providers.find(p => p.id === providerId)
+    if (!provider)
+      return null
+    const model = provider.models[modelId]
+    return model ? toProviderConfigModel(providerId, modelId, model) : null
+  }
+
+  resolveModel(providerId: string, modelId: string): { model: ProviderConfigModelSchema, provider: ProviderConfigSchema } | null {
+    const provider = this.store.read().providers.find(p => p.id === providerId)
+    if (!provider)
+      return null
+    const model = provider.models[modelId]
+    if (!model)
+      return null
+    return {
+      model: toProviderConfigModel(providerId, modelId, model),
+      provider: toProviderConfig(provider),
+    }
   }
 
   getAllAvailableModels(): AllAvailableModelsSchema[] {
@@ -221,16 +237,6 @@ export class ProviderSettingsRepository {
       })
       return { ...settings, providers }
     })
-  }
-
-  getModelById(id: string): ProviderConfigModelSchema | null {
-    for (const provider of this.store.read().providers) {
-      const model = provider.models[id]
-      if (model) {
-        return toProviderConfigModel(provider.id, id, model)
-      }
-    }
-    return null
   }
 
   async migratePlaintextApiKeys(secretStore: SecretStore): Promise<boolean> {

--- a/packages/app-data/src/settings/providerSettingsRepository.ts
+++ b/packages/app-data/src/settings/providerSettingsRepository.ts
@@ -109,6 +109,10 @@ export class ProviderSettingsRepository {
   }
 
   getModel(providerId: string, modelId: string): ProviderConfigModelSchema | null {
+    if (!providerId && modelId) {
+      const legacy = this.findModelByModelId(modelId)
+      return legacy ? toProviderConfigModel(legacy.provider.id, modelId, legacy.model) : null
+    }
     const provider = this.store.read().providers.find(p => p.id === providerId)
     if (!provider)
       return null
@@ -117,6 +121,15 @@ export class ProviderSettingsRepository {
   }
 
   resolveModel(providerId: string, modelId: string): { model: ProviderConfigModelSchema, provider: ProviderConfigSchema } | null {
+    if (!providerId && modelId) {
+      const legacy = this.findModelByModelId(modelId)
+      if (!legacy)
+        return null
+      return {
+        model: toProviderConfigModel(legacy.provider.id, modelId, legacy.model),
+        provider: toProviderConfig(legacy.provider),
+      }
+    }
     const provider = this.store.read().providers.find(p => p.id === providerId)
     if (!provider)
       return null
@@ -127,6 +140,18 @@ export class ProviderSettingsRepository {
       model: toProviderConfigModel(providerId, modelId, model),
       provider: toProviderConfig(provider),
     }
+  }
+
+  /**
+   * 旧会话数据只有 modelId、没有 providerId（升级前未拆分）。
+   * 在 providerId 为空时，按 modelId 跨已启用 provider 无歧义回退：
+   * 恰好 1 个已启用 provider 拥有该 modelId 才命中，0 个或多个则返回 null（保持报错，避免猜错）。
+   */
+  private findModelByModelId(modelId: string): { provider: ProviderSettingsSchema, model: ProviderModelSettingsSchema } | null {
+    const matches = this.store.read().providers.filter(p => p.isEnabled && p.models[modelId])
+    if (matches.length !== 1)
+      return null
+    return { provider: matches[0], model: matches[0].models[modelId] }
   }
 
   getAllAvailableModels(): AllAvailableModelsSchema[] {

--- a/packages/app-data/src/sqlite/repositories/__tests__/sqliteRepositories.spec.ts
+++ b/packages/app-data/src/sqlite/repositories/__tests__/sqliteRepositories.spec.ts
@@ -89,6 +89,7 @@ describe('sqlite repositories', () => {
       updatedAt: 1,
       settings: {
         modelId: 'model-1',
+        providerId: '',
         systemPrompt: '',
         temperature: 0.7,
         maxTokens: 1024,
@@ -118,6 +119,7 @@ describe('sqlite repositories', () => {
       updatedAt: 1,
       settings: {
         modelId: 'model-1',
+        providerId: '',
         systemPrompt: '',
         temperature: 0.7,
         maxTokens: 1024,
@@ -145,6 +147,7 @@ describe('sqlite repositories', () => {
       updatedAt: 1,
       settings: {
         modelId: 'model-1',
+        providerId: '',
         systemPrompt: '',
         temperature: 0.7,
         maxTokens: 1024,
@@ -197,6 +200,7 @@ describe('sqlite repositories', () => {
       updatedAt: 1,
       settings: {
         modelId: 'model-1',
+        providerId: '',
         systemPrompt: '',
         temperature: 0.7,
         maxTokens: 1024,
@@ -209,6 +213,7 @@ describe('sqlite repositories', () => {
       updatedAt: 2,
       settings: {
         modelId: 'model-1',
+        providerId: '',
         systemPrompt: '',
         temperature: 0.7,
         maxTokens: 1024,
@@ -278,6 +283,7 @@ describe('sqlite repositories', () => {
       updatedAt: 1,
       settings: {
         modelId: 'model-1',
+        providerId: '',
         systemPrompt: '',
         temperature: 0.7,
         maxTokens: 1024,
@@ -329,6 +335,7 @@ describe('sqlite repositories', () => {
       updatedAt: 1,
       settings: {
         modelId: 'model-1',
+        providerId: '',
         systemPrompt: '',
         temperature: 0.7,
         maxTokens: 1024,
@@ -382,9 +389,9 @@ describe('sqlite repositories', () => {
   it('deletes all conversations in target workspace via deleteByWorkspace', async () => {
     const conversationRepository = new SqliteConversationRepository(sqlite)
 
-    await conversationRepository.create({ title: 'Target 1', workspacePath: '/ws-a', createdAt: 1, updatedAt: 1, settings: { modelId: 'm', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
-    await conversationRepository.create({ title: 'Target 2', workspacePath: '/ws-a', createdAt: 2, updatedAt: 2, settings: { modelId: 'm', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
-    await conversationRepository.create({ title: 'Other', workspacePath: '/ws-b', createdAt: 3, updatedAt: 3, settings: { modelId: 'm', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
+    await conversationRepository.create({ title: 'Target 1', workspacePath: '/ws-a', createdAt: 1, updatedAt: 1, settings: { modelId: 'm', providerId: '', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
+    await conversationRepository.create({ title: 'Target 2', workspacePath: '/ws-a', createdAt: 2, updatedAt: 2, settings: { modelId: 'm', providerId: '', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
+    await conversationRepository.create({ title: 'Other', workspacePath: '/ws-b', createdAt: 3, updatedAt: 3, settings: { modelId: 'm', providerId: '', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
 
     const deletedIds = await conversationRepository.deleteByWorkspace('/ws-a')
 
@@ -397,9 +404,9 @@ describe('sqlite repositories', () => {
   it('includes null workspace conversations when includeNullWorkspace is true', async () => {
     const conversationRepository = new SqliteConversationRepository(sqlite)
 
-    await conversationRepository.create({ title: 'Named', workspacePath: '/ws-a', createdAt: 1, updatedAt: 1, settings: { modelId: 'm', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
-    await conversationRepository.create({ title: 'Default', workspacePath: undefined, createdAt: 2, updatedAt: 2, settings: { modelId: 'm', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
-    await conversationRepository.create({ title: 'Other', workspacePath: '/ws-b', createdAt: 3, updatedAt: 3, settings: { modelId: 'm', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
+    await conversationRepository.create({ title: 'Named', workspacePath: '/ws-a', createdAt: 1, updatedAt: 1, settings: { modelId: 'm', providerId: '', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
+    await conversationRepository.create({ title: 'Default', workspacePath: undefined, createdAt: 2, updatedAt: 2, settings: { modelId: 'm', providerId: '', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
+    await conversationRepository.create({ title: 'Other', workspacePath: '/ws-b', createdAt: 3, updatedAt: 3, settings: { modelId: 'm', providerId: '', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
 
     const deletedIds = await conversationRepository.deleteByWorkspace('/ws-a', true)
 
@@ -412,8 +419,8 @@ describe('sqlite repositories', () => {
   it('preserves conversations in other workspaces', async () => {
     const conversationRepository = new SqliteConversationRepository(sqlite)
 
-    await conversationRepository.create({ title: 'A', workspacePath: '/ws-a', createdAt: 1, updatedAt: 1, settings: { modelId: 'm', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
-    await conversationRepository.create({ title: 'B', workspacePath: '/ws-b', createdAt: 2, updatedAt: 2, settings: { modelId: 'm', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
+    await conversationRepository.create({ title: 'A', workspacePath: '/ws-a', createdAt: 1, updatedAt: 1, settings: { modelId: 'm', providerId: '', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
+    await conversationRepository.create({ title: 'B', workspacePath: '/ws-b', createdAt: 2, updatedAt: 2, settings: { modelId: 'm', providerId: '', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
 
     await conversationRepository.deleteByWorkspace('/ws-a')
 
@@ -457,7 +464,7 @@ describe('sqlite repositories', () => {
       workspacePath: '/workspace',
       createdAt: 1,
       updatedAt: 1,
-      settings: { modelId: 'model-1', systemPrompt: '', temperature: 0.7, maxTokens: 1024 },
+      settings: { modelId: 'model-1', providerId: '', systemPrompt: '', temperature: 0.7, maxTokens: 1024 },
     })
 
     await messageRepository.create({
@@ -512,7 +519,7 @@ describe('sqlite repositories', () => {
       workspacePath: '/workspace',
       createdAt: 1,
       updatedAt: 1,
-      settings: { modelId: 'model-1', systemPrompt: '', temperature: 0.7, maxTokens: 1024 },
+      settings: { modelId: 'model-1', providerId: '', systemPrompt: '', temperature: 0.7, maxTokens: 1024 },
     })
 
     const message = await messageRepository.create({
@@ -551,7 +558,7 @@ describe('sqlite repositories', () => {
       workspacePath: '/workspace',
       createdAt: 1,
       updatedAt: 1,
-      settings: { modelId: 'model-1', systemPrompt: '', temperature: 0.7, maxTokens: 1024 },
+      settings: { modelId: 'model-1', providerId: '', systemPrompt: '', temperature: 0.7, maxTokens: 1024 },
     })
 
     const message = await messageRepository.create({

--- a/packages/app-data/src/sqlite/rows.ts
+++ b/packages/app-data/src/sqlite/rows.ts
@@ -88,6 +88,10 @@ function parseConversationSettings(value: string): ConversationsSettingsSchema {
     }
     delete (settings.compaction as Record<string, unknown>).keepRecentPairs
   }
+  // Default providerId for legacy data that predates the (providerId, modelId) split
+  if (!settings.providerId) {
+    settings.providerId = ''
+  }
   return ConversationSettingsInput.parse(settings)
 }
 

--- a/packages/app-runtime/src/__tests__/appRuntime.spec.ts
+++ b/packages/app-runtime/src/__tests__/appRuntime.spec.ts
@@ -39,6 +39,7 @@ describe('app runtime', () => {
       updatedAt: 1,
       settings: {
         modelId: 'model-1',
+        providerId: 'provider-1',
         systemPrompt: '',
         temperature: 0.7,
         maxTokens: 1024,
@@ -71,8 +72,8 @@ describe('app runtime', () => {
   })
 
   it('clears all conversations in current workspace', async () => {
-    await runtime.chat.createConversation({ title: 'Conv 1', createdAt: 1, updatedAt: 1, settings: { modelId: 'm', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
-    await runtime.chat.createConversation({ title: 'Conv 2', createdAt: 2, updatedAt: 2, settings: { modelId: 'm', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
+    await runtime.chat.createConversation({ title: 'Conv 1', createdAt: 1, updatedAt: 1, settings: { modelId: 'm', providerId: 'p', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
+    await runtime.chat.createConversation({ title: 'Conv 2', createdAt: 2, updatedAt: 2, settings: { modelId: 'm', providerId: 'p', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
 
     const deletedIds = await runtime.chat.clearWorkspaceConversations()
 

--- a/packages/app-runtime/src/appRuntime.ts
+++ b/packages/app-runtime/src/appRuntime.ts
@@ -142,8 +142,8 @@ export function createAppRuntime(options: CreateAppRuntimeOptions) {
 
   const runtime = {
     chat: {
-      createConversationTitle: async (conversationId: string, modelId: string) => {
-        const conversation = await titleGenerator.updateTitle(conversationId, modelId)
+      createConversationTitle: async (conversationId: string, modelId: string, providerId: string) => {
+        const conversation = await titleGenerator.updateTitle(conversationId, { providerId, modelId })
         if (conversation) {
           events.emit('conversation:updated', { conversation })
         }
@@ -259,10 +259,9 @@ export function createAppRuntime(options: CreateAppRuntimeOptions) {
         return null
       },
       getById: (id: string) => requireValue(context.providerSettingsRepository.getProviderById(id), `Provider not found: ${id}`),
-      getByModelId: (id: string) => requireValue(context.providerSettingsRepository.getProviderByModelId(id), `Provider model not found: ${id}`),
       listAvailableModels: () => context.providerSettingsRepository.getAllAvailableModels(),
       listModels: (id: string) => context.providerSettingsRepository.listProviderModels(id),
-      getModel: (id: string) => requireValue(context.providerSettingsRepository.getModelById(id), `Provider model not found: ${id}`),
+      getModel: (providerId: string, modelId: string) => requireValue(context.providerSettingsRepository.getModel(providerId, modelId), `Provider model not found: ${providerId}/${modelId}`),
       setModelEnabled: (id: string, enabled: boolean) => {
         const result = context.providerSettingsRepository.setModelEnabledStatus(id, enabled)
         events.emit('provider:changed', { providerId: result.providerId })

--- a/packages/app-runtime/src/rpcHandlers.ts
+++ b/packages/app-runtime/src/rpcHandlers.ts
@@ -8,7 +8,7 @@ export type AppRpcHandlers = {
 export function createAppRpcHandlers(runtime: AppRuntime): AppRpcHandlers {
   return {
     'chat.createConversationsTitle': async (input) => {
-      const conversation = await runtime.chat.createConversationTitle(input.conversationsId, input.modelId)
+      const conversation = await runtime.chat.createConversationTitle(input.conversationsId, input.modelId, input.providerId)
       if (!conversation) {
         throw new Error(`Conversation title was not updated: ${input.conversationsId}`)
       }
@@ -38,13 +38,12 @@ export function createAppRpcHandlers(runtime: AppRuntime): AppRpcHandlers {
     'provider.updateProvider': input => runtime.provider.update(input.config),
     'provider.deleteProvider': input => runtime.provider.delete(input.id),
     'provider.getProviderById': input => runtime.provider.getById(input.id),
-    'provider.getProviderByModelId': input => runtime.provider.getByModelId(input.id),
     'provider.getAllAbvailableModels': () => runtime.provider.listAvailableModels(),
     'provider.listProviderModels': input => runtime.provider.listModels(input.id),
     'provider.setModelEnabledStatus': input => runtime.provider.setModelEnabled(input.id, input.status),
     'provider.createProviderModel': input => runtime.provider.createModel(input.config),
     'provider.deleteProviderModel': input => runtime.provider.deleteModel(input.id),
-    'provider.getModelById': input => runtime.provider.getModel(input.id),
+    'provider.getModel': input => runtime.provider.getModel(input.providerId, input.modelId),
     'provider.getModelsDevProviders': () => runtime.provider.getModelsDevProviders(),
     'provider.getModelsDevModelsByProviderId': input => runtime.provider.getModelsDevModels(input.providerId),
     'provider.importModelsDevModels': input => runtime.provider.importModelsDevModels(input.providerId),

--- a/packages/shared/src/interfaces/agent-runtime-electron.ts
+++ b/packages/shared/src/interfaces/agent-runtime-electron.ts
@@ -15,6 +15,7 @@ export interface StartAgentTurnOptions {
   mode?: AgentMode
   modelConfig: Omit<ModelSettings, 'model' | 'features'> & {
     modelId: string
+    providerId: string
     features: ChatFeatures
   }
 }

--- a/packages/shared/src/interfaces/agent-runtime-interfaces.ts
+++ b/packages/shared/src/interfaces/agent-runtime-interfaces.ts
@@ -127,6 +127,16 @@ export interface IAgentPathProvider {
 // Model Catalog
 // ============================================================
 
+export interface ModelRef {
+  providerId: string
+  modelId: string
+}
+
+export interface ResolvedModel {
+  model: AgentModel
+  provider: AgentProvider
+}
+
 export interface AgentModel {
   id: string
   model: string
@@ -138,8 +148,9 @@ export interface AgentModel {
 export type AgentProvider = ProviderConfigSchema
 
 export interface IModelCatalog {
-  getModelById: (id: string) => Promise<AgentModel | null>
-  getProviderById: (id: string) => Promise<ProviderConfigSchema | null>
+  resolveModel: (ref: ModelRef) => Promise<ResolvedModel | null>
+  getModel: (providerId: string, modelId: string) => Promise<AgentModel | null>
+  getProvider: (providerId: string) => Promise<ProviderConfigSchema | null>
 }
 
 // ============================================================
@@ -298,7 +309,8 @@ export interface AgentRuntimeStartTaskOptions {
   prompt: string
   conversationId: string
   userMessageId: string
-  modelId: string
+  model: AgentModel
+  provider: AgentProvider
   workspacePath: string
   aiProvider?: IAIProvider
   mode?: AgentMode

--- a/packages/shared/src/interfaces/app-rpc.ts
+++ b/packages/shared/src/interfaces/app-rpc.ts
@@ -67,13 +67,12 @@ export interface AppRpcContract {
   'provider.updateProvider': RpcEndpoint<{ config: UpdateProviderConfigSchema }, ProviderConfigSchema>
   'provider.deleteProvider': RpcEndpoint<{ id: string }, null>
   'provider.getProviderById': RpcEndpoint<{ id: string }, ProviderConfigSchema>
-  'provider.getProviderByModelId': RpcEndpoint<{ id: string }, ProviderConfigSchema>
   'provider.getAllAbvailableModels': RpcEndpoint<undefined, AllAvailableModelsSchema[]>
   'provider.listProviderModels': RpcEndpoint<{ id: string }, ProviderConfigModelSchema[]>
   'provider.setModelEnabledStatus': RpcEndpoint<{ id: string, status: boolean }, ProviderConfigModelSchema>
   'provider.createProviderModel': RpcEndpoint<{ config: CreateProviderConfigModelSchema }, ProviderConfigModelSchema>
   'provider.deleteProviderModel': RpcEndpoint<{ id: string }, null>
-  'provider.getModelById': RpcEndpoint<{ id: string }, ProviderConfigModelSchema>
+  'provider.getModel': RpcEndpoint<{ providerId: string, modelId: string }, ProviderConfigModelSchema>
   'provider.getModelsDevProviders': RpcEndpoint<undefined, ModelsDevProvider[]>
   'provider.getModelsDevModelsByProviderId': RpcEndpoint<{ providerId: string }, ModelsDevModel[]>
   'provider.importModelsDevModels': RpcEndpoint<{ providerId: string }, ModelsDevImportResult>

--- a/packages/shared/src/interfaces/builtin-command.ts
+++ b/packages/shared/src/interfaces/builtin-command.ts
@@ -53,6 +53,7 @@ export interface RunBuiltinCommandParams {
   argument?: string
   modelConfig: {
     modelId: string
+    providerId: string
     systemPrompt: string
     temperature: number
     maxTokens: number

--- a/packages/shared/src/interfaces/conversation-title.ts
+++ b/packages/shared/src/interfaces/conversation-title.ts
@@ -1,6 +1,7 @@
 export interface handleInitConversationTitleOptions {
   conversationsId: string
   modelId: string
+  providerId: string
 }
 
 export interface CreateConversationTitleOptions {

--- a/packages/shared/src/interfaces/generalSettings.ts
+++ b/packages/shared/src/interfaces/generalSettings.ts
@@ -4,6 +4,7 @@ import { AppSettingsSchema } from '../schemas/appSettings'
 
 export const GeneralSettingsSchema = AppSettingsSchema.pick({
   assistantModelId: true,
+  assistantProviderId: true,
   proxySettings: true,
 })
 

--- a/packages/shared/src/schemas/appSettings.ts
+++ b/packages/shared/src/schemas/appSettings.ts
@@ -30,7 +30,7 @@ export const ToolApprovalWhitelistEntrySchema = z.object({
 
 export const AppSettingsSchema = z.object({
   assistantModelId: z.string(),
-  assistantProviderId: z.string(),
+  assistantProviderId: z.string().default(''),
   proxySettings: z.object({
     mode: z.enum(['none', 'system', 'custom']),
     customProxyUrl: z.string().optional(),

--- a/packages/shared/src/schemas/appSettings.ts
+++ b/packages/shared/src/schemas/appSettings.ts
@@ -30,6 +30,7 @@ export const ToolApprovalWhitelistEntrySchema = z.object({
 
 export const AppSettingsSchema = z.object({
   assistantModelId: z.string(),
+  assistantProviderId: z.string(),
   proxySettings: z.object({
     mode: z.enum(['none', 'system', 'custom']),
     customProxyUrl: z.string().optional(),

--- a/packages/shared/src/schemas/conversations.ts
+++ b/packages/shared/src/schemas/conversations.ts
@@ -31,6 +31,7 @@ export const DEFAULT_COMPACTION_SETTINGS: Readonly<CompactionSettingsSchema> = O
 // Conversation settings
 export const ConversationsSettingsSchema = z.object({
   modelId: z.string(),
+  providerId: z.string(),
   systemPrompt: z.string(),
   temperature: z.number(),
   maxTokens: z.number(),


### PR DESCRIPTION
## Summary

将 flat `modelId` 引用重构为 `ModelRef { providerId, modelId }` 组合，消除同一 modelId 在不同 provider 下的歧义。核心变更涉及 **shared 类型层** → **app-data 数据层** → **agent-core/agent-runtime 逻辑层** → **前端 UI 层** 的全链路改造。

## 变更内容

### 类型系统 (packages/shared)
- 新增 `ModelRef` / `ResolvedModel` 接口
- `IModelCatalog` 重设计：`getModelById`/`getProviderByModelId` → `resolveModel(ref)` / `getModel(providerId, modelId)` / `getProvider(providerId)`
- `AgentRuntimeStartTaskOptions.modelId: string` → `model: AgentModel` + `provider: AgentProvider`
- `ConversationsSettingsSchema` / `AppSettingsSchema` / `GeneralSettings` 新增 `providerId` 字段
- `StartAgentTurnOptions.modelConfig` 和 `RunBuiltinCommandParams.modelConfig` 新增 `providerId`

### 数据层 (packages/app-data)
- `ProviderSettingsRepository` 新增 `getModel(providerId, modelId)` / `resolveModel(providerId, modelId)`
- `ModelCatalog` 适配新 IModelCatalog 接口
- 旧数据迁移：SQLite 解析 conversation 设置时，缺失 `providerId` 默认填充空字符串

### 运行时层 (packages/agent-core, agent-runtime, app-runtime)
- `SessionRuntime.startTask` 直接使用传入的 `model` / `provider` 对象，不再通过 modelCatalog 查找
- `AgentRuntime.startTask` 通过 `isSessionStartOptions`（`'model' in options`）路由 session 路径和 loop 路径
- `agentTurnService` 调用 `resolveModel` 获取 model+provider，传递给 runtime
- `compactCommand` / `conversationTitleGenerator` 适配新接口
- RPC handlers 更新方法名

### 前端 (apps/web)
- `PickerModel` 的 value 从 `string` 改为 `{ modelId, providerId }`
- `SelectModel` 使用复合 key `${providerId}-${modelId}`
- `Sender` 增加 `providerId` 守卫检查，确保两者都有值才发起 API 调用
- `chatSettings` context / store / hooks 全部新增 `providerId` 支持
- `GeneralSettings` 读取/保存 `assistantProviderId`

### 测试修复
- `TaskStore` 新增 `clear()` 方法，各测试文件 `afterEach` 中调用以隔离测试
- 所有 mock 适配新接口（`resolveModel` 代替 `getModelById`）
- 所有 settings 对象补充 `providerId` 字段
- agent-core 测试重写：移除不再适用的 model-not-found 用例，替换为 conversation / userMessage 查找失败用例

## 兼容性

- 旧 DB 记录的 conversation settings 缺少 `providerId` 时自动填充空字符串
- 前端 `Sender` 在 `providerId` 为空时跳过 API 调用，避免空白请求
- 标题生成链路在 `assistantProviderId` 读取失败时回退到当前对话 modelId