### PR TITLE
refactor(web): 工作区状态源整合——消除 currentWorkspacePath 第三源, 统一改为 workspaceStore SSOT

### DIFF
--- a/apps/web/src/__tests__/gui.spec.tsx
+++ b/apps/web/src/__tests__/gui.spec.tsx
@@ -15,6 +15,7 @@ import { useAgentStore } from '../store/agent'
 import { useConversationsStore } from '../store/conversation'
 import { createInitialState } from '../store/conversation/initialState'
 import { setActiveConversationsId, useMessagesStore } from '../store/messages'
+import { useWorkspaceStore } from '../store/workspace'
 
 const mocks = vi.hoisted(() => ({
   agent: {
@@ -89,6 +90,7 @@ const mocks = vi.hoisted(() => ({
     chooseWorkspace: vi.fn(async () => null),
     listWorkspaces: vi.fn(),
     openWorkspace: vi.fn(),
+    searchWorkspaceFiles: vi.fn(async () => []),
   },
 }))
 
@@ -154,7 +156,6 @@ describe('gui ui flow', () => {
     mocks.provider.getAllAbvailableModels.mockResolvedValue([])
     mocks.skill.listSkills.mockResolvedValue({ skills: [] })
     mocks.workspace.listWorkspaces.mockResolvedValue({
-      currentWorkspacePath: guiWorkspacePath,
       workspaces: [{
         path: guiWorkspacePath,
         displayName: 'ant-chat-gui-workspace',
@@ -551,8 +552,8 @@ function seedActiveConversation(conversationId: string) {
   useConversationsStore.setState({
     activeConversationsId: conversationId,
     conversations: [conversation],
-    currentWorkspacePath: guiWorkspacePath,
   })
+  useWorkspaceStore.setState({ currentWorkspacePath: guiWorkspacePath })
 }
 
 function createConversation(id: string): IConversations {

--- a/apps/web/src/__tests__/gui.spec.tsx
+++ b/apps/web/src/__tests__/gui.spec.tsx
@@ -392,6 +392,11 @@ describe('gui ui flow', () => {
       },
     })
 
+    // WorkspacePanels.initialize 在 render 后异步调用 activateWorkspace(currentWorkspacePath),
+    // 而 activateWorkspace 会先 setActiveConversationsId('') 清空调试会话。
+    // 将 workspaces mock 为空列表，使 refresh → pickLatestWorkspace([]) → '' → activateWorkspace('') 提前 return。
+    mocks.workspace.listWorkspaces.mockResolvedValue({ workspaces: [] })
+
     renderGui('/chat')
 
     expect(await screen.findByTestId('agent-approval-card')).toHaveTextContent('write_file')
@@ -424,6 +429,9 @@ describe('gui ui flow', () => {
 
     await setActiveConversationsId('conv-running' as ConversationsId)
 
+    // 阻止 WorkspacePanels.initialize → activateWorkspace 清空调试会话
+    mocks.workspace.listWorkspaces.mockResolvedValue({ workspaces: [] })
+
     renderGui('/chat')
 
     const cancelButton = await screen.findByTestId('chat-cancel')
@@ -455,6 +463,9 @@ describe('gui ui flow', () => {
     })
 
     await setActiveConversationsId('conv-steering' as ConversationsId)
+
+    // 阻止 WorkspacePanels.initialize → activateWorkspace 清空调试会话
+    mocks.workspace.listWorkspaces.mockResolvedValue({ workspaces: [] })
 
     renderGui('/chat')
 

--- a/apps/web/src/api/workspaceApi.ts
+++ b/apps/web/src/api/workspaceApi.ts
@@ -29,8 +29,8 @@ async function createDirectory(parentPath: string, name: string): Promise<{ name
   return getAppRpcClient().call('workspace.createDirectory', { parentPath, name })
 }
 
-async function searchWorkspaceFiles(query: string, limit = 50): Promise<WorkspaceFileSearchResult[]> {
-  return getAppRpcClient().call('workspace.searchWorkspaceFiles', { query, limit })
+async function searchWorkspaceFiles(workspacePath: string, query: string, limit = 50): Promise<WorkspaceFileSearchResult[]> {
+  return getAppRpcClient().call('workspace.searchWorkspaceFiles', { workspacePath, query, limit })
 }
 
 export default {

--- a/apps/web/src/components/Chat/Chat.tsx
+++ b/apps/web/src/components/Chat/Chat.tsx
@@ -19,13 +19,15 @@ import {
 import Sender from '../Sender'
 import { ModelControlPanel } from '../Sender/PickerModel'
 
+import { useWorkspaceStore } from '@/store/workspace'
+
 const BubbleList = lazy(() => import('./BubbleList'))
 
 export default function Chat() {
   const messages = useMessagesStore(state => state.messages)
   const activeConversationsId = useMessagesStore(state => state.activeConversationsId)
   const currentConversations = useConversationsStore(state => state.conversations.find(item => item.id === activeConversationsId))
-  const currentWorkspacePath = useConversationsStore(state => state.currentWorkspacePath)
+  const currentWorkspacePath = useWorkspaceStore(state => state.currentWorkspacePath)
 
   const { settings, updateSettings } = useChatSettingsContext()
   const agentTask = useAgentStore(state => state.getActiveTaskByConversation(activeConversationsId))

--- a/apps/web/src/components/Chat/Chat.tsx
+++ b/apps/web/src/components/Chat/Chat.tsx
@@ -16,10 +16,10 @@ import {
   setActiveConversationsId,
   useMessagesStore,
 } from '@/store/messages'
-import Sender from '../Sender'
-import { ModelControlPanel } from '../Sender/PickerModel'
-
 import { useWorkspaceStore } from '@/store/workspace'
+import Sender from '../Sender'
+
+import { ModelControlPanel } from '../Sender/PickerModel'
 
 const BubbleList = lazy(() => import('./BubbleList'))
 
@@ -82,7 +82,7 @@ export default function Chat() {
         referencedFiles,
         selectedSkill,
         mode: agentMode,
-        workspacePath: currentWorkspacePath || undefined,
+        workspacePath: currentWorkspacePath,
         modelConfig: {
           ...settings,
           features,

--- a/apps/web/src/components/Sender/Sender.tsx
+++ b/apps/web/src/components/Sender/Sender.tsx
@@ -53,10 +53,10 @@ import {
   useChatSttingsStore,
 } from '@/store/chatSettings'
 import {
-  switchWorkspaceConversationsAction,
+  activateWorkspace,
   useConversationsStore,
 } from '@/store/conversation'
-import { setActiveConversationsId, useMessagesStore } from '@/store/messages'
+import { useMessagesStore } from '@/store/messages'
 import { useWorkspaceStore } from '@/store/workspace'
 import { fileToBase64 } from '@/utils'
 import TypingEffect from '../TypingEffect'
@@ -331,6 +331,7 @@ function Sender({ disabled = false, actions, ...props }: SenderProps) {
   })
 
   const workspaceData = useWorkspaceStore(state => state.workspaceData)
+  const currentWorkspacePath = useWorkspaceStore(state => state.currentWorkspacePath)
   const refreshWorkspace = useWorkspaceStore(state => state.refresh)
   const openWorkspace = useWorkspaceStore(state => state.openWorkspace)
 
@@ -413,9 +414,9 @@ function Sender({ disabled = false, actions, ...props }: SenderProps) {
   const currentWorkspace = useMemo(
     () =>
       workspaceData?.workspaces.find(
-        item => item.path === workspaceData?.currentWorkspacePath,
+        item => item.path === currentWorkspacePath,
       ),
-    [workspaceData],
+    [workspaceData, currentWorkspacePath],
   )
   const workspaceDisplayName = currentWorkspace?.displayName || '未选择工作区'
   const workspaceSwitchDisabled = workspaceLoading || !canSwitchWorkspaceSelect
@@ -437,7 +438,7 @@ function Sender({ disabled = false, actions, ...props }: SenderProps) {
     }
 
     const timer = window.setTimeout(() => {
-      void workspaceApi.searchWorkspaceFiles(activeReferenceTrigger.query, 50)
+      void workspaceApi.searchWorkspaceFiles(currentWorkspacePath, activeReferenceTrigger.query, 50)
         .then((results) => {
           dispatchSenderData({ type: 'SET_FILE_RESULTS', results })
         })
@@ -479,7 +480,7 @@ function Sender({ disabled = false, actions, ...props }: SenderProps) {
     if (
       !canSwitchWorkspace
       || !workspaceData
-      || nextWorkspacePath === workspaceData.currentWorkspacePath
+      || nextWorkspacePath === currentWorkspacePath
     ) {
       return
     }
@@ -492,8 +493,7 @@ function Sender({ disabled = false, actions, ...props }: SenderProps) {
     try {
       await openWorkspace(nextWorkspacePath)
       setWorkspacePickerOpen(false)
-      await setActiveConversationsId('')
-      await switchWorkspaceConversationsAction(nextWorkspacePath)
+      await activateWorkspace(nextWorkspacePath)
     }
     catch (error) {
       setNotice((error as Error).message)
@@ -817,7 +817,7 @@ function Sender({ disabled = false, actions, ...props }: SenderProps) {
             files={senderData.fileResults}
             skills={filteredSkills}
             builtinCommands={filteredCommands}
-            hasWorkspace={Boolean(workspaceData?.currentWorkspacePath)}
+            hasWorkspace={Boolean(currentWorkspacePath)}
             highlightedIndex={senderData.highlightedIndex}
             anchorRect={senderData.suggestionAnchorRect}
             onSelectFile={selectFileReference}

--- a/apps/web/src/components/Sender/__tests__/Sender.spec.tsx
+++ b/apps/web/src/components/Sender/__tests__/Sender.spec.tsx
@@ -5,10 +5,12 @@ import { ChatSettingsContext, DEFAULT_SETTINGS } from '@/contexts/chatSettings'
 import { useChatSttingsStore } from '@/store/chatSettings'
 import { useConversationsStore } from '@/store/conversation'
 import { useMessagesStore } from '@/store/messages'
+import { useWorkspaceStore } from '@/store/workspace'
 import Sender from '../Sender'
 
 const mocks = vi.hoisted(() => ({
   searchWorkspaceFiles: vi.fn(),
+  listWorkspaces: vi.fn(),
 }))
 
 class ResizeObserverMock {
@@ -19,12 +21,7 @@ class ResizeObserverMock {
 
 vi.mock('@/api/workspaceApi', () => ({
   default: {
-    listWorkspaces: vi.fn(async () => ({
-      currentWorkspacePath: '/tmp/workspace',
-      workspaces: [
-        { path: '/tmp/workspace', displayName: 'workspace' },
-      ],
-    })),
+    listWorkspaces: mocks.listWorkspaces,
     openWorkspace: vi.fn(),
     searchWorkspaceFiles: mocks.searchWorkspaceFiles,
   },
@@ -92,6 +89,11 @@ describe('sender reference token overlay', () => {
     mocks.searchWorkspaceFiles.mockResolvedValue([
       { path: 'resume.md', name: 'resume.md', type: 'file' },
     ])
+    mocks.listWorkspaces.mockResolvedValue({
+      workspaces: [
+        { path: '/tmp/workspace', displayName: 'workspace' },
+      ],
+    })
     useMessagesStore.setState({
       activeConversationsId: '',
       messages: [],
@@ -105,9 +107,9 @@ describe('sender reference token overlay', () => {
       conversationsTotal: 1,
       streamingConversationIds: new Set<string>(),
       loadVersion: 0,
-      currentWorkspacePath: '/tmp/workspace',
       workspaceConversations: {},
     })
+    useWorkspaceStore.setState({ currentWorkspacePath: '/tmp/workspace', workspaceData: null, loading: false })
     useChatSttingsStore.setState({
       enableMCP: false,
       agentMode: 'hybrid',
@@ -151,7 +153,7 @@ describe('sender reference token overlay', () => {
     setTextareaValue(textarea, '看 @res')
 
     await waitFor(() => {
-      expect(mocks.searchWorkspaceFiles).toHaveBeenCalledWith('res', 50)
+      expect(mocks.searchWorkspaceFiles).toHaveBeenCalledWith('/tmp/workspace', 'res', 50)
     })
 
     fireEvent.mouseDown(await screen.findByText('resume.md'))

--- a/apps/web/src/components/Workspace/WorkspacePanels.tsx
+++ b/apps/web/src/components/Workspace/WorkspacePanels.tsx
@@ -21,7 +21,7 @@ import {
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router'
 import { activateWorkspace, ensureWorkspaceConversationsAction, useConversationsStore } from '@/store/conversation'
-import { useMessagesStore } from '@/store/messages'
+import { setActiveConversationsId, useMessagesStore } from '@/store/messages'
 import { useWorkspaceStore } from '@/store/workspace'
 import { WorkspaceDirectoryPickerDialog } from './WorkspaceDirectoryPickerDialog'
 

--- a/apps/web/src/components/Workspace/WorkspacePanels.tsx
+++ b/apps/web/src/components/Workspace/WorkspacePanels.tsx
@@ -20,13 +20,8 @@ import {
 } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router'
-import {
-  ensureWorkspaceConversationsAction,
-  nextPageConversationsAction,
-  switchWorkspaceConversationsAction,
-  useConversationsStore,
-} from '@/store/conversation'
-import { setActiveConversationsId, useMessagesStore } from '@/store/messages'
+import { activateWorkspace, ensureWorkspaceConversationsAction, useConversationsStore } from '@/store/conversation'
+import { useMessagesStore } from '@/store/messages'
 import { useWorkspaceStore } from '@/store/workspace'
 import { WorkspaceDirectoryPickerDialog } from './WorkspaceDirectoryPickerDialog'
 
@@ -51,25 +46,21 @@ export function WorkspacePanels({ onNavigate }: WorkspacePanelsProps) {
   const workspaceConversations = useConversationsStore(
     state => state.workspaceConversations,
   )
-  const storeWorkspacePath = useConversationsStore(
-    state => state.currentWorkspacePath,
-  )
-  const activeConversationsId = useMessagesStore(
-    state => state.activeConversationsId,
-  )
   const workspaceData = useWorkspaceStore(state => state.workspaceData)
+  const currentWorkspacePath = useWorkspaceStore(state => state.currentWorkspacePath)
   const refreshWorkspace = useWorkspaceStore(state => state.refresh)
   const openWorkspace = useWorkspaceStore(state => state.openWorkspace)
   const addWorkspace = useWorkspaceStore(state => state.addWorkspace)
   const removeWorkspace = useWorkspaceStore(state => state.removeWorkspace)
+  const activeConversationsId = useMessagesStore(
+    state => state.activeConversationsId,
+  )
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(
     () => new Set(),
   )
   const [panelError, setPanelError] = useState('')
   const [pickerOpen, setPickerOpen] = useState(false)
   const initializedRef = useRef(false)
-
-  const currentWorkspacePath = storeWorkspacePath || workspaceData?.currentWorkspacePath
 
   const initialize = useCallback(async () => {
     if (initializedRef.current) {
@@ -80,21 +71,11 @@ export function WorkspacePanels({ onNavigate }: WorkspacePanelsProps) {
     await refreshWorkspace()
     const data = useWorkspaceStore.getState().workspaceData
     if (data) {
-      setExpandedPaths(new Set([data.currentWorkspacePath]))
-      useConversationsStore.getState().switchWorkspace(data.currentWorkspacePath)
-
-      if (useConversationsStore.getState().conversations.length === 0) {
-        await nextPageConversationsAction()
-      }
+      const currentPath = useWorkspaceStore.getState().currentWorkspacePath
+      setExpandedPaths(new Set([currentPath]))
+      await activateWorkspace(currentPath)
     }
   }, [refreshWorkspace])
-
-  const reloadCurrentWorkspace = useCallback(async () => {
-    await setActiveConversationsId('')
-    if (currentWorkspacePath) {
-      await switchWorkspaceConversationsAction(currentWorkspacePath)
-    }
-  }, [currentWorkspacePath])
 
   const handleChooseWorkspace = useCallback(() => {
     setPickerOpen(true)
@@ -104,20 +85,23 @@ export function WorkspacePanels({ onNavigate }: WorkspacePanelsProps) {
     setPickerOpen(false)
     setPanelError('')
     try {
-      const data = await addWorkspace(path)
-      setExpandedPaths(
-        paths => new Set([...paths, data.currentWorkspacePath]),
-      )
-      await reloadCurrentWorkspace()
+      await addWorkspace(path)
+      // addWorkspace 内部已 set currentWorkspacePath=path(SSOT 更新),
+      // 用入参 path 调 activateWorkspace,不依赖闭包渲染期变量
+      setExpandedPaths(paths => new Set([...paths, path]))
+      await activateWorkspace(path)
     }
     catch (error) {
       setPanelError((error as Error).message)
     }
-  }, [addWorkspace, reloadCurrentWorkspace])
+  }, [addWorkspace])
 
   const handleDeleteWorkspace = useCallback(async (path: string) => {
     try {
       await removeWorkspace(path)
+      // removeWorkspace 内部已按 lastOpenedAt 回退 currentWorkspacePath,
+      // 从 workspaceStore 取回退后的当前路径再 activate
+      await activateWorkspace(useWorkspaceStore.getState().currentWorkspacePath)
       setExpandedPaths((paths) => {
         const next = new Set(paths)
         next.delete(path)
@@ -155,11 +139,9 @@ export function WorkspacePanels({ onNavigate }: WorkspacePanelsProps) {
     navigate('/chat')
 
     if (workspacePath !== currentWorkspacePath) {
-      const data = await openWorkspace(workspacePath)
-      setExpandedPaths(
-        paths => new Set([...paths, data.currentWorkspacePath]),
-      )
-      await switchWorkspaceConversationsAction(workspacePath)
+      await openWorkspace(workspacePath)
+      setExpandedPaths(paths => new Set([...paths, workspacePath]))
+      await activateWorkspace(workspacePath)
     }
 
     await setActiveConversationsId(conversationId)
@@ -170,9 +152,9 @@ export function WorkspacePanels({ onNavigate }: WorkspacePanelsProps) {
     navigate('/chat')
 
     if (workspacePath !== currentWorkspacePath) {
-      const data = await openWorkspace(workspacePath)
-      setExpandedPaths(paths => new Set([...paths, data.currentWorkspacePath]))
-      await switchWorkspaceConversationsAction(workspacePath)
+      await openWorkspace(workspacePath)
+      setExpandedPaths(paths => new Set([...paths, workspacePath]))
+      await activateWorkspace(workspacePath)
     }
 
     await setActiveConversationsId('')

--- a/apps/web/src/components/Workspace/WorkspaceSelector.tsx
+++ b/apps/web/src/components/Workspace/WorkspaceSelector.tsx
@@ -1,4 +1,4 @@
-import type { ListWorkspacesData, WorkspaceItem } from '@ant-chat/shared'
+import type { WorkspaceItem } from '@ant-chat/shared'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -26,14 +26,13 @@ import {
   PlusIcon,
   Trash2Icon,
 } from 'lucide-react'
-import { useEffect, useMemo, useReducer, useState } from 'react'
-import workspaceApi from '@/api/workspaceApi'
+import { useEffect, useMemo, useState } from 'react'
 import {
   emitWorkspaceChanged,
   WORKSPACE_CHANGED_EVENT,
 } from '@/constants/workspaceEvents'
-import { switchWorkspaceConversationsAction, useConversationsStore } from '@/store/conversation'
-import { setActiveConversationsId } from '@/store/messages'
+import { activateWorkspace } from '@/store/conversation'
+import { useWorkspaceStore } from '@/store/workspace'
 import { WorkspaceDirectoryPickerDialog } from './WorkspaceDirectoryPickerDialog'
 
 interface WorkspaceSelectorProps {
@@ -48,11 +47,6 @@ interface NoticeState {
 export function WorkspaceSelector({ compact = false }: WorkspaceSelectorProps) {
   const [open, setOpen] = useState(false)
   const [loading, setLoading] = useState(false)
-  // useReducer to avoid react-hooks/set-state-in-effect: dispatch is allowed in effects
-  const [workspaceData, setWorkspaceData] = useReducer(
-    (_s: ListWorkspacesData | null, a: ListWorkspacesData | null) => a,
-    null,
-  )
   const [notice, setNotice] = useState<NoticeState | null>(null)
   const [removeTarget, setRemoveTarget] = useState<WorkspaceItem | null>(null)
   const [pickerOpen, setPickerOpen] = useState(false)
@@ -63,15 +57,16 @@ export function WorkspaceSelector({ compact = false }: WorkspaceSelectorProps) {
     `
     : ''
 
+  // 唯一事实源:workspaceStore。不再持有本地 workspaceData(第三源)。
+  const workspaceData = useWorkspaceStore(state => state.workspaceData)
+  const currentWorkspacePath = useWorkspaceStore(state => state.currentWorkspacePath)
   const currentWorkspace = useMemo(
-    () => workspaceData?.workspaces.find(item => item.path === workspaceData.currentWorkspacePath),
-    [workspaceData],
+    () => workspaceData?.workspaces.find(item => item.path === currentWorkspacePath),
+    [workspaceData, currentWorkspacePath],
   )
 
   async function refreshWorkspaces() {
-    const data = await workspaceApi.listWorkspaces()
-    setWorkspaceData(data)
-    useConversationsStore.getState().switchWorkspace(data.currentWorkspacePath)
+    await useWorkspaceStore.getState().refresh()
   }
 
   useEffect(() => {
@@ -98,15 +93,6 @@ export function WorkspaceSelector({ compact = false }: WorkspaceSelectorProps) {
     return () => window.clearTimeout(timer)
   }, [notice])
 
-  async function applyWorkspaceData(data: ListWorkspacesData | null) {
-    if (!data) {
-      return
-    }
-    setWorkspaceData(data)
-    await setActiveConversationsId('')
-    await switchWorkspaceConversationsAction(data.currentWorkspacePath)
-  }
-
   function handleChooseWorkspace() {
     setPickerOpen(true)
   }
@@ -116,8 +102,8 @@ export function WorkspaceSelector({ compact = false }: WorkspaceSelectorProps) {
     setLoading(true)
     setNotice(null)
     try {
-      const data = await workspaceApi.addWorkspace(path)
-      await applyWorkspaceData(data)
+      await useWorkspaceStore.getState().addWorkspace(path)
+      await activateWorkspace(path)
       emitWorkspaceChanged()
       setNotice({ type: 'success', message: '工作区已添加' })
       setOpen(false)
@@ -131,15 +117,15 @@ export function WorkspaceSelector({ compact = false }: WorkspaceSelectorProps) {
   }
 
   async function handleOpenWorkspace(item: WorkspaceItem) {
-    if (item.path === workspaceData?.currentWorkspacePath) {
+    if (item.path === useWorkspaceStore.getState().currentWorkspacePath) {
       return
     }
 
     setLoading(true)
     setNotice(null)
     try {
-      const data = await workspaceApi.openWorkspace(item.path)
-      await applyWorkspaceData(data)
+      await useWorkspaceStore.getState().openWorkspace(item.path)
+      await activateWorkspace(item.path)
       setOpen(false)
     }
     catch (error) {
@@ -162,8 +148,8 @@ export function WorkspaceSelector({ compact = false }: WorkspaceSelectorProps) {
     setLoading(true)
     setNotice(null)
     try {
-      const data = await workspaceApi.removeWorkspace(removeTarget.path)
-      await applyWorkspaceData(data)
+      await useWorkspaceStore.getState().removeWorkspace(removeTarget.path)
+      await activateWorkspace(useWorkspaceStore.getState().currentWorkspacePath)
       emitWorkspaceChanged()
       setRemoveTarget(null)
     }
@@ -184,7 +170,7 @@ export function WorkspaceSelector({ compact = false }: WorkspaceSelectorProps) {
                 <WorkspaceRow
                   key={item.path}
                   item={item}
-                  active={item.path === workspaceData.currentWorkspacePath}
+                  active={item.path === currentWorkspacePath}
                   loading={loading}
                   onOpen={handleOpenWorkspace}
                   onRemove={handleRemoveWorkspace}

--- a/apps/web/src/store/agent/__tests__/actions.spec.ts
+++ b/apps/web/src/store/agent/__tests__/actions.spec.ts
@@ -32,6 +32,7 @@ describe('agent store actions', () => {
   it('调用 agent api', async () => {
     const created = await startAgentTurn({
       prompt: 'p',
+      workspacePath: '/workspace',
       modelConfig: {
         modelId: 'model-1',
         providerId: 'provider-1',

--- a/apps/web/src/store/conversation/__tests__/activateWorkspace.spec.ts
+++ b/apps/web/src/store/conversation/__tests__/activateWorkspace.spec.ts
@@ -1,0 +1,120 @@
+import type { IConversations } from '@ant-chat/shared'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const chatMocks = vi.hoisted(() => ({
+  getWorkspaceConversations: vi.fn(),
+  clearWorkspaceConversations: vi.fn(),
+}))
+
+vi.mock('@/api/chatApi', () => ({
+  default: chatMocks,
+}))
+
+import { useWorkspaceStore } from '@/store/workspace'
+import { activateWorkspace, clearConversationsAction } from '../actions'
+import { useConversationsStore } from '../conversationsStore'
+import { useMessagesStore } from '@/store/messages'
+
+function makeConversation(id: string, workspacePath: string): IConversations {
+  return {
+    id,
+    workspacePath,
+    title: id,
+    createdAt: 1,
+    updatedAt: 1,
+    settings: { modelId: 'm', providerId: 'p', systemPrompt: '', temperature: 0.7, maxTokens: 1024 },
+  } as IConversations
+}
+
+describe('activateWorkspace', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useWorkspaceStore.setState({ currentWorkspacePath: '', workspaceData: null, loading: false })
+    useConversationsStore.setState({
+      conversations: [],
+      abortCallbacks: [],
+      pageIndex: 0,
+      pageSize: 20,
+      conversationsTotal: 1,
+      activeConversationsId: 'stale-id',
+      streamingConversationIds: new Set<string>(),
+      loadVersion: 0,
+      workspaceConversations: {},
+    })
+    useMessagesStore.setState({ activeConversationsId: 'stale-id', messages: [] })
+  })
+
+  it('空路径时仅清空 activeConversationsId,不加载会话', async () => {
+    await activateWorkspace('')
+
+    expect(useMessagesStore.getState().activeConversationsId).toBe('')
+    expect(chatMocks.getWorkspaceConversations).not.toHaveBeenCalled()
+  })
+
+  it('非空路径时加载该工作区分片并切换顶层 slice', async () => {
+    useWorkspaceStore.setState({ currentWorkspacePath: '/other' })
+    chatMocks.getWorkspaceConversations.mockResolvedValue({
+      data: [makeConversation('c1', '/target')],
+      total: 1,
+    })
+
+    await activateWorkspace('/target')
+
+    expect(chatMocks.getWorkspaceConversations).toHaveBeenCalledWith('/target', 0, 20)
+    expect(useConversationsStore.getState().conversations).toHaveLength(1)
+    expect(useConversationsStore.getState().conversations[0].id).toBe('c1')
+  })
+
+  it('分片已加载时复用缓存,不重复请求', async () => {
+    useWorkspaceStore.setState({ currentWorkspacePath: '/other' })
+    // 预置已加载的分片
+    useConversationsStore.setState({
+      workspaceConversations: {
+        '/target': {
+          conversations: [makeConversation('cached', '/target')],
+          pageIndex: 0,
+          conversationsTotal: 1,
+          loadVersion: 0,
+          loaded: true,
+        },
+      },
+    })
+
+    await activateWorkspace('/target')
+
+    expect(chatMocks.getWorkspaceConversations).not.toHaveBeenCalled()
+    expect(useConversationsStore.getState().conversations[0].id).toBe('cached')
+  })
+})
+
+describe('clearConversationsAction 跨 store 取路径', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useWorkspaceStore.setState({ currentWorkspacePath: '/cur', workspaceData: null, loading: false })
+    useConversationsStore.setState({
+      conversations: [makeConversation('c1', '/cur')],
+      abortCallbacks: [],
+      pageIndex: 0,
+      pageSize: 20,
+      conversationsTotal: 1,
+      activeConversationsId: '',
+      streamingConversationIds: new Set<string>(),
+      loadVersion: 0,
+      workspaceConversations: {},
+    })
+  })
+
+  it('用 workspaceStore 当前路径清空,不再读 conversationsStore.currentWorkspacePath', async () => {
+    chatMocks.clearWorkspaceConversations.mockResolvedValue([])
+
+    await clearConversationsAction()
+
+    expect(chatMocks.clearWorkspaceConversations).toHaveBeenCalledWith('/cur')
+  })
+
+  it('workspaceStore 路径为空时抛错', async () => {
+    useWorkspaceStore.setState({ currentWorkspacePath: '' })
+
+    await expect(clearConversationsAction()).rejects.toThrow('当前工作区路径不存在，无法清空对话')
+  })
+})

--- a/apps/web/src/store/conversation/__tests__/activateWorkspace.spec.ts
+++ b/apps/web/src/store/conversation/__tests__/activateWorkspace.spec.ts
@@ -44,10 +44,10 @@ describe('activateWorkspace', () => {
     useMessagesStore.setState({ activeConversationsId: 'stale-id', messages: [] })
   })
 
-  it('空路径时仅清空 activeConversationsId,不加载会话', async () => {
+  it('空路径时不触发任何操作', async () => {
     await activateWorkspace('')
 
-    expect(useMessagesStore.getState().activeConversationsId).toBe('')
+    expect(useMessagesStore.getState().activeConversationsId).toBe('stale-id')
     expect(chatMocks.getWorkspaceConversations).not.toHaveBeenCalled()
   })
 

--- a/apps/web/src/store/conversation/__tests__/activateWorkspace.spec.ts
+++ b/apps/web/src/store/conversation/__tests__/activateWorkspace.spec.ts
@@ -1,6 +1,11 @@
 import type { IConversations } from '@ant-chat/shared'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { useMessagesStore } from '@/store/messages'
+import { useWorkspaceStore } from '@/store/workspace'
+import { activateWorkspace, clearConversationsAction } from '../actions'
+import { useConversationsStore } from '../conversationsStore'
+
 const chatMocks = vi.hoisted(() => ({
   getWorkspaceConversations: vi.fn(),
   clearWorkspaceConversations: vi.fn(),
@@ -9,11 +14,6 @@ const chatMocks = vi.hoisted(() => ({
 vi.mock('@/api/chatApi', () => ({
   default: chatMocks,
 }))
-
-import { useWorkspaceStore } from '@/store/workspace'
-import { activateWorkspace, clearConversationsAction } from '../actions'
-import { useConversationsStore } from '../conversationsStore'
-import { useMessagesStore } from '@/store/messages'
 
 function makeConversation(id: string, workspacePath: string): IConversations {
   return {

--- a/apps/web/src/store/conversation/actions.ts
+++ b/apps/web/src/store/conversation/actions.ts
@@ -82,10 +82,10 @@ export async function ensureWorkspaceConversationsAction(workspacePath: string) 
  * 不依赖任何闭包渲染期变量。activateWorkspace 不写 workspaceStore(SSOT 由 workspaceStore action 负责)。
  */
 export async function activateWorkspace(workspacePath: string): Promise<void> {
-  await setActiveConversationsId('')
   if (!workspacePath) {
     return
   }
+  await setActiveConversationsId('')
   await ensureWorkspaceConversationsAction(workspacePath)
   useConversationsStore.getState().switchWorkspaceSlice(workspacePath)
 

--- a/apps/web/src/store/conversation/actions.ts
+++ b/apps/web/src/store/conversation/actions.ts
@@ -3,8 +3,8 @@ import type { AntChatFileStructure } from '@/constants'
 import { produce } from 'immer'
 import chatApi from '@/api/chatApi'
 import { useGeneralSettingsStore } from '@/store/generalSettings'
-import { clearActiveConversations, setActiveConversationsId } from '../messages'
 import { useWorkspaceStore } from '@/store/workspace'
+import { clearActiveConversations, setActiveConversationsId } from '../messages'
 import { useConversationsStore } from './conversationsStore'
 
 const loadingConversationPages = new Set<string>()

--- a/apps/web/src/store/conversation/actions.ts
+++ b/apps/web/src/store/conversation/actions.ts
@@ -3,7 +3,8 @@ import type { AntChatFileStructure } from '@/constants'
 import { produce } from 'immer'
 import chatApi from '@/api/chatApi'
 import { useGeneralSettingsStore } from '@/store/generalSettings'
-import { clearActiveConversations } from '../messages'
+import { clearActiveConversations, setActiveConversationsId } from '../messages'
+import { useWorkspaceStore } from '@/store/workspace'
 import { useConversationsStore } from './conversationsStore'
 
 const loadingConversationPages = new Set<string>()
@@ -14,6 +15,10 @@ export function getConversationByIdAction(id: string) {
 
 function saveCurrentSlice() {
   useConversationsStore.getState().saveCurrentWorkspaceSlice()
+}
+
+function getCurrentWorkspacePath(): string {
+  return useWorkspaceStore.getState().currentWorkspacePath ?? ''
 }
 
 export async function ensureWorkspaceConversationsAction(workspacePath: string) {
@@ -68,9 +73,21 @@ export async function ensureWorkspaceConversationsAction(workspacePath: string) 
   }
 }
 
-export async function switchWorkspaceConversationsAction(workspacePath: string) {
+/**
+ * 统一的工作区激活入口:在 workspaceStore 已更新当前路径后,
+ * 同步会话分片缓存到该路径。所有切换/新增/删除场景调用此入口,
+ * 避免手动拼装 ensure+switch 导致的遗漏与闭包陷阱。
+ *
+ * 入参为目标工作区路径,由调用方传入(与紧邻的 workspaceStore action 的 path 入参一致),
+ * 不依赖任何闭包渲染期变量。activateWorkspace 不写 workspaceStore(SSOT 由 workspaceStore action 负责)。
+ */
+export async function activateWorkspace(workspacePath: string): Promise<void> {
+  await setActiveConversationsId('')
+  if (!workspacePath) {
+    return
+  }
   await ensureWorkspaceConversationsAction(workspacePath)
-  useConversationsStore.getState().switchWorkspace(workspacePath)
+  useConversationsStore.getState().switchWorkspaceSlice(workspacePath)
 
   const nextState = useConversationsStore.getState()
   if (nextState.conversations.length === 0 && nextState.conversationsTotal > 0) {
@@ -133,7 +150,7 @@ export async function importConversationsAction(_: AntChatFileStructure) {
 }
 
 export async function clearConversationsAction() {
-  const { currentWorkspacePath } = useConversationsStore.getState()
+  const currentWorkspacePath = getCurrentWorkspacePath()
   if (!currentWorkspacePath) {
     throw new Error('当前工作区路径不存在，无法清空对话')
   }
@@ -152,7 +169,8 @@ export async function clearConversationsAction() {
 }
 
 export async function nextPageConversationsAction() {
-  const { pageIndex, pageSize, loadVersion, currentWorkspacePath } = useConversationsStore.getState()
+  const { pageIndex, pageSize, loadVersion } = useConversationsStore.getState()
+  const currentWorkspacePath = getCurrentWorkspacePath()
   if (!currentWorkspacePath) {
     return
   }
@@ -169,8 +187,10 @@ export async function nextPageConversationsAction() {
     const { data: conversations, total } = await chatApi.getWorkspaceConversations(currentWorkspacePath, pageIndex, pageSize)
 
     useConversationsStore.setState(state => produce(state, (draft) => {
+      // 分页加载是异步的:加载期间用户可能切了工作区,加载回来时若 workspaceStore
+      // 当前路径已不是发起时的路径,则丢弃结果,不污染新工作区顶层 conversations。
       if (
-        draft.currentWorkspacePath !== currentWorkspacePath
+        useWorkspaceStore.getState().currentWorkspacePath !== currentWorkspacePath
         || draft.loadVersion !== loadVersion
         || draft.pageIndex !== pageIndex
       ) {

--- a/apps/web/src/store/conversation/conversationsStore.ts
+++ b/apps/web/src/store/conversation/conversationsStore.ts
@@ -2,12 +2,12 @@ import type { StoreState, WorkspaceConversationsState } from './initialState'
 
 import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
+import { useWorkspaceStore } from '@/store/workspace'
 import {
   createInitialState,
   createWorkspaceConversationsState,
   initialState,
 } from './initialState'
-import { useWorkspaceStore } from '@/store/workspace'
 
 interface StoreActions {
   reset: () => void

--- a/apps/web/src/store/conversation/conversationsStore.ts
+++ b/apps/web/src/store/conversation/conversationsStore.ts
@@ -7,14 +7,23 @@ import {
   createWorkspaceConversationsState,
   initialState,
 } from './initialState'
+import { useWorkspaceStore } from '@/store/workspace'
 
 interface StoreActions {
   reset: () => void
   setActiveConversationsId: (id: string) => void
-  switchWorkspace: (workspacePath: string) => void
+  switchWorkspaceSlice: (workspacePath: string) => void
   saveCurrentWorkspaceSlice: () => void
 }
 export type ConversationsStore = StoreState & StoreActions
+
+/**
+ * 跨 store 读取当前工作区路径(SSOT 在 workspaceStore)。
+ * conversationsStore 不再持有 currentWorkspacePath,需要时统一从此取。
+ */
+function getCurrentWorkspacePath(): string {
+  return useWorkspaceStore.getState().currentWorkspacePath ?? ''
+}
 
 function getWorkspaceSlice(state: StoreState, workspacePath: string): WorkspaceConversationsState {
   return state.workspaceConversations[workspacePath] || createWorkspaceConversationsState()
@@ -26,13 +35,13 @@ export const useConversationsStore = create<ConversationsStore>()(
     (set, get) => ({
       ...initialState,
       reset: () => {
+        const currentPath = getCurrentWorkspacePath()
         set((state) => {
           const nextState = createInitialState()
           nextState.pageSize = state.pageSize
-          nextState.currentWorkspacePath = state.currentWorkspacePath
 
-          if (state.currentWorkspacePath) {
-            const currentSlice = getWorkspaceSlice(state, state.currentWorkspacePath)
+          if (currentPath) {
+            const currentSlice = getWorkspaceSlice(state, currentPath)
             const nextSlice: WorkspaceConversationsState = {
               ...currentSlice,
               conversations: [],
@@ -43,7 +52,7 @@ export const useConversationsStore = create<ConversationsStore>()(
             }
             nextState.workspaceConversations = {
               ...state.workspaceConversations,
-              [state.currentWorkspacePath]: nextSlice,
+              [currentPath]: nextSlice,
             }
             nextState.conversations = nextSlice.conversations
             nextState.pageIndex = nextSlice.pageIndex
@@ -59,14 +68,15 @@ export const useConversationsStore = create<ConversationsStore>()(
       },
       saveCurrentWorkspaceSlice: () => {
         const state = get()
-        if (!state.currentWorkspacePath) {
+        const currentPath = getCurrentWorkspacePath()
+        if (!currentPath) {
           return
         }
 
         set({
           workspaceConversations: {
             ...state.workspaceConversations,
-            [state.currentWorkspacePath]: {
+            [currentPath]: {
               conversations: state.conversations,
               pageIndex: state.pageIndex,
               conversationsTotal: state.conversationsTotal,
@@ -76,16 +86,17 @@ export const useConversationsStore = create<ConversationsStore>()(
           },
         })
       },
-      switchWorkspace: (workspacePath: string) => {
-        set((state) => {
-          if (workspacePath === state.currentWorkspacePath) {
-            return state
-          }
+      switchWorkspaceSlice: (workspacePath: string) => {
+        const currentPath = getCurrentWorkspacePath()
+        if (workspacePath === currentPath) {
+          return
+        }
 
+        set((state) => {
           const nextWorkspaceConversations = { ...state.workspaceConversations }
 
-          if (state.currentWorkspacePath) {
-            nextWorkspaceConversations[state.currentWorkspacePath] = {
+          if (currentPath) {
+            nextWorkspaceConversations[currentPath] = {
               conversations: state.conversations,
               pageIndex: state.pageIndex,
               conversationsTotal: state.conversationsTotal,
@@ -98,7 +109,6 @@ export const useConversationsStore = create<ConversationsStore>()(
 
           return {
             ...state,
-            currentWorkspacePath: workspacePath,
             workspaceConversations: nextWorkspaceConversations,
             conversations: nextSlice.conversations,
             pageIndex: nextSlice.pageIndex,

--- a/apps/web/src/store/conversation/initialState.ts
+++ b/apps/web/src/store/conversation/initialState.ts
@@ -17,7 +17,6 @@ export interface StoreState {
   activeConversationsId: string
   streamingConversationIds: Set<string>
   loadVersion: number
-  currentWorkspacePath: string
   workspaceConversations: Record<string, WorkspaceConversationsState>
 }
 
@@ -41,7 +40,6 @@ export function createInitialState(): StoreState {
     conversationsTotal: 1,
     activeConversationsId: '',
     loadVersion: 0,
-    currentWorkspacePath: '',
     workspaceConversations: {},
   }
 }

--- a/apps/web/src/store/workspace/__tests__/store.spec.ts
+++ b/apps/web/src/store/workspace/__tests__/store.spec.ts
@@ -1,0 +1,115 @@
+import type { ListWorkspacesData } from '@ant-chat/shared'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  listWorkspaces: vi.fn(),
+  addWorkspace: vi.fn(),
+  openWorkspace: vi.fn(),
+  removeWorkspace: vi.fn(),
+}))
+
+vi.mock('@/api/workspaceApi', () => ({
+  default: mocks,
+}))
+
+import { useWorkspaceStore } from '../store'
+
+function makeWorkspaces(paths: Array<{ path: string, lastOpenedAt: number }>): ListWorkspacesData {
+  return {
+    workspaces: paths.map(item => ({
+      path: item.path,
+      displayName: item.path,
+      isDefault: false,
+      lastOpenedAt: item.lastOpenedAt,
+    })),
+  }
+}
+
+describe('workspaceStore currentWorkspacePath SSOT', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useWorkspaceStore.setState({ workspaceData: null, currentWorkspacePath: '', loading: false })
+  })
+
+  it('refresh 后 currentWorkspacePath 派生为 lastOpenedAt 最大者', async () => {
+    mocks.listWorkspaces.mockResolvedValue(makeWorkspaces([
+      { path: '/a', lastOpenedAt: 1 },
+      { path: '/b', lastOpenedAt: 5 },
+      { path: '/c', lastOpenedAt: 3 },
+    ]))
+
+    await useWorkspaceStore.getState().refresh()
+
+    expect(useWorkspaceStore.getState().currentWorkspacePath).toBe('/b')
+  })
+
+  it('refresh 后若当前路径仍有效则保持不变', async () => {
+    useWorkspaceStore.setState({ currentWorkspacePath: '/c' })
+    mocks.listWorkspaces.mockResolvedValue(makeWorkspaces([
+      { path: '/a', lastOpenedAt: 1 },
+      { path: '/c', lastOpenedAt: 3 },
+    ]))
+
+    await useWorkspaceStore.getState().refresh()
+
+    expect(useWorkspaceStore.getState().currentWorkspacePath).toBe('/c')
+  })
+
+  it('refresh 后若当前路径不在列表则回退到 lastOpenedAt 最大者', async () => {
+    useWorkspaceStore.setState({ currentWorkspacePath: '/gone' })
+    mocks.listWorkspaces.mockResolvedValue(makeWorkspaces([
+      { path: '/a', lastOpenedAt: 1 },
+      { path: '/b', lastOpenedAt: 9 },
+    ]))
+
+    await useWorkspaceStore.getState().refresh()
+
+    expect(useWorkspaceStore.getState().currentWorkspacePath).toBe('/b')
+  })
+
+  it('addWorkspace 后 currentWorkspacePath 显式设置为目标路径', async () => {
+    mocks.addWorkspace.mockResolvedValue(makeWorkspaces([{ path: '/new', lastOpenedAt: 10 }]))
+
+    await useWorkspaceStore.getState().addWorkspace('/new')
+
+    expect(useWorkspaceStore.getState().currentWorkspacePath).toBe('/new')
+  })
+
+  it('openWorkspace 后 currentWorkspacePath 显式设置为目标路径', async () => {
+    mocks.openWorkspace.mockResolvedValue(makeWorkspaces([{ path: '/opened', lastOpenedAt: 10 }]))
+
+    await useWorkspaceStore.getState().openWorkspace('/opened')
+
+    expect(useWorkspaceStore.getState().currentWorkspacePath).toBe('/opened')
+  })
+
+  it('removeWorkspace 删除当前工作区后回退到 lastOpenedAt 最大者', async () => {
+    useWorkspaceStore.setState({
+      currentWorkspacePath: '/cur',
+      workspaceData: makeWorkspaces([
+        { path: '/cur', lastOpenedAt: 5 },
+        { path: '/other', lastOpenedAt: 8 },
+      ]),
+    })
+    mocks.removeWorkspace.mockResolvedValue(makeWorkspaces([{ path: '/other', lastOpenedAt: 8 }]))
+
+    await useWorkspaceStore.getState().removeWorkspace('/cur')
+
+    expect(useWorkspaceStore.getState().currentWorkspacePath).toBe('/other')
+  })
+
+  it('removeWorkspace 删除非当前工作区时 currentWorkspacePath 保持不变', async () => {
+    useWorkspaceStore.setState({
+      currentWorkspacePath: '/cur',
+      workspaceData: makeWorkspaces([
+        { path: '/cur', lastOpenedAt: 5 },
+        { path: '/other', lastOpenedAt: 8 },
+      ]),
+    })
+    mocks.removeWorkspace.mockResolvedValue(makeWorkspaces([{ path: '/cur', lastOpenedAt: 5 }]))
+
+    await useWorkspaceStore.getState().removeWorkspace('/other')
+
+    expect(useWorkspaceStore.getState().currentWorkspacePath).toBe('/cur')
+  })
+})

--- a/apps/web/src/store/workspace/__tests__/store.spec.ts
+++ b/apps/web/src/store/workspace/__tests__/store.spec.ts
@@ -1,6 +1,8 @@
 import type { ListWorkspacesData } from '@ant-chat/shared'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { useWorkspaceStore } from '../store'
+
 const mocks = vi.hoisted(() => ({
   listWorkspaces: vi.fn(),
   addWorkspace: vi.fn(),
@@ -11,8 +13,6 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@/api/workspaceApi', () => ({
   default: mocks,
 }))
-
-import { useWorkspaceStore } from '../store'
 
 function makeWorkspaces(paths: Array<{ path: string, lastOpenedAt: number }>): ListWorkspacesData {
   return {

--- a/apps/web/src/store/workspace/store.ts
+++ b/apps/web/src/store/workspace/store.ts
@@ -1,10 +1,12 @@
-import type { ListWorkspacesData } from '@ant-chat/shared'
+import type { ListWorkspacesData, WorkspaceItem } from '@ant-chat/shared'
 import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 import workspaceApi from '@/api/workspaceApi'
 import { WORKSPACE_CHANGED_EVENT } from '@/constants/workspaceEvents'
 
 interface WorkspaceStoreState {
+  /** 当前工作区路径(SSOT):前端派生 + 工作区操作显式设置。后端不再回传。 */
+  currentWorkspacePath: string
   workspaceData: ListWorkspacesData | null
   loading: boolean
 }
@@ -18,32 +20,64 @@ interface WorkspaceStoreActions {
 
 export type WorkspaceStore = WorkspaceStoreState & WorkspaceStoreActions
 
+/**
+ * 从 workspaces 列表中取 lastOpenedAt 最大者为当前工作区。
+ * 列表为空时返回空串(由后端 ensureInitialized 保证默认工作区始终在列表,实际不会为空)。
+ */
+function pickLatestWorkspace(workspaces: WorkspaceItem[]): string {
+  if (workspaces.length === 0) {
+    return ''
+  }
+  return workspaces.reduce((latest, item) => {
+    const ts = item.lastOpenedAt ?? 0
+    const latestTs = latest.lastOpenedAt ?? 0
+    return ts > latestTs ? item : latest
+  }).path
+}
+
 export const useWorkspaceStore = create<WorkspaceStore>()(
   devtools(
     set => ({
+      currentWorkspacePath: '',
       workspaceData: null,
       loading: false,
 
       refresh: async () => {
         const data = await workspaceApi.listWorkspaces()
-        set({ workspaceData: data })
+        set((state) => {
+          const workspaces = data.workspaces
+          // 当前路径为空或不在列表中时,按 lastOpenedAt 派生;否则保持
+          const stillValid = state.currentWorkspacePath
+            && workspaces.some(item => item.path === state.currentWorkspacePath)
+          const currentWorkspacePath = stillValid
+            ? state.currentWorkspacePath
+            : pickLatestWorkspace(workspaces)
+          return { workspaceData: data, currentWorkspacePath }
+        })
       },
 
       openWorkspace: async (path: string) => {
         const data = await workspaceApi.openWorkspace(path)
-        set({ workspaceData: data })
+        set({ workspaceData: data, currentWorkspacePath: path })
         return data
       },
 
       addWorkspace: async (path: string) => {
         const data = await workspaceApi.addWorkspace(path)
-        set({ workspaceData: data })
+        set({ workspaceData: data, currentWorkspacePath: path })
         return data
       },
 
       removeWorkspace: async (path: string) => {
         const data = await workspaceApi.removeWorkspace(path)
-        set({ workspaceData: data })
+        set((state) => {
+          // 删的是当前工作区时,回退到 lastOpenedAt 最大者;否则保持
+          const isCurrent = path === state.currentWorkspacePath
+          const currentWorkspacePath = isCurrent
+            ? pickLatestWorkspace(data.workspaces)
+            : state.currentWorkspacePath
+          return { workspaceData: data, currentWorkspacePath }
+        })
         return data
       },
     }),
@@ -51,7 +85,7 @@ export const useWorkspaceStore = create<WorkspaceStore>()(
   ),
 )
 
-// 全局监听工作区变更事件，自动刷新
+// 全局监听工作区变更事件,自动刷新(刷新内部按 lastOpenedAt 派生当前路径)
 if (typeof window !== 'undefined') {
   window.addEventListener(WORKSPACE_CHANGED_EVENT, () => {
     void useWorkspaceStore.getState().refresh()

--- a/docs/superpowers/plans/2026-06-21-workspace-state-consolidation.md
+++ b/docs/superpowers/plans/2026-06-21-workspace-state-consolidation.md
@@ -1,0 +1,2787 @@
+# 工作区状态源整合 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 将 web 端「当前工作区路径」整合为 `useWorkspaceStore.currentWorkspacePath` 单一事实源(SSOT),删除 `conversationsStore.currentWorkspacePath` 与 `WorkspaceSelector` 本地第三源;后端去掉 `currentWorkspacePath` 持久化,会话写接口改必传 `workspacePath`,从根上消除「Sender 显示工作区」与「会话实际归属」不一致的 bug。
+
+**Architecture:** workspaceStore 顶层新增 `currentWorkspacePath` 字段(前端派生 + 显式设置),后端 `ListWorkspacesData` 不再回传该字段。新增统一入口 `activateWorkspace(path)` 封装「workspaceStore 已更新当前路径后,同步会话分片缓存到该路径」的成对操作,所有切换/新增/删除场景调用它,避免闭包陷阱与手动拼装遗漏。`conversationsStore` 删除 `currentWorkspacePath`,需要当前路径时跨 store 从 `useWorkspaceStore.getState().currentWorkspacePath` 读取。后端 `createConversation`/`startTurn`/`clearWorkspaceConversations` 的 `workspacePath` 改必传,`listConversations` 未传时语义改为跨工作区全量查询,删除 `getCurrentWorkspacePath()` 方法与 RPC 端点。
+
+**Tech Stack:** TypeScript、Zustand、Immer、Vitest、Zod、React Testing Library;前端 `apps/web`,后端 workspace packages `app-data`/`app-runtime`/`agent-runtime`/`shared`。
+
+## Global Constraints
+
+- 单 PR 完成;前端 store/action/组件与后端 service/runtime/rpc 同步改,不留双源或前后端不一致。
+- 所有对话、注释、UI 文案、提交信息使用中文;代码用 JSDoc 注释「为什么」。
+- TypeScript-first,导出 API 显式标注类型;2 空格缩进;LF 行尾。
+- 导入顺序(@antfu/eslint-config):`@ant-chat/*` workspace 包优先,其次外部包,最后相对导入。
+- 测试框架 Vitest;行为导向,mock 系统边界(HTTP/IPC/文件系统),不 mock 内部 store/repository 模块。
+- 每步运行 `pnpm check`(type-check + lint + unit tests),一次性修复所有错误再提交;后端接口签名变更会触发 `tsc -b` 跨包报错,据此定位调用点。
+- `searchFiles` 端点入参加 `workspacePath: string` 必传(用户决策);`parseConfig` 容忍并忽略旧 `currentWorkspacePath` 字段(用户决策),`ensureInitialized` 派生只依赖 `workspaces` 列表的 `lastOpenedAt`。
+- 提交前必须本地运行 `pnpm check` 全量通过。
+
+---
+
+## File Structure
+
+### 后端(packages)
+
+- **`packages/shared/src/interfaces/workspace.ts`**:`WorkspaceConfig` 删 `currentWorkspacePath` 字段;`ListWorkspacesData` 删 `currentWorkspacePath` 字段。
+- **`packages/shared/src/interfaces/app-rpc.ts`**:删 `workspace.getCurrentWorkspacePath` 端点;`workspace.searchWorkspaceFiles` 入参加 `workspacePath: string` 必传。
+- **`packages/shared/src/interfaces/agent-runtime-electron.ts`**:`StartAgentTurnOptions.workspacePath` 从可选改必传 `string`。
+- **`packages/shared/src/ipc-events.ts`**:`workspace:changed` 事件 payload 删 `currentWorkspacePath`。
+- **`packages/app-data/src/workspace/workspaceService.ts`**:`WorkspaceConfig` 不再持久化 `currentWorkspacePath`;删除 `getCurrentWorkspacePath()` 方法;`ensureInitialized`/`addWorkspace`/`openWorkspace`/`removeWorkspace`/`listWorkspaces` 对齐;`parseConfig` 容忍忽略旧字段。
+- **`packages/app-runtime/src/appRuntime.ts`**:`createConversation`/`clearWorkspaceConversations` 的 `workspacePath` 改必传;`listConversations` 未传 = 全量查询;`searchFiles` 入参改必传;删除 `workspace.getCurrentPath`;`emitWorkspaceResult` 事件 payload 删 `currentWorkspacePath`。
+- **`packages/app-runtime/src/rpcHandlers.ts`**:删 `workspace.getCurrentWorkspacePath` handler;`workspace.searchWorkspaceFiles` 传 `workspacePath`。
+- **`packages/agent-runtime/src/agentTurnService.ts`**:`startTurn` 的 `workspacePath` 改必传,删兜底。
+
+### 前端(apps/web)
+
+- **`apps/web/src/store/workspace/store.ts`**:新增顶层 `currentWorkspacePath` 字段;`refresh`/`openWorkspace`/`addWorkspace`/`removeWorkspace` 显式设置/派生该字段。
+- **`apps/web/src/store/conversation/initialState.ts`**:`StoreState` 与 `createInitialState` 删 `currentWorkspacePath`。
+- **`apps/web/src/store/conversation/conversationsStore.ts`**:新增 `getCurrentWorkspacePath()` helper;`switchWorkspace` 重命名 `switchWorkspaceSlice`,key 跨 store 取;`reset`/`saveCurrentWorkspaceSlice` 对齐。
+- **`apps/web/src/store/conversation/actions.ts`**:新增 `activateWorkspace(path)`;删 `switchWorkspaceConversationsAction`;`clearConversationsAction`/`nextPageConversationsAction` 跨 store 取路径与竞态守护。
+- **`apps/web/src/components/Workspace/WorkspacePanels.tsx`**:删 `reloadCurrentWorkspace` 与本地派生;调用点改 `activateWorkspace`。
+- **`apps/web/src/components/Workspace/WorkspaceSelector.tsx`**:删本地 `useReducer`/`applyWorkspaceData`;直接走 workspaceStore action + `activateWorkspace`。
+- **`apps/web/src/components/Chat/Chat.tsx`**:`currentWorkspacePath` 改读 workspaceStore。
+- **`apps/web/src/components/Sender/Sender.tsx`**:显示工作区名读 workspaceStore 顶层字段;`handleSwitchWorkspace` 改 `activateWorkspace`;`searchWorkspaceFiles` 调用传 `currentWorkspacePath`。
+- **`apps/web/src/api/workspaceApi.ts`**:`searchWorkspaceFiles` 签名加 `workspacePath`。
+- **`apps/web/src/hooks/useBuiltinCommandSubmit.ts`**:无逻辑改动,仅因 `Chat.tsx` 传入源变更而确认入参类型不变(`currentWorkspacePath?: string` 保留)。
+
+### 测试文件(更新)
+
+- **`packages/app-runtime/src/__tests__/appRuntime.spec.ts`**:改 `createConversation`/`clearWorkspaceConversations` 必传;`workspace:changed` 事件 payload 断言改空对象;`searchFiles` 传 `workspacePath`。
+- **`packages/local-server/src/__tests__/server.spec.ts`**:`workspace:changed` SSE payload 断言改为空对象。
+- **`packages/agent-runtime/src/__tests__/agentService.spec.ts`**:删除 mock 中 `getCurrentWorkspacePath`(必传后不再调用);确认所有 `startTurn` 已传 `workspacePath`。
+- **`apps/web/src/__tests__/gui.spec.tsx`**:`seedActiveConversation`/`beforeEach` 改用 workspaceStore set `currentWorkspacePath`;`listWorkspaces` mock 返回删 `currentWorkspacePath`。
+- **`apps/web/src/components/Sender/__tests__/Sender.spec.tsx`**:`listWorkspaces` mock 与 `useConversationsStore.setState` 删 `currentWorkspacePath`;`searchWorkspaceFiles` mock 断言加 `workspacePath`;改用 workspaceStore 设置当前路径。
+- **新增**`apps/web/src/store/workspace/__tests__/store.spec.ts`:workspaceStore 派生与显式设置行为测试。
+- **新增**`apps/web/src/store/conversation/__tests__/activateWorkspace.spec.ts`:`activateWorkspace` 行为测试。
+
+---
+
+## Task 1: 后端 shared 接口 — 删 currentWorkspacePath 字段与端点,searchFiles 入参必传
+
+**Files:**
+- Modify: `packages/shared/src/interfaces/workspace.ts:1-20`
+- Modify: `packages/shared/src/interfaces/app-rpc.ts:105-113`
+- Modify: `packages/shared/src/interfaces/agent-runtime-electron.ts:8-21`
+- Modify: `packages/shared/src/ipc-events.ts:65-75`
+- Test: `packages/shared/src/interfaces/__tests__/workspace-types.spec.ts`(新增,类型与运行时事件 payload 行为)
+
+**Interfaces:**
+- Consumes: 无(起始任务)
+- Produces:
+  - `WorkspaceConfig { workspaces: Array<{ path, addedAt, lastOpenedAt? }> }`(无 `currentWorkspacePath`)
+  - `ListWorkspacesData { workspaces: WorkspaceItem[] }`(无 `currentWorkspacePath`)
+  - `StartAgentTurnOptions.workspacePath: string`(必传)
+  - `AppRendererEvents['workspace:changed'] = Record<string, never>`(空 payload)
+  - `workspace.searchWorkspaceFiles` 端点入参 `{ workspacePath: string, query?: string, limit?: number }`
+
+> 类型层面的破坏性改动会让 `tsc -b` 在下游包(app-data/app-runtime/agent-runtime/apps/web)报错,后续任务逐一修复。本任务只改 shared 类型与事件定义,先让类型变更落地。
+
+- [ ] **Step 1: 写失败测试 — 事件 payload 不再含 currentWorkspacePath**
+
+创建 `packages/shared/src/interfaces/__tests__/workspace-types.spec.ts`:
+
+```ts
+import { APP_RENDERER_EVENT_NAMES } from '../ipc-events'
+import type { AppRendererEvents } from '../ipc-events'
+import type { ListWorkspacesData, WorkspaceConfig } from '../workspace'
+import { describe, expect, it } from 'vitest'
+
+describe('workspace shared types', () => {
+  it('ListWorkspacesData 不再含 currentWorkspacePath', () => {
+    const data: ListWorkspacesData = { workspaces: [] }
+    // 类型断言:该字段已不存在,访问应报类型错误(运行时此断言恒真,仅作占位)
+    expect(data).not.toHaveProperty('currentWorkspacePath')
+  })
+
+  it('WorkspaceConfig 不再含 currentWorkspacePath', () => {
+    const config: WorkspaceConfig = { workspaces: [] }
+    expect(config).not.toHaveProperty('currentWorkspacePath')
+  })
+
+  it('workspace:changed 事件名仍在注册表且 payload 为空', () => {
+    expect(APP_RENDERER_EVENT_NAMES).toContain('workspace:changed')
+    // payload 类型为空对象:无法合法携带 currentWorkspacePath
+    const payload: AppRendererEvents['workspace:changed'] = {}
+    expect(payload).toEqual({})
+  })
+})
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `pnpm --filter @ant-chat/shared test -- workspace-types`
+Expected: FAIL —— `ListWorkspacesData` 当前含 `currentWorkspacePath`,但断言 `not.toHaveProperty` 对类型未删的运行时对象可能通过;真正失败来自类型 `WorkspaceConfig` 仍要求/允许该字段。若运行时通过而类型未改,需在 Step 3 删字段后用 `tsc -b` 验证类型错误消除。先记录当前状态,继续。
+
+> 注:此测试主要作为类型契约的回归守卫。Step 3 删字段后,旧代码 `workspaceService.ts` 等会因引用 `currentWorkspacePath` 产生 `tsc -b` 报错,后续任务修复。
+
+- [ ] **Step 3: 删 workspace.ts 字段**
+
+编辑 `packages/shared/src/interfaces/workspace.ts`:
+
+```ts
+export interface WorkspaceConfig {
+  workspaces: Array<{
+    path: string
+    addedAt: number
+    lastOpenedAt?: number
+  }>
+}
+
+export interface WorkspaceItem {
+  path: string
+  displayName: string
+  isDefault: boolean
+  lastOpenedAt?: number
+}
+
+export interface ListWorkspacesData {
+  workspaces: WorkspaceItem[]
+}
+```
+
+(删除 `WorkspaceConfig.currentWorkspacePath?: string` 与 `ListWorkspacesData.currentWorkspacePath: string`。)
+
+- [ ] **Step 4: 删 app-rpc.ts 端点 + searchFiles 入参必传**
+
+编辑 `packages/shared/src/interfaces/app-rpc.ts`:
+
+将第 113 行:
+```ts
+  'workspace.searchWorkspaceFiles': RpcEndpoint<{ query?: string, limit?: number } | undefined, WorkspaceFileSearchResult[]>
+```
+改为:
+```ts
+  'workspace.searchWorkspaceFiles': RpcEndpoint<{ workspacePath: string, query?: string, limit?: number }, WorkspaceFileSearchResult[]>
+```
+
+删除第 109 行:
+```ts
+  'workspace.getCurrentWorkspacePath': RpcEndpoint<undefined, string>
+```
+
+- [ ] **Step 5: StartAgentTurnOptions.workspacePath 改必传**
+
+编辑 `packages/shared/src/interfaces/agent-runtime-electron.ts`,将:
+```ts
+  workspacePath?: string
+```
+改为:
+```ts
+  workspacePath: string
+```
+
+- [ ] **Step 6: workspace:changed 事件 payload 改空**
+
+编辑 `packages/shared/src/ipc-events.ts`,将第 71 行:
+```ts
+  'workspace:changed': { currentWorkspacePath: string }
+```
+改为:
+```ts
+  'workspace:changed': Record<string, never>
+```
+
+- [ ] **Step 7: 运行 shared 包测试 + 类型检查**
+
+Run: `pnpm --filter @ant-chat/shared test && pnpm --filter @ant-chat/shared exec tsc --noEmit`
+Expected: shared 包测试 PASS(含新 workspace-types.spec)。`tsc --noEmit` 在 shared 包内 PASS。**注意**:`pnpm type-check`(全仓 `tsc -b`)此时会在 app-data/app-runtime/agent-runtime/apps/web 报错,因为它们仍引用已删字段——这是预期,后续任务修复。本步只确认 shared 包自身通过。
+
+- [ ] **Step 8: 提交**
+
+```bash
+git add packages/shared/src/interfaces/workspace.ts packages/shared/src/interfaces/app-rpc.ts packages/shared/src/interfaces/agent-runtime-electron.ts packages/shared/src/ipc-events.ts packages/shared/src/interfaces/__tests__/workspace-types.spec.ts
+git commit -m "refactor(shared): 删除 currentWorkspacePath 字段与端点,searchFiles 入参加 workspacePath 必传"
+```
+
+---
+
+## Task 2: 后端 workspaceService — 删持久化与方法,ensureInitialized 按 lastOpenedAt 派生
+
+**Files:**
+- Modify: `packages/app-data/src/workspace/workspaceService.ts:1-304`
+- Test: `packages/app-data/src/workspace/__tests__/workspaceService.spec.ts`(扩展现有文件)
+
+**Interfaces:**
+- Consumes: Task 1 的 `WorkspaceConfig`(无 `currentWorkspacePath`)、`ListWorkspacesData`(无 `currentWorkspacePath`)。
+- Produces:
+  - `WorkspaceService.listWorkspaces(): ListWorkspacesData`(只返回 `workspaces`)
+  - `WorkspaceService.addWorkspace(path)`/`openWorkspace(path)`/`removeWorkspace(path)`:只更新 `workspaces` 列表与 `lastOpenedAt`,不再写 `currentWorkspacePath`
+  - `ensureInitialized()`:派生逻辑只依赖 `workspaces`,保证默认工作区在列表中
+  - 删除 `getCurrentWorkspacePath()` 方法
+  - `parseConfig`:容忍并忽略旧 `currentWorkspacePath` 字段
+
+- [ ] **Step 1: 写失败测试 — listWorkspaces 不含 currentWorkspacePath,持久化只存 workspaces**
+
+在 `packages/app-data/src/workspace/__tests__/workspaceService.spec.ts` 顶部追加导入与测试(保留现有 `computeDisplayNames` 测试):
+
+```ts
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { WorkspaceService } from '../workspaceService'
+
+describe('workspaceService currentWorkspacePath 整合', () => {
+  let configPath: string
+  let service: WorkspaceService
+
+  beforeEach(() => {
+    configPath = path.join(mkdtempSync(path.join(tmpdir(), 'ant-chat-ws-')), 'workspace.json')
+    service = new WorkspaceService({ filePath: configPath })
+  })
+
+  afterEach(() => {
+    rmSync(path.dirname(configPath), { force: true, recursive: true })
+  })
+
+  it('listWorkspaces 不再返回 currentWorkspacePath', () => {
+    const data = service.listWorkspaces()
+    expect(data).not.toHaveProperty('currentWorkspacePath')
+    expect(data.workspaces.length).toBeGreaterThan(0)
+  })
+
+  it('addWorkspace 后配置文件只持久化 workspaces,不含 currentWorkspacePath', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'ant-chat-ws-added-'))
+    try {
+      service.addWorkspace(dir)
+      const raw = JSON.parse(readFileSync(configPath, 'utf8')) as Record<string, unknown>
+      expect(raw).not.toHaveProperty('currentWorkspacePath')
+      expect(Array.isArray(raw.workspaces)).toBe(true)
+    }
+    finally {
+      rmSync(dir, { force: true, recursive: true })
+    }
+  })
+
+  it('openWorkspace 只更新 lastOpenedAt,不写 currentWorkspacePath', () => {
+    const list = service.listWorkspaces()
+    const target = list.workspaces[0]
+    service.openWorkspace(target.path)
+    const raw = JSON.parse(readFileSync(configPath, 'utf8')) as Record<string, unknown>
+    expect(raw).not.toHaveProperty('currentWorkspacePath')
+    const opened = (raw.workspaces as Array<{ path: string, lastOpenedAt?: number }>)
+      .find(item => item.path === target.path)
+    expect(opened?.lastOpenedAt).toBeTypeOf('number')
+  })
+
+  it('removeWorkspace 删除当前工作区后配置仍不含 currentWorkspacePath', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'ant-chat-ws-rm-'))
+    try {
+      service.addWorkspace(dir)
+      service.removeWorkspace(dir)
+      const raw = JSON.parse(readFileSync(configPath, 'utf8')) as Record<string, unknown>
+      expect(raw).not.toHaveProperty('currentWorkspacePath')
+    }
+    finally {
+      rmSync(dir, { force: true, recursive: true })
+    }
+  })
+
+  it('读取含旧 currentWorkspacePath 字段的配置文件时容忍并忽略该字段', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'ant-chat-ws-legacy-'))
+    try {
+      // 先正常添加,再手写一个含旧字段的配置
+      service.addWorkspace(dir)
+      const legacy = {
+        currentWorkspacePath: dir,
+        workspaces: [
+          { path: dir, addedAt: 1, lastOpenedAt: 2 },
+        ],
+      }
+      require('node:fs').writeFileSync(configPath, JSON.stringify(legacy))
+
+      // 重新创建 service 读取旧配置,不应抛错
+      const legacyService = new WorkspaceService({ filePath: configPath })
+      const data = legacyService.listWorkspaces()
+      expect(data).not.toHaveProperty('currentWorkspacePath')
+      expect(data.workspaces.some(item => item.path === dir)).toBe(true)
+    }
+    finally {
+      rmSync(dir, { force: true, recursive: true })
+    }
+  })
+})
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `pnpm --filter @ant-chat/app-data test -- workspaceService`
+Expected: FAIL —— `listWorkspaces` 仍返回 `currentWorkspacePath`,配置文件仍写该字段。
+
+- [ ] **Step 3: 改 workspaceService.ts — 删字段持久化与 getCurrentWorkspacePath 方法**
+
+编辑 `packages/app-data/src/workspace/workspaceService.ts`:
+
+(a) `ensureInitialized`(行 41-75)改为:
+```ts
+  ensureInitialized(): WorkspaceConfig {
+    fs.mkdirSync(this.getDefaultWorkspacePath(), { recursive: true })
+    const defaultPath = this.normalizeExistingDirectory(this.getDefaultWorkspacePath())
+
+    const current = this.getConfig()
+    const normalizedWorkspaces = current.workspaces
+      .map((item) => {
+        try {
+          return {
+            ...item,
+            path: this.normalizeExistingDirectory(item.path),
+          }
+        }
+        catch {
+          return null
+        }
+      })
+      .filter(item => item !== null)
+
+    const existsDefault = normalizedWorkspaces.some(item => item.path === defaultPath)
+    const workspaces = existsDefault
+      ? normalizedWorkspaces
+      : [{ path: defaultPath, addedAt: Date.now(), lastOpenedAt: Date.now() }, ...normalizedWorkspaces]
+
+    const next = { workspaces: this.dedupeWorkspaces(workspaces) }
+    this.saveConfig(next)
+    return next
+  }
+```
+(删除 `currentWorkspacePath` 的校验与回填逻辑。)
+
+(b) `listWorkspaces`(行 77-83)改为:
+```ts
+  listWorkspaces(): ListWorkspacesData {
+    const config = this.ensureInitialized()
+    return {
+      workspaces: this.toWorkspaceItems(config.workspaces),
+    }
+  }
+```
+
+(c) `addWorkspace`(行 85-103),将 `saveConfig` 调用改为:
+```ts
+    const now = Date.now()
+    this.saveConfig({
+      workspaces: [
+        ...config.workspaces,
+        { path: normalizedPath, addedAt: now, lastOpenedAt: now },
+      ],
+    })
+```
+(删除 `currentWorkspacePath: normalizedPath`。)
+
+(d) `removeWorkspace`(行 105-121),将 `saveConfig` 调用改为:
+```ts
+    this.saveConfig({
+      workspaces: nextWorkspaces,
+    })
+```
+(删除 `currentWorkspacePath: ...` 整行。)
+
+(e) `openWorkspace`(行 123-138),将 `saveConfig` 调用改为:
+```ts
+    const now = Date.now()
+    this.saveConfig({
+      workspaces: config.workspaces.map(item => item.path === normalizedPath ? { ...item, lastOpenedAt: now } : item),
+    })
+```
+(删除 `currentWorkspacePath: normalizedPath`。)
+
+(f) 删除 `getCurrentWorkspacePath` 方法(行 140-143):
+```ts
+  getCurrentWorkspacePath(): string {
+    const config = this.ensureInitialized()
+    return config.currentWorkspacePath || this.getDefaultWorkspacePath()
+  }
+```
+整段删除。
+
+(g) `parseConfig`(行 230-266),将末尾 return 与校验改为:
+```ts
+    // 兼容旧配置文件中残留的 currentWorkspacePath 字段:忽略不解析
+    return {
+      workspaces,
+    }
+```
+删除 `if (record.currentWorkspacePath !== undefined && typeof record.currentWorkspacePath !== 'string')` 校验块(行 258-260)与 return 中的 `currentWorkspacePath: record.currentWorkspacePath`。
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `pnpm --filter @ant-chat/app-data test -- workspaceService`
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add packages/app-data/src/workspace/workspaceService.ts packages/app-data/src/workspace/__tests__/workspaceService.spec.ts
+git commit -m "refactor(app-data): workspaceService 去掉 currentWorkspacePath 持久化与方法,按 lastOpenedAt 派生"
+```
+
+---
+
+## Task 3: 后端 appRuntime — 会话接口读写区分语义,searchFiles 必传,删 getCurrentPath
+
+**Files:**
+- Modify: `packages/app-runtime/src/appRuntime.ts:140-200,360-375,434-437`
+- Modify: `packages/app-runtime/src/rpcHandlers.ts:80,84`
+- Test: `packages/app-runtime/src/__tests__/appRuntime.spec.ts:34-83`
+
+**Interfaces:**
+- Consumes: Task 1 的 RPC 契约(`chat.clearWorkspaceConversations` 已声明 `workspacePath: string` 必传;`workspace.searchWorkspaceFiles` 入参含 `workspacePath`;`workspace.getCurrentWorkspacePath` 端点已删)。Task 2 的 `WorkspaceService`(无 `getCurrentWorkspacePath`)。
+- Produces:
+  - `runtime.chat.createConversation(conversation)`:要求 `conversation.workspacePath` 必传非空,否则抛 `workspacePath is required`
+  - `runtime.chat.listConversations(pageIndex, pageSize, workspacePath?)`:未传 `workspacePath` = 跨工作区全量查询(`getWorkspaceWhere` 返回空 WHERE,含 `workspace_path IS NULL`);传了 = 按路径筛选;删除 `includeNullWorkspace` 的默认工作区特判
+  - `runtime.chat.clearWorkspaceConversations(workspacePath)`:必传,无兜底
+  - `runtime.workspace.searchFiles(workspacePath, query?, limit?)`:`workspacePath` 必传
+  - 删除 `runtime.workspace.getCurrentPath`
+  - `emitWorkspaceResult`:`workspace:changed` 事件 payload 为空对象
+
+- [ ] **Step 1: 写失败测试 — createConversation 必传、listConversations 全量语义、事件 payload 空**
+
+替换 `packages/app-runtime/src/__tests__/appRuntime.spec.ts` 中三个测试(行 34-83):
+
+```ts
+  it('createConversation 必传 workspacePath,未传时抛错', async () => {
+    await expect(runtime.chat.createConversation({
+      title: 'no workspace',
+      createdAt: 1,
+      updatedAt: 1,
+      settings: { modelId: 'model-1', providerId: 'provider-1', systemPrompt: '', temperature: 0.7, maxTokens: 1024 },
+    } as any)).rejects.toThrow('workspacePath is required')
+  })
+
+  it('createConversation 传入 workspacePath 时归属该工作区', async () => {
+    const workspacePath = runtime.workspace.getDefaultPath()
+    const conversation = await runtime.chat.createConversation({
+      title: 'explicit workspace',
+      createdAt: 1,
+      updatedAt: 1,
+      workspacePath,
+      settings: { modelId: 'model-1', providerId: 'provider-1', systemPrompt: '', temperature: 0.7, maxTokens: 1024 },
+    })
+
+    expect(conversation.workspacePath).toBe(workspacePath)
+    const result = await runtime.chat.listConversations(0, 20, workspacePath)
+    expect(result.data).toEqual([expect.objectContaining({ id: conversation.id, workspacePath })])
+  })
+
+  it('listConversations 未传 workspacePath 时返回跨工作区全量', async () => {
+    const defaultPath = runtime.workspace.getDefaultPath()
+    await runtime.chat.createConversation({
+      title: 'in default',
+      createdAt: 1,
+      updatedAt: 1,
+      workspacePath: defaultPath,
+      settings: { modelId: 'm', providerId: 'p', systemPrompt: '', temperature: 0.7, maxTokens: 1024 },
+    })
+
+    const result = await runtime.chat.listConversations(0, 100)
+
+    // 全量查询:不依赖 currentWorkspacePath 兜底,返回所有会话
+    expect(result.total).toBeGreaterThanOrEqual(1)
+  })
+
+  it('workspace:changed 事件 payload 为空对象', async () => {
+    const workspaceEvents: Record<string, never>[] = []
+    runtime.events.on('workspace:changed', event => workspaceEvents.push(event))
+
+    const workspace = runtime.workspace.list().workspaces[0]
+    runtime.workspace.open(workspace.path)
+
+    expect(workspaceEvents).toEqual([{}])
+  })
+
+  it('clearWorkspaceConversations 必传 workspacePath', async () => {
+    const defaultPath = runtime.workspace.getDefaultPath()
+    await runtime.chat.createConversation({
+      title: 'to clear',
+      createdAt: 1,
+      updatedAt: 1,
+      workspacePath: defaultPath,
+      settings: { modelId: 'm', providerId: 'p', systemPrompt: '', temperature: 0.7, maxTokens: 1024 },
+    })
+
+    await expect(runtime.chat.clearWorkspaceConversations(undefined as any)).rejects.toThrow('workspacePath is required')
+
+    const deletedIds = await runtime.chat.clearWorkspaceConversations(defaultPath)
+    expect(deletedIds.length).toBe(1)
+  })
+
+  it('searchFiles 必传 workspacePath', async () => {
+    const defaultPath = runtime.workspace.getDefaultPath()
+    const results = await runtime.workspace.searchFiles(defaultPath, '', 10)
+    expect(Array.isArray(results)).toBe(true)
+  })
+```
+
+> 注:删除原 `it('applies the current workspace...')`(行 34-58)、`it('emits domain events...')`(行 60-72)、`it('clears all conversations...')`(行 74-83)三个测试,由上述五个替换。`runtime.workspace.getCurrentPath()` 调用全部移除。
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `pnpm --filter @ant-chat/app-runtime test -- appRuntime`
+Expected: FAIL —— 当前 `createConversation` 仍兜底不抛错;事件 payload 仍含 `currentWorkspacePath`;`searchFiles` 签名仍不含 `workspacePath`。
+
+- [ ] **Step 3: 改 appRuntime.ts — listConversations 全量语义**
+
+编辑 `packages/app-runtime/src/appRuntime.ts` 行 152-156,改为:
+```ts
+      listConversations: async (pageIndex: number, pageSize: number, workspacePath?: string) => {
+        // 未传 workspacePath = 跨工作区全量查询(含 workspace_path IS NULL);
+        // 传了 = 按该路径筛选。不再用 currentWorkspacePath 兜底。
+        return await context.conversationRepository.list(pageIndex, pageSize, workspacePath, false)
+      },
+```
+(删除 `getCurrentWorkspacePath()` 兜底与 `includeNullWorkspace` 的默认工作区特判;`includeNullWorkspace` 固定 `false`,由调用方显式决定是否纳入 null 工作区——本任务简化为常参 `false`,保留 repository 的 `includeNullWorkspace` 参数能力。)
+
+- [ ] **Step 4: 改 appRuntime.ts — createConversation 必传**
+
+编辑行 158-165,改为:
+```ts
+      createConversation: async (conversation: AddConversationsSchema) => {
+        if (!conversation.workspacePath) {
+          throw new Error('workspacePath is required')
+        }
+        const result = await context.conversationRepository.create({
+          ...conversation,
+          workspacePath: conversation.workspacePath,
+        })
+        events.emit('conversation:updated', { conversation: result })
+        return result
+      },
+```
+
+- [ ] **Step 5: 改 appRuntime.ts — clearWorkspaceConversations 必传**
+
+编辑行 176-192,改为:
+```ts
+      clearWorkspaceConversations: async (workspacePath: string) => {
+        if (!workspacePath) {
+          throw new Error('workspacePath is required')
+        }
+        const targetWorkspace = workspacePath
+
+        const listResult = await context.conversationRepository.list(0, Number.MAX_SAFE_INTEGER, targetWorkspace, false)
+        const targetIds = listResult.data.map(c => c.id)
+
+        if (targetIds.length === 0) {
+          return []
+        }
+
+        for (const id of targetIds) {
+          await agentRuntime.closeConversation(id)
+        }
+
+        return await context.conversationRepository.deleteByWorkspace(targetWorkspace, false)
+      },
+```
+
+- [ ] **Step 6: 改 appRuntime.ts — searchFiles 必传 + 删 getCurrentPath**
+
+编辑行 362-375 `workspace` 对象,改为:
+```ts
+    workspace: {
+      list: () => context.workspaceService.listWorkspaces(),
+      add: (path: string) => emitWorkspaceResult(context.workspaceService.addWorkspace(path)),
+      remove: (path: string) => emitWorkspaceResult(context.workspaceService.removeWorkspace(path)),
+      open: (path: string) => emitWorkspaceResult(context.workspaceService.openWorkspace(path)),
+      getDefaultPath: () => context.workspaceService.getDefaultWorkspacePath(),
+      listDirectories: (path?: string) => context.workspaceService.listDirectories(path),
+      createDirectory: (parentPath: string, name: string) => context.workspaceService.createDirectory(parentPath, name),
+      searchFiles: async (workspacePath: string, query = '', limit = 50) => {
+        if (!workspacePath) {
+          throw new Error('workspacePath is required')
+        }
+        return await searchWorkspaceFiles(workspacePath, query, limit)
+      },
+    },
+```
+(删除 `getCurrentPath: () => context.workspaceService.getCurrentWorkspacePath()`;`searchFiles` 第一参 `workspacePath` 必传,删 `getCurrentWorkspacePath()` 兜底。)
+
+- [ ] **Step 7: 改 appRuntime.ts — emitWorkspaceResult 事件 payload 空**
+
+编辑行 434-437,改为:
+```ts
+  function emitWorkspaceResult(result: ReturnType<typeof context.workspaceService.listWorkspaces>) {
+    events.emit('workspace:changed', {})
+    return result
+  }
+```
+
+- [ ] **Step 8: 改 rpcHandlers.ts — 删 getCurrentWorkspacePath handler,searchFiles 传 workspacePath**
+
+编辑 `packages/app-runtime/src/rpcHandlers.ts`:
+
+删除行 80:
+```ts
+    'workspace.getCurrentWorkspacePath': () => runtime.workspace.getCurrentPath(),
+```
+
+将行 84:
+```ts
+    'workspace.searchWorkspaceFiles': input => runtime.workspace.searchFiles(input?.query, input?.limit),
+```
+改为:
+```ts
+    'workspace.searchWorkspaceFiles': input => runtime.workspace.searchFiles(input.workspacePath, input?.query, input?.limit),
+```
+
+- [ ] **Step 9: 运行 app-runtime 测试确认通过**
+
+Run: `pnpm --filter @ant-chat/app-runtime test -- appRuntime`
+Expected: PASS。
+
+- [ ] **Step 10: 提交**
+
+```bash
+git add packages/app-runtime/src/appRuntime.ts packages/app-runtime/src/rpcHandlers.ts packages/app-runtime/src/__tests__/appRuntime.spec.ts
+git commit -m "refactor(app-runtime): 会话接口读写区分语义,searchFiles 必传 workspacePath,删除 getCurrentPath"
+```
+
+---
+
+## Task 4: 后端 agentTurnService — startTurn 必传 workspacePath
+
+**Files:**
+- Modify: `packages/agent-runtime/src/agentTurnService.ts:1-60`
+- Test: `packages/agent-runtime/src/__tests__/agentService.spec.ts:60-70`
+
+**Interfaces:**
+- Consumes: Task 1 的 `StartAgentTurnOptions.workspacePath: string`(必传)。Task 2 的 `WorkspaceService`(无 `getCurrentWorkspacePath`)。
+- Produces: `startTurn(options)` 要求 `options.workspacePath` 非空,不再兜底 `process.cwd()`。
+
+- [ ] **Step 1: 写失败测试 — startTurn 未传 workspacePath 抛错**
+
+在 `packages/agent-runtime/src/__tests__/agentService.spec.ts` 的 `describe` 内追加(找到现有 `it('保留显式传入的 turn 上下文字段')` 附近):
+
+```ts
+  it('startTurn 未传 workspacePath 时抛错,不再兜底 process.cwd()', async () => {
+    const service = createAgentRuntimeController(runtime, appDataContext, { aiProviderFactory })
+    await expect(service.startTurn({
+      prompt: 'inspect',
+      modelConfig: {
+        modelId: 'model-1',
+        providerId: 'provider-1',
+        systemPrompt: 'custom',
+        temperature: 0.2,
+        maxTokens: 2048,
+        features: { enableMCP: false },
+      },
+    } as any)).rejects.toThrow('workspacePath is required')
+  })
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `pnpm --filter @ant-chat/agent-runtime test -- agentService`
+Expected: FAIL —— 当前 `startTurn` 用 `?? getCurrentWorkspacePath() ?? process.cwd()` 兜底,不抛错。
+
+- [ ] **Step 3: 改 agentTurnService.ts — workspacePath 必传**
+
+编辑 `packages/agent-runtime/src/agentTurnService.ts`:
+
+(a) 删除顶部 `import process from 'node:process'`(行 11),不再需要。
+
+(b) 将行 38-40:
+```ts
+      const workspacePath = options.workspacePath
+        ?? appDataContext.workspaceService.getCurrentWorkspacePath()
+        ?? process.cwd()
+```
+改为:
+```ts
+      const workspacePath = options.workspacePath
+      if (!workspacePath) {
+        throw new Error('workspacePath is required')
+      }
+```
+
+- [ ] **Step 4: 清理 agentService.spec.ts mock 中的 getCurrentWorkspacePath**
+
+编辑 `packages/agent-runtime/src/__tests__/agentService.spec.ts` 行 66,删除:
+```ts
+    getCurrentWorkspacePath: vi.fn(() => '/workspace'),
+```
+(必传后该 mock 不再被调用;删除避免误导。确认其余 `startTurn` 调用均显式传 `workspacePath`——行 39/122/144/164 等已传,无需改。)
+
+- [ ] **Step 5: 运行 agent-runtime 测试确认通过**
+
+Run: `pnpm --filter @ant-chat/agent-runtime test -- agentService`
+Expected: PASS。
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add packages/agent-runtime/src/agentTurnService.ts packages/agent-runtime/src/__tests__/agentService.spec.ts
+git commit -m "refactor(agent-runtime): startTurn 必传 workspacePath,删除 getCurrentWorkspacePath 兜底"
+```
+
+---
+
+## Task 5: 后端 local-server 测试 — workspace:changed SSE payload 空
+
+**Files:**
+- Modify: `packages/local-server/src/__tests__/server.spec.ts:96-103`
+
+**Interfaces:**
+- Consumes: Task 3 的 `workspace:changed` 事件 payload 为空对象。
+- Produces: 无(仅测试对齐)。
+
+- [ ] **Step 1: 改测试 — SSE payload 断言改为空对象**
+
+编辑 `packages/local-server/src/__tests__/server.spec.ts` 行 96-103:
+```ts
+  it('通过 SSE 推送运行时事件', async () => {
+    const payload = await readSseEvent('workspace:changed', () => {
+      eventEmitter.emit('workspace:changed', {})
+    })
+
+    expect(payload).toContain('event: workspace:changed')
+    expect(payload).toContain('data: {}')
+  })
+```
+
+- [ ] **Step 2: 运行 local-server 测试确认通过**
+
+Run: `pnpm --filter @ant-chat/local-server test -- server`
+Expected: PASS。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add packages/local-server/src/__tests__/server.spec.ts
+git commit -m "test(local-server): workspace:changed SSE payload 对齐为空对象"
+```
+
+---
+
+## Task 6: 前端 workspaceStore — 新增顶层 currentWorkspacePath SSOT 字段与派生
+
+**Files:**
+- Modify: `apps/web/src/store/workspace/store.ts:1-59`
+- Test: `apps/web/src/store/workspace/__tests__/store.spec.ts`(新增)
+
+**Interfaces:**
+- Consumes: Task 1 的 `ListWorkspacesData`(无 `currentWorkspacePath`,只含 `workspaces`)。`workspaceApi.listWorkspaces`/`addWorkspace`/`openWorkspace`/`removeWorkspace`(返回 `ListWorkspacesData`)。
+- Produces:
+  - `WorkspaceStoreState.currentWorkspacePath: string`(顶层 SSOT,初始 `''`)
+  - `refresh()`:拉 `workspaces` 后,若 `currentWorkspacePath` 为空或不在列表中,取 `lastOpenedAt` 最大者为当前;列表为空时取 `''`(由后端 `ensureInitialized` 保证默认工作区在列表,实际不为空)
+  - `openWorkspace(path)`/`addWorkspace(path)`:`set({ workspaceData, currentWorkspacePath: path })`
+  - `removeWorkspace(path)`:若删的是当前工作区,`currentWorkspacePath` 回退到 `workspaces` 中 `lastOpenedAt` 最大者;否则保持
+  - `workspaceData: ListWorkspacesData | null`(只含 `workspaces`)
+
+- [ ] **Step 1: 写失败测试 — 派生与显式设置行为**
+
+创建 `apps/web/src/store/workspace/__tests__/store.spec.ts`:
+
+```ts
+import type { ListWorkspacesData } from '@ant-chat/shared'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  listWorkspaces: vi.fn(),
+  addWorkspace: vi.fn(),
+  openWorkspace: vi.fn(),
+  removeWorkspace: vi.fn(),
+}))
+
+vi.mock('@/api/workspaceApi', () => ({
+  default: mocks,
+}))
+
+import { useWorkspaceStore } from '../store'
+
+function makeWorkspaces(paths: Array<{ path: string, lastOpenedAt: number }>): ListWorkspacesData {
+  return {
+    workspaces: paths.map(item => ({
+      path: item.path,
+      displayName: item.path,
+      isDefault: false,
+      lastOpenedAt: item.lastOpenedAt,
+    })),
+  }
+}
+
+describe('workspaceStore currentWorkspacePath SSOT', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useWorkspaceStore.setState({ workspaceData: null, currentWorkspacePath: '', loading: false })
+  })
+
+  it('refresh 后 currentWorkspacePath 派生为 lastOpenedAt 最大者', async () => {
+    mocks.listWorkspaces.mockResolvedValue(makeWorkspaces([
+      { path: '/a', lastOpenedAt: 1 },
+      { path: '/b', lastOpenedAt: 5 },
+      { path: '/c', lastOpenedAt: 3 },
+    ]))
+
+    await useWorkspaceStore.getState().refresh()
+
+    expect(useWorkspaceStore.getState().currentWorkspacePath).toBe('/b')
+  })
+
+  it('refresh 后若当前路径仍有效则保持不变', async () => {
+    useWorkspaceStore.setState({ currentWorkspacePath: '/c' })
+    mocks.listWorkspaces.mockResolvedValue(makeWorkspaces([
+      { path: '/a', lastOpenedAt: 1 },
+      { path: '/c', lastOpenedAt: 3 },
+    ]))
+
+    await useWorkspaceStore.getState().refresh()
+
+    expect(useWorkspaceStore.getState().currentWorkspacePath).toBe('/c')
+  })
+
+  it('refresh 后若当前路径不在列表则回退到 lastOpenedAt 最大者', async () => {
+    useWorkspaceStore.setState({ currentWorkspacePath: '/gone' })
+    mocks.listWorkspaces.mockResolvedValue(makeWorkspaces([
+      { path: '/a', lastOpenedAt: 1 },
+      { path: '/b', lastOpenedAt: 9 },
+    ]))
+
+    await useWorkspaceStore.getState().refresh()
+
+    expect(useWorkspaceStore.getState().currentWorkspacePath).toBe('/b')
+  })
+
+  it('addWorkspace 后 currentWorkspacePath 显式设置为目标路径', async () => {
+    mocks.addWorkspace.mockResolvedValue(makeWorkspaces([{ path: '/new', lastOpenedAt: 10 }]))
+
+    await useWorkspaceStore.getState().addWorkspace('/new')
+
+    expect(useWorkspaceStore.getState().currentWorkspacePath).toBe('/new')
+  })
+
+  it('openWorkspace 后 currentWorkspacePath 显式设置为目标路径', async () => {
+    mocks.openWorkspace.mockResolvedValue(makeWorkspaces([{ path: '/opened', lastOpenedAt: 10 }]))
+
+    await useWorkspaceStore.getState().openWorkspace('/opened')
+
+    expect(useWorkspaceStore.getState().currentWorkspacePath).toBe('/opened')
+  })
+
+  it('removeWorkspace 删除当前工作区后回退到 lastOpenedAt 最大者', async () => {
+    useWorkspaceStore.setState({
+      currentWorkspacePath: '/cur',
+      workspaceData: makeWorkspaces([
+        { path: '/cur', lastOpenedAt: 5 },
+        { path: '/other', lastOpenedAt: 8 },
+      ]),
+    })
+    mocks.removeWorkspace.mockResolvedValue(makeWorkspaces([{ path: '/other', lastOpenedAt: 8 }]))
+
+    await useWorkspaceStore.getState().removeWorkspace('/cur')
+
+    expect(useWorkspaceStore.getState().currentWorkspacePath).toBe('/other')
+  })
+
+  it('removeWorkspace 删除非当前工作区时 currentWorkspacePath 保持不变', async () => {
+    useWorkspaceStore.setState({
+      currentWorkspacePath: '/cur',
+      workspaceData: makeWorkspaces([
+        { path: '/cur', lastOpenedAt: 5 },
+        { path: '/other', lastOpenedAt: 8 },
+      ]),
+    })
+    mocks.removeWorkspace.mockResolvedValue(makeWorkspaces([{ path: '/cur', lastOpenedAt: 5 }]))
+
+    await useWorkspaceStore.getState().removeWorkspace('/other')
+
+    expect(useWorkspaceStore.getState().currentWorkspacePath).toBe('/cur')
+  })
+})
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `pnpm --filter @ant-chat/web test -- store/workspace/__tests__/store`
+Expected: FAIL —— 当前 `WorkspaceStoreState` 无 `currentWorkspacePath` 字段;`refresh` 不派生该字段;`addWorkspace`/`openWorkspace`/`removeWorkspace` 不设置该字段。
+
+> 若 `pnpm --filter @ant-chat/web` 名称不匹配,改用 `pnpm -F apps/web test` 或直接 `cd apps/web && pnpm test -- store/workspace/__tests__/store`。以 `apps/web/package.json` 的 `name` 字段为准。
+
+- [ ] **Step 3: 改 store.ts — 新增 SSOT 字段与派生**
+
+编辑 `apps/web/src/store/workspace/store.ts`,整体替换为:
+
+```ts
+import type { ListWorkspacesData, WorkspaceItem } from '@ant-chat/shared'
+import { create } from 'zustand'
+import { devtools } from 'zustand/middleware'
+import workspaceApi from '@/api/workspaceApi'
+import { WORKSPACE_CHANGED_EVENT } from '@/constants/workspaceEvents'
+
+interface WorkspaceStoreState {
+  /** 当前工作区路径(SSOT):前端派生 + 工作区操作显式设置。后端不再回传。 */
+  currentWorkspacePath: string
+  workspaceData: ListWorkspacesData | null
+  loading: boolean
+}
+
+interface WorkspaceStoreActions {
+  refresh: () => Promise<void>
+  openWorkspace: (path: string) => Promise<ListWorkspacesData>
+  addWorkspace: (path: string) => Promise<ListWorkspacesData>
+  removeWorkspace: (path: string) => Promise<ListWorkspacesData>
+}
+
+export type WorkspaceStore = WorkspaceStoreState & WorkspaceStoreActions
+
+/**
+ * 从 workspaces 列表中取 lastOpenedAt 最大者为当前工作区。
+ * 列表为空时返回空串(由后端 ensureInitialized 保证默认工作区始终在列表,实际不会为空)。
+ */
+function pickLatestWorkspace(workspaces: WorkspaceItem[]): string {
+  if (workspaces.length === 0) {
+    return ''
+  }
+  return workspaces.reduce((latest, item) => {
+    const ts = item.lastOpenedAt ?? 0
+    const latestTs = latest.lastOpenedAt ?? 0
+    return ts > latestTs ? item : latest
+  }).path
+}
+
+export const useWorkspaceStore = create<WorkspaceStore>()(
+  devtools(
+    set => ({
+      currentWorkspacePath: '',
+      workspaceData: null,
+      loading: false,
+
+      refresh: async () => {
+        const data = await workspaceApi.listWorkspaces()
+        set((state) => {
+          const workspaces = data.workspaces
+          // 当前路径为空或不在列表中时,按 lastOpenedAt 派生;否则保持
+          const stillValid = state.currentWorkspacePath
+            && workspaces.some(item => item.path === state.currentWorkspacePath)
+          const currentWorkspacePath = stillValid
+            ? state.currentWorkspacePath
+            : pickLatestWorkspace(workspaces)
+          return { workspaceData: data, currentWorkspacePath }
+        })
+      },
+
+      openWorkspace: async (path: string) => {
+        const data = await workspaceApi.openWorkspace(path)
+        set({ workspaceData: data, currentWorkspacePath: path })
+        return data
+      },
+
+      addWorkspace: async (path: string) => {
+        const data = await workspaceApi.addWorkspace(path)
+        set({ workspaceData: data, currentWorkspacePath: path })
+        return data
+      },
+
+      removeWorkspace: async (path: string) => {
+        const data = await workspaceApi.removeWorkspace(path)
+        set((state) => {
+          // 删的是当前工作区时,回退到 lastOpenedAt 最大者;否则保持
+          const isCurrent = path === state.currentWorkspacePath
+          const currentWorkspacePath = isCurrent
+            ? pickLatestWorkspace(data.workspaces)
+            : state.currentWorkspacePath
+          return { workspaceData: data, currentWorkspacePath }
+        })
+        return data
+      },
+    }),
+    { name: 'workspace-store' },
+  ),
+)
+
+// 全局监听工作区变更事件,自动刷新(刷新内部按 lastOpenedAt 派生当前路径)
+if (typeof window !== 'undefined') {
+  window.addEventListener(WORKSPACE_CHANGED_EVENT, () => {
+    void useWorkspaceStore.getState().refresh()
+  })
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `pnpm --filter @ant-chat/web test -- store/workspace/__tests__/store`(或等价命令)
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add apps/web/src/store/workspace/store.ts apps/web/src/store/workspace/__tests__/store.spec.ts
+git commit -m "feat(web): workspaceStore 新增顶层 currentWorkspacePath SSOT 字段与 lastOpenedAt 派生"
+```
+
+---
+
+## Task 7: 前端 conversationsStore — 删 currentWorkspacePath,switchWorkspace 改名跨 store 取 key
+
+**Files:**
+- Modify: `apps/web/src/store/conversation/initialState.ts:11-47`
+- Modify: `apps/web/src/store/conversation/conversationsStore.ts:1-118`
+
+**Interfaces:**
+- Consumes: Task 6 的 `useWorkspaceStore.getState().currentWorkspacePath`。
+- Produces:
+  - `StoreState` 删除 `currentWorkspacePath`
+  - `createInitialState()` 不再含 `currentWorkspacePath`
+  - `getCurrentWorkspacePath(): string`(conversationsStore 内部 helper,读 workspaceStore)
+  - `switchWorkspaceSlice(workspacePath: string)`:no-op 守卫用 `getCurrentWorkspacePath()`;save 旧分片 key 用 `getCurrentWorkspacePath()`,restore 新分片 key 用入参 `path`;不再 set `currentWorkspacePath`
+  - `saveCurrentWorkspaceSlice`:key 用 `getCurrentWorkspacePath()`
+  - `reset`:在 `set` 回调外先取 `currentPath`,用该值替代 `state.currentWorkspacePath`
+
+> 本任务与 Task 8(actions.ts 新增 `activateWorkspace`)紧耦合:`switchWorkspace` 重命名为 `switchWorkspaceSlice` 后,`ensureWorkspaceConversationsAction`(actions.ts:72)仍调用旧名,会报类型错误。Task 8 同步修复。本任务先改 store,允许 `pnpm check` 暂时报 actions.ts 的错,Task 8 修复。
+
+- [ ] **Step 1: 改 initialState.ts — 删字段**
+
+编辑 `apps/web/src/store/conversation/initialState.ts`:
+
+(a) `StoreState`(行 11-22)删除 `currentWorkspacePath: string` 行(行 20)。
+
+(b) `createInitialState`(行 34-47)删除 `currentWorkspacePath: '',`(行 44)。
+
+改后 `StoreState`:
+```ts
+export interface StoreState {
+  conversations: IConversations[]
+  abortCallbacks: (() => void)[]
+  pageIndex: number
+  pageSize: number
+  conversationsTotal: number
+  activeConversationsId: string
+  streamingConversationIds: Set<string>
+  loadVersion: number
+  workspaceConversations: Record<string, WorkspaceConversationsState>
+}
+```
+
+`createInitialState`:
+```ts
+export function createInitialState(): StoreState {
+  return {
+    conversations: [],
+    abortCallbacks: [],
+    streamingConversationIds: new Set<string>(),
+    pageIndex: 0,
+    pageSize: 20,
+    conversationsTotal: 1,
+    activeConversationsId: '',
+    loadVersion: 0,
+    workspaceConversations: {},
+  }
+}
+```
+
+- [ ] **Step 2: 改 conversationsStore.ts — helper + switchWorkspaceSlice + reset + saveCurrentWorkspaceSlice**
+
+编辑 `apps/web/src/store/conversation/conversationsStore.ts`,整体替换为:
+
+```ts
+import type { StoreState, WorkspaceConversationsState } from './initialState'
+
+import { create } from 'zustand'
+import { devtools } from 'zustand/middleware'
+import {
+  createInitialState,
+  createWorkspaceConversationsState,
+  initialState,
+} from './initialState'
+import { useWorkspaceStore } from '@/store/workspace'
+
+interface StoreActions {
+  reset: () => void
+  setActiveConversationsId: (id: string) => void
+  switchWorkspaceSlice: (workspacePath: string) => void
+  saveCurrentWorkspaceSlice: () => void
+}
+export type ConversationsStore = StoreState & StoreActions
+
+/**
+ * 跨 store 读取当前工作区路径(SSOT 在 workspaceStore)。
+ * conversationsStore 不再持有 currentWorkspacePath,需要时统一从此取。
+ */
+function getCurrentWorkspacePath(): string {
+  return useWorkspaceStore.getState().currentWorkspacePath ?? ''
+}
+
+function getWorkspaceSlice(state: StoreState, workspacePath: string): WorkspaceConversationsState {
+  return state.workspaceConversations[workspacePath] || createWorkspaceConversationsState()
+}
+
+// 创建基础 store
+export const useConversationsStore = create<ConversationsStore>()(
+  devtools(
+    (set, get) => ({
+      ...initialState,
+      reset: () => {
+        // 在 set 回调外先取当前路径,避免回调内跨 store 读取的时序歧义
+        const currentPath = getCurrentWorkspacePath()
+        set((state) => {
+          const nextState = createInitialState()
+          nextState.pageSize = state.pageSize
+
+          if (currentPath) {
+            const currentSlice = getWorkspaceSlice(state, currentPath)
+            const nextSlice: WorkspaceConversationsState = {
+              ...currentSlice,
+              conversations: [],
+              pageIndex: 0,
+              conversationsTotal: 0,
+              loadVersion: currentSlice.loadVersion + 1,
+              loaded: true,
+            }
+            nextState.workspaceConversations = {
+              ...state.workspaceConversations,
+              [currentPath]: nextSlice,
+            }
+            nextState.conversations = nextSlice.conversations
+            nextState.pageIndex = nextSlice.pageIndex
+            nextState.conversationsTotal = nextSlice.conversationsTotal
+            nextState.loadVersion = nextSlice.loadVersion
+          }
+
+          return nextState
+        })
+      },
+      setActiveConversationsId: (id: string) => {
+        set({ activeConversationsId: id })
+      },
+      saveCurrentWorkspaceSlice: () => {
+        const state = get()
+        const currentPath = getCurrentWorkspacePath()
+        if (!currentPath) {
+          return
+        }
+
+        set({
+          workspaceConversations: {
+            ...state.workspaceConversations,
+            [currentPath]: {
+              conversations: state.conversations,
+              pageIndex: state.pageIndex,
+              conversationsTotal: state.conversationsTotal,
+              loadVersion: state.loadVersion,
+              loaded: true,
+            },
+          },
+        })
+      },
+      switchWorkspaceSlice: (workspacePath: string) => {
+        // no-op 守卫用 workspaceStore 当前路径(旧路径),与 save key 一致
+        const currentPath = getCurrentWorkspacePath()
+        if (workspacePath === currentPath) {
+          return
+        }
+
+        set((state) => {
+          const nextWorkspaceConversations = { ...state.workspaceConversations }
+
+          // save 旧分片,key 用旧路径(currentPath)
+          if (currentPath) {
+            nextWorkspaceConversations[currentPath] = {
+              conversations: state.conversations,
+              pageIndex: state.pageIndex,
+              conversationsTotal: state.conversationsTotal,
+              loadVersion: state.loadVersion,
+              loaded: true,
+            }
+          }
+
+          // restore 新分片,key 用入参 path
+          const nextSlice = nextWorkspaceConversations[workspacePath] || createWorkspaceConversationsState()
+
+          return {
+            ...state,
+            // 不再 set currentWorkspacePath(SSOT 在 workspaceStore)
+            workspaceConversations: nextWorkspaceConversations,
+            conversations: nextSlice.conversations,
+            pageIndex: nextSlice.pageIndex,
+            conversationsTotal: nextSlice.conversationsTotal,
+            loadVersion: nextSlice.loadVersion,
+            activeConversationsId: '',
+            streamingConversationIds: new Set<string>(),
+            abortCallbacks: [],
+          }
+        })
+      },
+    }),
+    {
+      enabled: import.meta.env.MODE === 'development',
+    },
+  ),
+)
+```
+
+- [ ] **Step 3: 暂不运行全量 check(actions.ts 仍引用旧名,Task 8 修复)**
+
+确认 `conversationsStore.ts` 与 `initialState.ts` 自身无语法错误:
+Run: `pnpm --filter @ant-chat/web exec tsc --noEmit -p apps/web/tsconfig.json 2>&1 | rg "conversationsStore|initialState" || echo "store 文件自身无新错"`
+Expected: store 文件自身无新错(可能仍有 actions.ts 的 `switchWorkspace` 旧名引用错,属预期)。
+
+- [ ] **Step 4: 提交(与 Task 8 合并提交亦可,此处单独提交 store 层)**
+
+```bash
+git add apps/web/src/store/conversation/initialState.ts apps/web/src/store/conversation/conversationsStore.ts
+git commit -m "refactor(web): conversationsStore 删 currentWorkspacePath,switchWorkspaceSlice 跨 store 取 key"
+```
+
+> 注:此时 `pnpm check` 仍会因 actions.ts 与组件引用 `switchWorkspace`/`switchWorkspaceConversationsAction` 报错,后续 Task 8-11 修复。本提交是 store 层的干净切片。
+
+---
+
+## Task 8: 前端 actions.ts — 新增 activateWorkspace,改 clear/nextPage 跨 store 取路径
+
+**Files:**
+- Modify: `apps/web/src/store/conversation/actions.ts:1-260`
+- Test: `apps/web/src/store/conversation/__tests__/activateWorkspace.spec.ts`(新增)
+
+**Interfaces:**
+- Consumes: Task 7 的 `switchWorkspaceSlice`、`saveCurrentWorkspaceSlice`、`getCurrentWorkspacePath`(store 导出需补)。Task 6 的 `useWorkspaceStore.getState().currentWorkspacePath`。`setActiveConversationsId`(来自 `@/store/messages`)。
+- Produces:
+  - `activateWorkspace(workspacePath: string): Promise<void>`:空路径 → 仅 `setActiveConversationsId('')`;非空 → `ensureWorkspaceConversationsAction(path)` + `switchWorkspaceSlice(path)` + 必要时 `nextPageConversationsAction()` 补加载首页
+  - 删除 `switchWorkspaceConversationsAction`
+  - `ensureWorkspaceConversationsAction`:内部 `switchWorkspace` 改为 `switchWorkspaceSlice`
+  - `clearConversationsAction`:`currentWorkspacePath` 从 `useWorkspaceStore.getState().currentWorkspacePath` 取
+  - `nextPageConversationsAction`:发起时 `currentWorkspacePath` 从 workspaceStore 取;竞态守护在 produce 回调内读 `useWorkspaceStore.getState().currentWorkspacePath` 与发起时值比较
+
+- [ ] **Step 1: 写失败测试 — activateWorkspace 行为**
+
+创建 `apps/web/src/store/conversation/__tests__/activateWorkspace.spec.ts`:
+
+```ts
+import type { IConversations } from '@ant-chat/shared'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const chatMocks = vi.hoisted(() => ({
+  getWorkspaceConversations: vi.fn(),
+  clearWorkspaceConversations: vi.fn(),
+}))
+
+vi.mock('@/api/chatApi', () => ({
+  default: chatMocks,
+}))
+
+import { useWorkspaceStore } from '@/store/workspace'
+import { activateWorkspace, clearConversationsAction } from '../actions'
+import { useConversationsStore } from '../conversationsStore'
+import { useMessagesStore } from '@/store/messages'
+
+function makeConversation(id: string, workspacePath: string): IConversations {
+  return {
+    id,
+    workspacePath,
+    title: id,
+    createdAt: 1,
+    updatedAt: 1,
+    settings: { modelId: 'm', providerId: 'p', systemPrompt: '', temperature: 0.7, maxTokens: 1024 },
+  } as IConversations
+}
+
+describe('activateWorkspace', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useWorkspaceStore.setState({ currentWorkspacePath: '', workspaceData: null, loading: false })
+    useConversationsStore.setState({
+      conversations: [],
+      abortCallbacks: [],
+      pageIndex: 0,
+      pageSize: 20,
+      conversationsTotal: 1,
+      activeConversationsId: 'stale-id',
+      streamingConversationIds: new Set<string>(),
+      loadVersion: 0,
+      workspaceConversations: {},
+    })
+    useMessagesStore.setState({ activeConversationsId: 'stale-id', messages: [] })
+  })
+
+  it('空路径时仅清空 activeConversationsId,不加载会话', async () => {
+    await activateWorkspace('')
+
+    expect(useMessagesStore.getState().activeConversationsId).toBe('')
+    expect(chatMocks.getWorkspaceConversations).not.toHaveBeenCalled()
+  })
+
+  it('非空路径时加载该工作区分片并切换顶层 slice', async () => {
+    useWorkspaceStore.setState({ currentWorkspacePath: '/other' })
+    chatMocks.getWorkspaceConversations.mockResolvedValue({
+      data: [makeConversation('c1', '/target')],
+      total: 1,
+    })
+
+    await activateWorkspace('/target')
+
+    expect(chatMocks.getWorkspaceConversations).toHaveBeenCalledWith('/target', 0, 20)
+    expect(useConversationsStore.getState().conversations).toHaveLength(1)
+    expect(useConversationsStore.getState().conversations[0].id).toBe('c1')
+  })
+
+  it('分片已加载时复用缓存,不重复请求', async () => {
+    useWorkspaceStore.setState({ currentWorkspacePath: '/other' })
+    // 预置已加载的分片
+    useConversationsStore.setState({
+      workspaceConversations: {
+        '/target': {
+          conversations: [makeConversation('cached', '/target')],
+          pageIndex: 0,
+          conversationsTotal: 1,
+          loadVersion: 0,
+          loaded: true,
+        },
+      },
+    })
+
+    await activateWorkspace('/target')
+
+    expect(chatMocks.getWorkspaceConversations).not.toHaveBeenCalled()
+    expect(useConversationsStore.getState().conversations[0].id).toBe('cached')
+  })
+})
+
+describe('clearConversationsAction 跨 store 取路径', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useWorkspaceStore.setState({ currentWorkspacePath: '/cur', workspaceData: null, loading: false })
+    useConversationsStore.setState({
+      conversations: [makeConversation('c1', '/cur')],
+      abortCallbacks: [],
+      pageIndex: 0,
+      pageSize: 20,
+      conversationsTotal: 1,
+      activeConversationsId: '',
+      streamingConversationIds: new Set<string>(),
+      loadVersion: 0,
+      workspaceConversations: {},
+    })
+  })
+
+  it('用 workspaceStore 当前路径清空,不再读 conversationsStore.currentWorkspacePath', async () => {
+    chatMocks.clearWorkspaceConversations.mockResolvedValue([])
+
+    await clearConversationsAction()
+
+    expect(chatMocks.clearWorkspaceConversations).toHaveBeenCalledWith('/cur')
+  })
+
+  it('workspaceStore 路径为空时抛错', async () => {
+    useWorkspaceStore.setState({ currentWorkspacePath: '' })
+
+    await expect(clearConversationsAction()).rejects.toThrow('当前工作区路径不存在，无法清空对话')
+  })
+})
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `pnpm --filter @ant-chat/web test -- store/conversation/__tests__/activateWorkspace`
+Expected: FAIL —— `activateWorkspace` 未导出;`clearConversationsAction` 仍读 `conversationsStore.currentWorkspacePath`(已删字段)。
+
+- [ ] **Step 3: 改 actions.ts — 新增 activateWorkspace,删 switchWorkspaceConversationsAction,改 ensure/clear/nextPage**
+
+编辑 `apps/web/src/store/conversation/actions.ts`:
+
+(a) 顶部导入补 `useWorkspaceStore` 与 `setActiveConversationsId`。将行 1-7 的导入区改为:
+```ts
+import type { AddConversationsSchema, ConversationsId, ConversationsSettingsSchema, IConversations } from '@ant-chat/shared'
+import type { AntChatFileStructure } from '@/constants'
+import { produce } from 'immer'
+import chatApi from '@/api/chatApi'
+import { useGeneralSettingsStore } from '@/store/generalSettings'
+import { setActiveConversationsId, clearActiveConversations } from '@/store/messages'
+import { useWorkspaceStore } from '@/store/workspace'
+import { useConversationsStore } from './conversationsStore'
+```
+(注意:`clearActiveConversations` 原本就从 `../messages` 导入,保持;`setActiveConversationsId` 新增导入——确认 `@/store/messages` 导出 `setActiveConversationsId`,若导出路径不同则调整。)
+
+(b) 新增 `getCurrentWorkspacePath` helper(放在 `saveCurrentSlice` 之后,`ensureWorkspaceConversationsAction` 之前):
+```ts
+function getCurrentWorkspacePath(): string {
+  return useWorkspaceStore.getState().currentWorkspacePath ?? ''
+}
+```
+
+(c) `ensureWorkspaceConversationsAction`(行 19-69)末尾的 `switchWorkspace` 调用——本函数内无该调用,无需改。但检查:原 `switchWorkspaceConversationsAction`(行 71-79)调用 `useConversationsStore.getState().switchWorkspace(workspacePath)`,本步骤删除整个 `switchWorkspaceConversationsAction` 函数(行 71-79),用 `activateWorkspace` 替代。
+
+在原 `switchWorkspaceConversationsAction` 位置(行 71 前)新增:
+```ts
+/**
+ * 统一的工作区激活入口:在 workspaceStore 已更新当前路径后,
+ * 同步会话分片缓存到该路径。所有切换/新增/删除场景调用此入口,
+ * 避免手动拼装 ensure+switch 导致的遗漏与闭包陷阱。
+ *
+ * 入参为目标工作区路径,由调用方传入(与紧邻的 workspaceStore action 的 path 入参一致),
+ * 不依赖任何闭包渲染期变量。activateWorkspace 不写 workspaceStore(SSOT 由 workspaceStore action 负责)。
+ */
+export async function activateWorkspace(workspacePath: string): Promise<void> {
+  await setActiveConversationsId('')
+  if (!workspacePath) {
+    return
+  }
+  await ensureWorkspaceConversationsAction(workspacePath)
+  useConversationsStore.getState().switchWorkspaceSlice(workspacePath)
+
+  const nextState = useConversationsStore.getState()
+  if (nextState.conversations.length === 0 && nextState.conversationsTotal > 0) {
+    await nextPageConversationsAction()
+  }
+}
+```
+
+删除原 `switchWorkspaceConversationsAction`(行 71-79)整段。
+
+(d) `clearConversationsAction`(行 135-152),将:
+```ts
+export async function clearConversationsAction() {
+  const { currentWorkspacePath } = useConversationsStore.getState()
+  if (!currentWorkspacePath) {
+    throw new Error('当前工作区路径不存在，无法清空对话')
+  }
+
+  await chatApi.clearWorkspaceConversations(currentWorkspacePath)
+```
+改为:
+```ts
+export async function clearConversationsAction() {
+  const currentWorkspacePath = getCurrentWorkspacePath()
+  if (!currentWorkspacePath) {
+    throw new Error('当前工作区路径不存在，无法清空对话')
+  }
+
+  await chatApi.clearWorkspaceConversations(currentWorkspacePath)
+```
+
+(e) `nextPageConversationsAction`(行 154-195),将:
+```ts
+export async function nextPageConversationsAction() {
+  const { pageIndex, pageSize, loadVersion, currentWorkspacePath } = useConversationsStore.getState()
+  if (!currentWorkspacePath) {
+    return
+  }
+```
+改为:
+```ts
+export async function nextPageConversationsAction() {
+  const { pageIndex, pageSize, loadVersion } = useConversationsStore.getState()
+  const currentWorkspacePath = getCurrentWorkspacePath()
+  if (!currentWorkspacePath) {
+    return
+  }
+```
+
+将竞态守护(行 171-178):
+```ts
+    useConversationsStore.setState(state => produce(state, (draft) => {
+      if (
+        draft.currentWorkspacePath !== currentWorkspacePath
+        || draft.loadVersion !== loadVersion
+        || draft.pageIndex !== pageIndex
+      ) {
+        return
+      }
+```
+改为:
+```ts
+    useConversationsStore.setState(state => produce(state, (draft) => {
+      // 分页加载是异步的:加载期间用户可能切了工作区,加载回来时若 workspaceStore
+      // 当前路径已不是发起时的路径,则丢弃结果,不污染新工作区顶层 conversations。
+      if (
+        useWorkspaceStore.getState().currentWorkspacePath !== currentWorkspacePath
+        || draft.loadVersion !== loadVersion
+        || draft.pageIndex !== pageIndex
+      ) {
+        return
+      }
+```
+
+- [ ] **Step 4: 确认 messages store 导出 setActiveConversationsId**
+
+Run: `rg -n "export.*setActiveConversationsId" apps/web/src/store/messages`
+Expected: 命中(若未导出,需在 `@/store/messages` 入口补导出现有 `setActiveConversationsId`)。若导出名不同,调整 Task 8(c) 导入。
+
+- [ ] **Step 5: 运行 activateWorkspace 测试确认通过**
+
+Run: `pnpm --filter @ant-chat/web test -- store/conversation/__tests__/activateWorkspace`
+Expected: PASS。
+
+- [ ] **Step 6: 运行类型检查定位组件层剩余报错**
+
+Run: `pnpm --filter @ant-chat/web exec tsc --noEmit 2>&1 | rg "switchWorkspace|switchWorkspaceConversationsAction|currentWorkspacePath" | head -30`
+Expected: 报错集中在组件层(`WorkspacePanels`/`WorkspaceSelector`/`Sender`/`Chat` 仍引用旧 action 名或 `workspaceData.currentWorkspacePath`),由 Task 9-11 修复。
+
+- [ ] **Step 7: 提交**
+
+```bash
+git add apps/web/src/store/conversation/actions.ts apps/web/src/store/conversation/__tests__/activateWorkspace.spec.ts
+git commit -m "feat(web): 新增 activateWorkspace 统一入口,clear/nextPage 跨 store 取 currentWorkspacePath"
+```
+
+---
+
+## Task 9: 前端 WorkspacePanels — 删 reloadCurrentWorkspace,调用点改 activateWorkspace
+
+**Files:**
+- Modify: `apps/web/src/components/Workspace/WorkspacePanels.tsx:1-438`
+
+**Interfaces:**
+- Consumes: Task 8 的 `activateWorkspace`、`ensureWorkspaceConversationsAction`、`nextPageConversationsAction`。Task 6 的 `useWorkspaceStore(state => state.currentWorkspacePath)`。Task 7 的 `useConversationsStore`(无 `currentWorkspacePath`)。
+- Produces: `WorkspacePanels` 组件不再有 `reloadCurrentWorkspace` 与本地 `currentWorkspacePath` 派生;所有切换/新增/删除/初始化调用 `activateWorkspace`。
+
+- [ ] **Step 1: 改 WorkspacePanels.tsx — 导入与 currentWorkspacePath 来源**
+
+编辑 `apps/web/src/components/Workspace/WorkspacePanels.tsx`:
+
+(a) 导入区(行 23-31),将:
+```ts
+import {
+  ensureWorkspaceConversationsAction,
+  nextPageConversationsAction,
+  switchWorkspaceConversationsAction,
+  useConversationsStore,
+} from '@/store/conversation'
+import { setActiveConversationsId, useMessagesStore } from '@/store/messages'
+import { useWorkspaceStore } from '@/store/workspace'
+```
+改为:
+```ts
+import {
+  activateWorkspace,
+  ensureWorkspaceConversationsAction,
+  useConversationsStore,
+} from '@/store/conversation'
+import { setActiveConversationsId, useMessagesStore } from '@/store/messages'
+import { useWorkspaceStore } from '@/store/workspace'
+```
+(删除 `switchWorkspaceConversationsAction`、`nextPageConversationsAction` 导入;新增 `activateWorkspace`。保留 `setActiveConversationsId`——`openConversation`/`createConversation` 仍直接调用它设置具体会话 id,`activateWorkspace` 只在切换工作区入口清空 id,不替代设置具体 id 的场景。)
+
+(b) `currentWorkspacePath` 来源(行 54-56 + 行 72),将:
+```ts
+  const storeWorkspacePath = useConversationsStore(
+    state => state.currentWorkspacePath,
+  )
+```
+删除该段;将行 72:
+```ts
+  const currentWorkspacePath = storeWorkspacePath || workspaceData?.currentWorkspacePath
+```
+改为:
+```ts
+  const currentWorkspacePath = useWorkspaceStore(state => state.currentWorkspacePath)
+```
+
+- [ ] **Step 2: 改 initialize — refresh 后 activateWorkspace**
+
+将行 74-90 `initialize`:
+```ts
+  const initialize = useCallback(async () => {
+    if (initializedRef.current) {
+      return
+    }
+
+    initializedRef.current = true
+    await refreshWorkspace()
+    const data = useWorkspaceStore.getState().workspaceData
+    if (data) {
+      setExpandedPaths(new Set([data.currentWorkspacePath]))
+      useConversationsStore.getState().switchWorkspace(data.currentWorkspacePath)
+
+      if (useConversationsStore.getState().conversations.length === 0) {
+        await nextPageConversationsAction()
+      }
+    }
+  }, [refreshWorkspace])
+```
+改为:
+```ts
+  const initialize = useCallback(async () => {
+    if (initializedRef.current) {
+      return
+    }
+
+    initializedRef.current = true
+    await refreshWorkspace()
+    const data = useWorkspaceStore.getState().workspaceData
+    if (data) {
+      const currentPath = useWorkspaceStore.getState().currentWorkspacePath
+      setExpandedPaths(new Set([currentPath]))
+      await activateWorkspace(currentPath)
+    }
+  }, [refreshWorkspace])
+```
+
+- [ ] **Step 3: 删 reloadCurrentWorkspace,改 handlePickerConfirm**
+
+将行 92-97 `reloadCurrentWorkspace` 整段删除:
+```ts
+  const reloadCurrentWorkspace = useCallback(async () => {
+    await setActiveConversationsId('')
+    if (currentWorkspacePath) {
+      await switchWorkspaceConversationsAction(currentWorkspacePath)
+    }
+  }, [currentWorkspacePath])
+```
+
+将行 103-116 `handlePickerConfirm`:
+```ts
+  const handlePickerConfirm = useCallback(async (path: string) => {
+    setPickerOpen(false)
+    setPanelError('')
+    try {
+      const data = await addWorkspace(path)
+      setExpandedPaths(
+        paths => new Set([...paths, data.currentWorkspacePath]),
+      )
+      await reloadCurrentWorkspace()
+    }
+    catch (error) {
+      setPanelError((error as Error).message)
+    }
+  }, [addWorkspace, reloadCurrentWorkspace])
+```
+改为:
+```ts
+  const handlePickerConfirm = useCallback(async (path: string) => {
+    setPickerOpen(false)
+    setPanelError('')
+    try {
+      await addWorkspace(path)
+      // addWorkspace 内部已 set currentWorkspacePath=path(SSOT 更新),
+      // 用入参 path 调 activateWorkspace,不依赖闭包渲染期变量
+      setExpandedPaths(paths => new Set([...paths, path]))
+      await activateWorkspace(path)
+    }
+    catch (error) {
+      setPanelError((error as Error).message)
+    }
+  }, [addWorkspace])
+```
+
+- [ ] **Step 4: 改 handleDeleteWorkspace — removeWorkspace 后 activateWorkspace**
+
+将行 118-130 `handleDeleteWorkspace`:
+```ts
+  const handleDeleteWorkspace = useCallback(async (path: string) => {
+    try {
+      await removeWorkspace(path)
+      setExpandedPaths((paths) => {
+        const next = new Set(paths)
+        next.delete(path)
+        return next
+      })
+    }
+    catch (error) {
+      setPanelError((error as Error).message)
+    }
+  }, [removeWorkspace])
+```
+改为:
+```ts
+  const handleDeleteWorkspace = useCallback(async (path: string) => {
+    try {
+      await removeWorkspace(path)
+      // removeWorkspace 内部已按 lastOpenedAt 回退 currentWorkspacePath,
+      // 从 workspaceStore 取回退后的当前路径再 activate
+      await activateWorkspace(useWorkspaceStore.getState().currentWorkspacePath)
+      setExpandedPaths((paths) => {
+        const next = new Set(paths)
+        next.delete(path)
+        return next
+      })
+    }
+    catch (error) {
+      setPanelError((error as Error).message)
+    }
+  }, [removeWorkspace])
+```
+
+- [ ] **Step 5: 改 openConversation / createConversation — openWorkspace 后 activateWorkspace**
+
+将行 151-167 `openConversation`:
+```ts
+  async function openConversation(
+    workspacePath: string,
+    conversationId: string,
+  ) {
+    navigate('/chat')
+
+    if (workspacePath !== currentWorkspacePath) {
+      const data = await openWorkspace(workspacePath)
+      setExpandedPaths(
+        paths => new Set([...paths, data.currentWorkspacePath]),
+      )
+      await switchWorkspaceConversationsAction(workspacePath)
+    }
+
+    await setActiveConversationsId(conversationId)
+    onNavigate?.()
+  }
+```
+改为:
+```ts
+  async function openConversation(
+    workspacePath: string,
+    conversationId: string,
+  ) {
+    navigate('/chat')
+
+    if (workspacePath !== currentWorkspacePath) {
+      await openWorkspace(workspacePath)
+      setExpandedPaths(paths => new Set([...paths, workspacePath]))
+      await activateWorkspace(workspacePath)
+    }
+
+    await setActiveConversationsId(conversationId)
+    onNavigate?.()
+  }
+```
+
+将行 169-180 `createConversation`:
+```ts
+  async function createConversation(workspacePath: string) {
+    navigate('/chat')
+
+    if (workspacePath !== currentWorkspacePath) {
+      const data = await openWorkspace(workspacePath)
+      setExpandedPaths(paths => new Set([...paths, data.currentWorkspacePath]))
+      await switchWorkspaceConversationsAction(workspacePath)
+    }
+
+    await setActiveConversationsId('')
+    onNavigate?.()
+  }
+```
+改为:
+```ts
+  async function createConversation(workspacePath: string) {
+    navigate('/chat')
+
+    if (workspacePath !== currentWorkspacePath) {
+      await openWorkspace(workspacePath)
+      setExpandedPaths(paths => new Set([...paths, workspacePath]))
+      await activateWorkspace(workspacePath)
+    }
+
+    await setActiveConversationsId('')
+    onNavigate?.()
+  }
+```
+
+- [ ] **Step 6: toggleWorkspace 保持单调 ensure(无需改)**
+
+确认行 132-149 `toggleWorkspace` 仍用 `ensureWorkspaceConversationsAction(item.path)`(行 147),这是"只需 ensure 不需切换顶层 slice"的预加载场景,保留不变。`currentWorkspacePath`(行 144)现在来自 workspaceStore(Step 1(b) 已改),守卫语义不变。
+
+- [ ] **Step 7: 运行类型检查确认 WorkspacePanels 无错**
+
+Run: `pnpm --filter @ant-chat/web exec tsc --noEmit 2>&1 | rg "WorkspacePanels" || echo "WorkspacePanels 无错"`
+Expected: `WorkspacePanels 无错`。
+
+- [ ] **Step 8: 提交**
+
+```bash
+git add apps/web/src/components/Workspace/WorkspacePanels.tsx
+git commit -m "refactor(web): WorkspacePanels 删 reloadCurrentWorkspace,调用点改 activateWorkspace"
+```
+
+---
+
+## Task 10: 前端 WorkspaceSelector — 消除第三源,直接走 workspaceStore action
+
+**Files:**
+- Modify: `apps/web/src/components/Workspace/WorkspaceSelector.tsx:1-344`
+
+**Interfaces:**
+- Consumes: Task 8 的 `activateWorkspace`、`setActiveConversationsId`。Task 6 的 `useWorkspaceStore`(state 与 actions)。`workspaceApi`(不再直接调,改用 store action)。
+- Produces: `WorkspaceSelector` 无本地 `useReducer workspaceData`;无 `applyWorkspaceData`;`refreshWorkspaces` 简化为调 `useWorkspaceStore.getState().refresh()`;三个操作走 store action + `activateWorkspace`。
+
+- [ ] **Step 1: 改 WorkspaceSelector.tsx — 导入与状态**
+
+编辑 `apps/web/src/components/Workspace/WorkspaceSelector.tsx`:
+
+(a) 导入区(行 29-36),将:
+```ts
+import { useEffect, useMemo, useReducer, useState } from 'react'
+import workspaceApi from '@/api/workspaceApi'
+import {
+  emitWorkspaceChanged,
+  WORKSPACE_CHANGED_EVENT,
+} from '@/constants/workspaceEvents'
+import { switchWorkspaceConversationsAction, useConversationsStore } from '@/store/conversation'
+import { setActiveConversationsId } from '@/store/messages'
+```
+改为:
+```ts
+import { useEffect, useMemo, useState } from 'react'
+import {
+  emitWorkspaceChanged,
+  WORKSPACE_CHANGED_EVENT,
+} from '@/constants/workspaceEvents'
+import { activateWorkspace } from '@/store/conversation'
+import { setActiveConversationsId } from '@/store/messages'
+import { useWorkspaceStore } from '@/store/workspace'
+```
+(删除 `useReducer`、`workspaceApi`、`switchWorkspaceConversationsAction`、`useConversationsStore`;新增 `activateWorkspace`、`useWorkspaceStore`。)
+
+(b) 组件内状态(行 48-69),将:
+```ts
+export function WorkspaceSelector({ compact = false }: WorkspaceSelectorProps) {
+  const [open, setOpen] = useState(false)
+  const [loading, setLoading] = useState(false)
+  // useReducer to avoid react-hooks/set-state-in-effect: dispatch is allowed in effects
+  const [workspaceData, setWorkspaceData] = useReducer(
+    (_s: ListWorkspacesData | null, a: ListWorkspacesData | null) => a,
+    null,
+  )
+  const [notice, setNotice] = useState<NoticeState | null>(null)
+  const [removeTarget, setRemoveTarget] = useState<WorkspaceItem | null>(null)
+  const [pickerOpen, setPickerOpen] = useState(false)
+  const compactClass = compact
+    ? `
+      text-slate-500
+      dark:text-slate-400
+    `
+    : ''
+
+  const currentWorkspace = useMemo(
+    () => workspaceData?.workspaces.find(item => item.path === workspaceData.currentWorkspacePath),
+    [workspaceData],
+  )
+```
+改为:
+```ts
+export function WorkspaceSelector({ compact = false }: WorkspaceSelectorProps) {
+  const [open, setOpen] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [notice, setNotice] = useState<NoticeState | null>(null)
+  const [removeTarget, setRemoveTarget] = useState<WorkspaceItem | null>(null)
+  const [pickerOpen, setPickerOpen] = useState(false)
+  const compactClass = compact
+    ? `
+      text-slate-500
+      dark:text-slate-400
+    `
+    : ''
+
+  // 唯一事实源:workspaceStore。不再持有本地 workspaceData(第三源)。
+  const workspaceData = useWorkspaceStore(state => state.workspaceData)
+  const currentWorkspacePath = useWorkspaceStore(state => state.currentWorkspacePath)
+  const currentWorkspace = useMemo(
+    () => workspaceData?.workspaces.find(item => item.path === currentWorkspacePath),
+    [workspaceData, currentWorkspacePath],
+  )
+```
+
+- [ ] **Step 2: 改 refreshWorkspaces — 调 store refresh**
+
+将行 71-75 `refreshWorkspaces`:
+```ts
+  async function refreshWorkspaces() {
+    const data = await workspaceApi.listWorkspaces()
+    setWorkspaceData(data)
+    useConversationsStore.getState().switchWorkspace(data.currentWorkspacePath)
+  }
+```
+改为:
+```ts
+  async function refreshWorkspaces() {
+    await useWorkspaceStore.getState().refresh()
+  }
+```
+
+- [ ] **Step 3: 删 applyWorkspaceData,改三个操作走 store action + activateWorkspace**
+
+将行 101-108 `applyWorkspaceData` 整段删除:
+```ts
+  async function applyWorkspaceData(data: ListWorkspacesData | null) {
+    if (!data) {
+      return
+    }
+    setWorkspaceData(data)
+    await setActiveConversationsId('')
+    await switchWorkspaceConversationsAction(data.currentWorkspacePath)
+  }
+```
+
+将行 114-131 `handlePickerConfirm`:
+```ts
+  async function handlePickerConfirm(path: string) {
+    setPickerOpen(false)
+    setLoading(true)
+    setNotice(null)
+    try {
+      const data = await workspaceApi.addWorkspace(path)
+      await applyWorkspaceData(data)
+      emitWorkspaceChanged()
+      setNotice({ type: 'success', message: '工作区已添加' })
+      setOpen(false)
+    }
+    catch (error) {
+      setNotice({ type: 'error', message: (error as Error).message })
+    }
+    finally {
+      setLoading(false)
+    }
+  }
+```
+改为:
+```ts
+  async function handlePickerConfirm(path: string) {
+    setPickerOpen(false)
+    setLoading(true)
+    setNotice(null)
+    try {
+      await setActiveConversationsId('')
+      await useWorkspaceStore.getState().addWorkspace(path)
+      await activateWorkspace(path)
+      emitWorkspaceChanged()
+      setNotice({ type: 'success', message: '工作区已添加' })
+      setOpen(false)
+    }
+    catch (error) {
+      setNotice({ type: 'error', message: (error as Error).message })
+    }
+    finally {
+      setLoading(false)
+    }
+  }
+```
+
+将行 133-151 `handleOpenWorkspace`:
+```ts
+  async function handleOpenWorkspace(item: WorkspaceItem) {
+    if (item.path === workspaceData?.currentWorkspacePath) {
+      return
+    }
+
+    setLoading(true)
+    setNotice(null)
+    try {
+      const data = await workspaceApi.openWorkspace(item.path)
+      await applyWorkspaceData(data)
+      setOpen(false)
+    }
+    catch (error) {
+      setNotice({ type: 'error', message: (error as Error).message })
+    }
+    finally {
+      setLoading(false)
+    }
+  }
+```
+改为:
+```ts
+  async function handleOpenWorkspace(item: WorkspaceItem) {
+    if (item.path === useWorkspaceStore.getState().currentWorkspacePath) {
+      return
+    }
+
+    setLoading(true)
+    setNotice(null)
+    try {
+      await setActiveConversationsId('')
+      await useWorkspaceStore.getState().openWorkspace(item.path)
+      await activateWorkspace(item.path)
+      setOpen(false)
+    }
+    catch (error) {
+      setNotice({ type: 'error', message: (error as Error).message })
+    }
+    finally {
+      setLoading(false)
+    }
+  }
+```
+
+将行 157-176 `confirmRemoveWorkspace`:
+```ts
+  async function confirmRemoveWorkspace() {
+    if (!removeTarget) {
+      return
+    }
+
+    setLoading(true)
+    setNotice(null)
+    try {
+      const data = await workspaceApi.removeWorkspace(removeTarget.path)
+      await applyWorkspaceData(data)
+      emitWorkspaceChanged()
+      setRemoveTarget(null)
+    }
+    catch (error) {
+      setNotice({ type: 'error', message: (error as Error).message })
+    }
+    finally {
+      setLoading(false)
+    }
+  }
+```
+改为:
+```ts
+  async function confirmRemoveWorkspace() {
+    if (!removeTarget) {
+      return
+    }
+
+    setLoading(true)
+    setNotice(null)
+    try {
+      await setActiveConversationsId('')
+      await useWorkspaceStore.getState().removeWorkspace(removeTarget.path)
+      await activateWorkspace(useWorkspaceStore.getState().currentWorkspacePath)
+      emitWorkspaceChanged()
+      setRemoveTarget(null)
+    }
+    catch (error) {
+      setNotice({ type: 'error', message: (error as Error).message })
+    }
+    finally {
+      setLoading(false)
+    }
+  }
+```
+
+- [ ] **Step 4: 改 JSX 中 workspaceData.currentWorkspacePath 引用**
+
+行 187 `active={item.path === workspaceData.currentWorkspacePath}` 改为:
+```tsx
+                  active={item.path === currentWorkspacePath}
+```
+
+- [ ] **Step 5: 清理未使用导入**
+
+确认 `ListWorkspacesData` 类型导入(行 1)若不再使用则删除;`useReducer` 已删;`workspaceApi` 已删。运行 lint 自动修复:
+Run: `pnpm --filter @ant-chat/web exec eslint --fix apps/web/src/components/Workspace/WorkspaceSelector.tsx`
+检查行 1 `import type { ListWorkspacesData, WorkspaceItem } from '@ant-chat/shared'`——`ListWorkspacesData` 不再使用,改为:
+```ts
+import type { WorkspaceItem } from '@ant-chat/shared'
+```
+
+- [ ] **Step 6: 运行类型检查确认 WorkspaceSelector 无错**
+
+Run: `pnpm --filter @ant-chat/web exec tsc --noEmit 2>&1 | rg "WorkspaceSelector" || echo "WorkspaceSelector 无错"`
+Expected: `WorkspaceSelector 无错`。
+
+- [ ] **Step 7: 提交**
+
+```bash
+git add apps/web/src/components/Workspace/WorkspaceSelector.tsx
+git commit -m "refactor(web): WorkspaceSelector 消除本地第三源,直接走 workspaceStore action + activateWorkspace"
+```
+
+---
+
+## Task 11: 前端 Chat 与 Sender — 读 workspaceStore,Sender 切换改 activateWorkspace,searchFiles 传路径
+
+**Files:**
+- Modify: `apps/web/src/components/Chat/Chat.tsx:1-95`
+- Modify: `apps/web/src/components/Sender/Sender.tsx:56,415-416,440,478-504`
+- Modify: `apps/web/src/api/workspaceApi.ts:32-34`
+
+**Interfaces:**
+- Consumes: Task 8 的 `activateWorkspace`。Task 6 的 `useWorkspaceStore(state => state.currentWorkspacePath)` 与 `useWorkspaceStore.getState()`。Task 1 的 `searchWorkspaceFiles` 端点入参含 `workspacePath`。
+- Produces:
+  - `Chat`:`currentWorkspacePath` 读 workspaceStore,传给 `AgentApprovalCard` 与 `startAgentTurn`
+  - `Sender`:显示工作区名读 workspaceStore 顶层字段;`handleSwitchWorkspace` 用 `activateWorkspace`;`searchWorkspaceFiles` 调用传 `currentWorkspacePath`
+  - `workspaceApi.searchWorkspaceFiles(workspacePath, query, limit)` 签名加 `workspacePath`
+
+- [ ] **Step 1: 改 Chat.tsx — currentWorkspacePath 读 workspaceStore**
+
+编辑 `apps/web/src/components/Chat/Chat.tsx`:
+
+(a) 导入区,将:
+```ts
+import {
+  upsertConversationAction,
+  useConversationsStore,
+} from '@/store/conversation'
+```
+确认是否已导入 `useWorkspaceStore`——当前未导入。在导入区补:
+```ts
+import { useWorkspaceStore } from '@/store/workspace'
+```
+(放在 `@/store/conversation` 导入之后,`@/store/messages` 导入之前,符合导入顺序。)
+
+(b) 行 28,将:
+```ts
+  const currentWorkspacePath = useConversationsStore(state => state.currentWorkspacePath)
+```
+改为:
+```ts
+  const currentWorkspacePath = useWorkspaceStore(state => state.currentWorkspacePath)
+```
+
+> `currentWorkspacePath` 传给 `useBuiltinCommandSubmit`(行 44)、`startAgentTurn`(行 83)、`AgentApprovalCard`(行 129)的用法不变,仅取值源变更。`useConversationsStore` 仍用于行 27 `currentConversations`,保留该导入。
+
+- [ ] **Step 2: 改 workspaceApi.ts — searchWorkspaceFiles 签名加 workspacePath**
+
+编辑 `apps/web/src/api/workspaceApi.ts`,将行 32-34:
+```ts
+async function searchWorkspaceFiles(query: string, limit = 50): Promise<WorkspaceFileSearchResult[]> {
+  return getAppRpcClient().call('workspace.searchWorkspaceFiles', { query, limit })
+}
+```
+改为:
+```ts
+async function searchWorkspaceFiles(workspacePath: string, query: string, limit = 50): Promise<WorkspaceFileSearchResult[]> {
+  return getAppRpcClient().call('workspace.searchWorkspaceFiles', { workspacePath, query, limit })
+}
+```
+
+- [ ] **Step 3: 改 Sender.tsx — 显示工作区名读 workspaceStore 顶层字段**
+
+编辑 `apps/web/src/components/Sender/Sender.tsx`:
+
+(a) 导入区(行 51-58),将:
+```ts
+import {
+  switchWorkspaceConversationsAction,
+  useConversationsStore,
+} from '@/store/conversation'
+import { setActiveConversationsId, useMessagesStore } from '@/store/messages'
+import { useWorkspaceStore } from '@/store/workspace'
+```
+改为:
+```ts
+import { activateWorkspace, useConversationsStore } from '@/store/conversation'
+import { setActiveConversationsId, useMessagesStore } from '@/store/messages'
+import { useWorkspaceStore } from '@/store/workspace'
+```
+(删除 `switchWorkspaceConversationsAction`,新增 `activateWorkspace`。)
+
+(b) 行 333 `const workspaceData = useWorkspaceStore(state => state.workspaceData)` 下方补:
+```ts
+  const currentWorkspacePath = useWorkspaceStore(state => state.currentWorkspacePath)
+```
+
+(c) 行 413-418 `currentWorkspace` 派生,将:
+```ts
+  const currentWorkspace = useMemo(
+    () =>
+      workspaceData?.workspaces.find(
+        item => item.path === workspaceData?.currentWorkspacePath,
+      ),
+    [workspaceData],
+  )
+```
+改为:
+```ts
+  const currentWorkspace = useMemo(
+    () =>
+      workspaceData?.workspaces.find(
+        item => item.path === currentWorkspacePath,
+      ),
+    [workspaceData, currentWorkspacePath],
+  )
+```
+
+(d) 行 482 `handleSwitchWorkspace` 守卫,将:
+```ts
+    if (
+      !canSwitchWorkspace
+      || !workspaceData
+      || nextWorkspacePath === workspaceData.currentWorkspacePath
+    ) {
+      return
+    }
+```
+改为:
+```ts
+    if (
+      !canSwitchWorkspace
+      || !workspaceData
+      || nextWorkspacePath === currentWorkspacePath
+    ) {
+      return
+    }
+```
+
+(e) 行 490-496 `handleSwitchWorkspace` 主体,将:
+```ts
+    setWorkspaceLoading(true)
+    setNotice('')
+    try {
+      await openWorkspace(nextWorkspacePath)
+      setWorkspacePickerOpen(false)
+      await setActiveConversationsId('')
+      await switchWorkspaceConversationsAction(nextWorkspacePath)
+    }
+```
+改为:
+```ts
+    setWorkspaceLoading(true)
+    setNotice('')
+    try {
+      await openWorkspace(nextWorkspacePath)
+      setWorkspacePickerOpen(false)
+      await activateWorkspace(nextWorkspacePath)
+    }
+```
+(`activateWorkspace` 内部已 `setActiveConversationsId('')`,无需单独调。)
+
+(f) 行 820 `hasWorkspace={Boolean(workspaceData?.currentWorkspacePath)}` 改为:
+```tsx
+            hasWorkspace={Boolean(currentWorkspacePath)}
+```
+
+- [ ] **Step 4: 改 Sender.tsx — searchWorkspaceFiles 调用传 currentWorkspacePath**
+
+行 440,将:
+```ts
+      void workspaceApi.searchWorkspaceFiles(activeReferenceTrigger.query, 50)
+```
+改为:
+```ts
+      void workspaceApi.searchWorkspaceFiles(currentWorkspacePath, activeReferenceTrigger.query, 50)
+```
+
+- [ ] **Step 5: 运行类型检查确认 Chat/Sender 无错**
+
+Run: `pnpm --filter @ant-chat/web exec tsc --noEmit 2>&1 | rg "Chat/Chat|Sender/Sender|workspaceApi" || echo "Chat/Sender/workspaceApi 无错"`
+Expected: `Chat/Sender/workspaceApi 无错`。
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add apps/web/src/components/Chat/Chat.tsx apps/web/src/components/Sender/Sender.tsx apps/web/src/api/workspaceApi.ts
+git commit -m "refactor(web): Chat/Sender 读 workspaceStore SSOT,Sender 切换改 activateWorkspace,searchFiles 传路径"
+```
+
+---
+
+## Task 12: 前端测试更新 — gui.spec 与 Sender.spec 对齐 SSOT
+
+**Files:**
+- Modify: `apps/web/src/__tests__/gui.spec.tsx:88-93,119-121,151,156-164,543-556`
+- Modify: `apps/web/src/components/Sender/__tests__/Sender.spec.tsx:20-31,95-115,440`
+
+**Interfaces:**
+- Consumes: Task 6 的 `useWorkspaceStore`。Task 7 的 `createInitialState`(无 `currentWorkspacePath`)。Task 1 的 `ListWorkspacesData`(无 `currentWorkspacePath`)。
+- Produces: 测试用例对齐 SSOT——mock `listWorkspaces` 返回不含 `currentWorkspacePath`;`useConversationsStore.setState` 不含 `currentWorkspacePath`;用 `useWorkspaceStore.setState({ currentWorkspacePath })` 设当前路径;`searchWorkspaceFiles` mock 断言含 `workspacePath`。
+
+- [ ] **Step 1: 改 gui.spec.tsx — mock 与 store setState 对齐**
+
+编辑 `apps/web/src/__tests__/gui.spec.tsx`:
+
+(a) 行 88-93 `mocks.workspace`,将:
+```ts
+  workspace: {
+    chooseWorkspace: vi.fn(async () => null),
+    listWorkspaces: vi.fn(),
+    openWorkspace: vi.fn(),
+  },
+```
+改为:
+```ts
+  workspace: {
+    chooseWorkspace: vi.fn(async () => null),
+    listWorkspaces: vi.fn(),
+    openWorkspace: vi.fn(),
+    searchWorkspaceFiles: vi.fn(async () => []),
+  },
+```
+(新增 `searchWorkspaceFiles` mock,供 Sender 调用。)
+
+(b) 行 119-121 `vi.mock('@/api/workspaceApi')` 保持 `default: mocks.workspace`。
+
+(c) 行 15-17 导入补 `useWorkspaceStore`:
+```ts
+import { useConversationsStore } from '../store/conversation'
+import { createInitialState } from '../store/conversation/initialState'
+import { setActiveConversationsId, useMessagesStore } from '../store/messages'
+import { useWorkspaceStore } from '../store/workspace'
+```
+
+(d) 行 151 `useConversationsStore.setState(createInitialState())` 保持(已无 `currentWorkspacePath`)。补 workspaceStore 重置:
+```ts
+    useConversationsStore.setState(createInitialState())
+    useWorkspaceStore.setState({ currentWorkspacePath: '', workspaceData: null, loading: false })
+    useAgentStore.setState({ pendingByTask: {}, tasks: {} })
+```
+
+(e) 行 156-164 `mocks.workspace.listWorkspaces.mockResolvedValue`,将:
+```ts
+    mocks.workspace.listWorkspaces.mockResolvedValue({
+      currentWorkspacePath: guiWorkspacePath,
+      workspaces: [{
+        path: guiWorkspacePath,
+        displayName: 'ant-chat-gui-workspace',
+        addedAt: 1,
+        lastOpenedAt: 1,
+      }],
+    })
+```
+改为:
+```ts
+    mocks.workspace.listWorkspaces.mockResolvedValue({
+      workspaces: [{
+        path: guiWorkspacePath,
+        displayName: 'ant-chat-gui-workspace',
+        addedAt: 1,
+        lastOpenedAt: 1,
+      }],
+    })
+```
+
+(f) 行 543-556 `seedActiveConversation`,将:
+```ts
+function seedActiveConversation(conversationId: string) {
+  const conversation = createConversation(conversationId)
+  conversationsById.set(conversationId, conversation)
+  messagesByConversation.set(conversationId, [])
+  useMessagesStore.setState({
+    activeConversationsId: conversationId as any,
+    messages: [],
+  })
+  useConversationsStore.setState({
+    activeConversationsId: conversationId,
+    conversations: [conversation],
+    currentWorkspacePath: guiWorkspacePath,
+  })
+}
+```
+改为:
+```ts
+function seedActiveConversation(conversationId: string) {
+  const conversation = createConversation(conversationId)
+  conversationsById.set(conversationId, conversation)
+  messagesByConversation.set(conversationId, [])
+  useMessagesStore.setState({
+    activeConversationsId: conversationId as any,
+    messages: [],
+  })
+  useConversationsStore.setState({
+    activeConversationsId: conversationId,
+    conversations: [conversation],
+  })
+  useWorkspaceStore.setState({ currentWorkspacePath: guiWorkspacePath })
+}
+```
+
+- [ ] **Step 2: 改 Sender.spec.tsx — mock 与 store 对齐**
+
+编辑 `apps/web/src/components/Sender/__tests__/Sender.spec.tsx`:
+
+(a) 行 10-12 `mocks` hoisted,将:
+```ts
+const mocks = vi.hoisted(() => ({
+  searchWorkspaceFiles: vi.fn(),
+}))
+```
+改为:
+```ts
+const mocks = vi.hoisted(() => ({
+  searchWorkspaceFiles: vi.fn(),
+  listWorkspaces: vi.fn(),
+}))
+```
+
+(b) 行 20-31 `vi.mock('@/api/workspaceApi')`,将:
+```ts
+vi.mock('@/api/workspaceApi', () => ({
+  default: {
+    listWorkspaces: vi.fn(async () => ({
+      currentWorkspacePath: '/tmp/workspace',
+      workspaces: [
+        { path: '/tmp/workspace', displayName: 'workspace' },
+      ],
+    })),
+    openWorkspace: vi.fn(),
+    searchWorkspaceFiles: mocks.searchWorkspaceFiles,
+  },
+}))
+```
+改为:
+```ts
+vi.mock('@/api/workspaceApi', () => ({
+  default: {
+    listWorkspaces: mocks.listWorkspaces,
+    openWorkspace: vi.fn(),
+    searchWorkspaceFiles: mocks.searchWorkspaceFiles,
+  },
+}))
+```
+
+(c) 导入补 `useWorkspaceStore`:
+```ts
+import { useConversationsStore } from '@/store/conversation'
+import { useMessagesStore } from '@/store/messages'
+import { useWorkspaceStore } from '@/store/workspace'
+```
+
+(d) 行 92-110 `beforeEach`,在 `mocks.searchWorkspaceFiles.mockResolvedValue(...)` 之后、`useMessagesStore.setState` 之前补 workspaceStore 设置;并将 `useConversationsStore.setState` 中删除 `currentWorkspacePath`。改为:
+```ts
+  beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+    Element.prototype.scrollIntoView = vi.fn()
+    mocks.searchWorkspaceFiles.mockResolvedValue([
+      { path: 'resume.md', name: 'resume.md', type: 'file' },
+    ])
+    mocks.listWorkspaces.mockResolvedValue({
+      workspaces: [
+        { path: '/tmp/workspace', displayName: 'workspace' },
+      ],
+    })
+    useMessagesStore.setState({
+      activeConversationsId: '',
+      messages: [],
+    })
+    useConversationsStore.setState({
+      activeConversationsId: '',
+      conversations: [],
+      abortCallbacks: [],
+      pageIndex: 0,
+      pageSize: 20,
+      conversationsTotal: 1,
+      streamingConversationIds: new Set<string>(),
+      loadVersion: 0,
+      workspaceConversations: {},
+    })
+    useWorkspaceStore.setState({ currentWorkspacePath: '/tmp/workspace', workspaceData: null, loading: false })
+    useChatSttingsStore.setState({
+      enableMCP: false,
+      agentMode: 'hybrid',
+    })
+  })
+```
+
+(e) 行 146-179 "选择文件引用后渲染 overlay token" 测试,将断言:
+```ts
+    await waitFor(() => {
+      expect(mocks.searchWorkspaceFiles).toHaveBeenCalledWith('res', 50)
+    })
+```
+改为:
+```ts
+    await waitFor(() => {
+      expect(mocks.searchWorkspaceFiles).toHaveBeenCalledWith('/tmp/workspace', 'res', 50)
+    })
+```
+
+- [ ] **Step 3: 运行前端测试确认通过**
+
+Run: `pnpm --filter @ant-chat/web test -- gui.spec Sender.spec`
+Expected: PASS。
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add apps/web/src/__tests__/gui.spec.tsx apps/web/src/components/Sender/__tests__/Sender.spec.tsx
+git commit -m "test(web): gui.spec 与 Sender.spec 对齐 workspaceStore SSOT"
+```
+
+---
+
+## Task 13: 全量检查与原 bug 行为测试
+
+**Files:**
+- Test: `apps/web/src/store/conversation/__tests__/activateWorkspace.spec.ts`(Task 8 已建,此处补竞态守护用例)
+- Test: `apps/web/src/__tests__/workspace-bug.spec.tsx`(新增,覆盖原 bug)
+
+**Interfaces:**
+- Consumes: Task 6-11 全部产出。
+- Produces: 全量 `pnpm check` 通过;原 bug 的行为回归测试(添加工作区后发送消息归属新工作区)。
+
+- [ ] **Step 1: 补 activateWorkspace 竞态守护测试**
+
+在 `apps/web/src/store/conversation/__tests__/activateWorkspace.spec.ts` 的 `describe('activateWorkspace')` 内追加:
+
+```ts
+  it('分页加载期间切换工作区,旧加载返回不污染新工作区顶层 conversations', async () => {
+    useWorkspaceStore.setState({ currentWorkspacePath: '/a' })
+    // 控制分页加载延迟,使切换发生在加载返回前
+    let resolveList: (value: { data: IConversations[], total: number }) => void = () => {}
+    chatMocks.getWorkspaceConversations.mockImplementationOnce(
+      () => new Promise(resolve => { resolveList = resolve }),
+    )
+
+    const pending = activateWorkspace('/a')
+    // 此时 /a 的首页加载在途;切到 /b
+    useWorkspaceStore.setState({ currentWorkspacePath: '/b' })
+    useConversationsStore.getState().switchWorkspaceSlice('/b')
+    useConversationsStore.setState({ conversations: [makeConversation('in-b', '/b')] })
+
+    // 旧加载返回 /a 的数据
+    resolveList({ data: [makeConversation('late-a', '/a')], total: 1 })
+    await pending
+
+    // 新工作区顶层 conversations 不被 /a 的迟到数据污染
+    const topIds = useConversationsStore.getState().conversations.map(c => c.id)
+    expect(topIds).not.toContain('late-a')
+  })
+```
+
+> 注:此用例验证 `nextPageConversationsAction` 的竞态守护——`activateWorkspace` 内部在 `conversations.length === 0 && conversationsTotal > 0` 时触发 `nextPage`。若该用例因 `activateWorkspace` 的首页已加载走 `ensure` 路径而不触发 `nextPage`,调整为直接测 `nextPageConversationsAction`:在 `/a` 发起 `nextPage` 后切到 `/b`,再 resolve,断言 `/b` 顶层不受污染。以实际行为为准。
+
+- [ ] **Step 2: 写原 bug 行为测试 — 添加工作区后发送消息归属新工作区**
+
+创建 `apps/web/src/__tests__/workspace-bug.spec.tsx`:
+
+```ts
+import type { AgentTaskSnapshot, ConversationsId, IConversations, IMessage } from '@ant-chat/shared'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { createMemoryRouter, Navigate, RouterProvider } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import AppWrapper from '../App'
+import { ChatLayout } from '../components/ChatLayout'
+import { ChatPage } from '../pages/Chat'
+import { useAgentStore } from '../store/agent'
+import { useConversationsStore } from '../store/conversation'
+import { createInitialState } from '../store/conversation/initialState'
+import { setActiveConversationsId, useMessagesStore } from '../store/messages'
+import { useWorkspaceStore } from '../store/workspace'
+
+const mocks = vi.hoisted(() => ({
+  agent: {
+    approvePendingAction: vi.fn(async () => null),
+    approvePendingActionWithWhitelist: vi.fn(async () => null),
+    cancelTask: vi.fn(async () => null),
+    injectSteering: vi.fn(async (): Promise<IMessage> => ({
+      id: 'msg-s', convId: 'c' as ConversationsId, createdAt: 1, role: 'user',
+      status: 'success', content: [{ type: 'text', text: 's' }], turnId: 'u-1',
+    })),
+    listActiveTasks: vi.fn<() => Promise<AgentTaskSnapshot[]>>(async () => []),
+    rejectPendingAction: vi.fn(async () => null),
+    startTurn: vi.fn(),
+  },
+  chat: {
+    getConversationById: vi.fn(),
+    getMessagesByConvId: vi.fn<(id: string) => Promise<IMessage[]>>(async () => []),
+    getMessagesByConvIdWithPagination: vi.fn(),
+    getWorkspaceConversations: vi.fn(async () => ({ data: [], total: 0 })),
+    initConversationsTitle: vi.fn(async () => ({ success: true, data: null })),
+    updateConversation: vi.fn(),
+  },
+  generalSettings: {
+    getSettings: vi.fn(async () => ({ assistantModelId: '', proxySettings: { mode: 'system', customProxyUrl: '' } })),
+    resetSettings: vi.fn(),
+    updateSettings: vi.fn(),
+  },
+  provider: {
+    getAllAbvailableModels: vi.fn(async () => [{
+      id: 'p1', name: 'P', models: [{ id: 'm1', model: 'mock', name: 'Mock', providerId: 'p1', maxTokens: 1024, temperature: 0 }],
+    }]),
+    getModelInfoById: vi.fn(async () => null),
+  },
+  memory: { getMemoryFiles: vi.fn(), rollbackSoul: vi.fn(), updateMemoryFiles: vi.fn() },
+  skill: { listSkills: vi.fn(async () => ({ skills: [] })) },
+  workspace: {
+    chooseWorkspace: vi.fn(async () => null),
+    listWorkspaces: vi.fn(),
+    openWorkspace: vi.fn(),
+    addWorkspace: vi.fn(),
+    searchWorkspaceFiles: vi.fn(async () => []),
+  },
+}))
+
+vi.mock('@/api/agentApi', () => ({ default: mocks.agent }))
+vi.mock('@/api/chatApi', () => ({ default: mocks.chat }))
+vi.mock('@/api/generalSettingsApi', () => ({ generalSettingsApi: mocks.generalSettings }))
+vi.mock('@/api/providerApi', () => ({ providerApi: mocks.provider }))
+vi.mock('@/api/memoryApi', () => ({ memoryApi: mocks.memory }))
+vi.mock('@/api/skillApi', () => ({ skillApi: mocks.skill }))
+vi.mock('@/api/workspaceApi', () => ({ default: mocks.workspace }))
+vi.mock('@/components/Search', () => ({ SearchContainer: () => null }))
+
+const oldWorkspace = '/tmp/ant-chat-old-ws'
+const newWorkspace = '/tmp/ant-chat-new-ws'
+
+describe('workspace state consolidation bug', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.matchMedia = vi.fn().mockImplementation(query => ({
+      addEventListener: vi.fn(), dispatchEvent: vi.fn(), matches: false, media: query,
+      onchange: null, removeEventListener: vi.fn(),
+    }))
+    Element.prototype.scrollIntoView = vi.fn()
+    useMessagesStore.setState({ activeConversationsId: '' as any, messages: [] })
+    useConversationsStore.setState(createInitialState())
+    useWorkspaceStore.setState({ currentWorkspacePath: '', workspaceData: null, loading: false })
+    useAgentStore.setState({ pendingByTask: {}, tasks: {} })
+
+    mocks.workspace.listWorkspaces.mockResolvedValue({
+      workspaces: [{ path: oldWorkspace, displayName: 'old', addedAt: 1, lastOpenedAt: 1 }],
+    })
+    mocks.workspace.addWorkspace.mockImplementation(async (path: string) => ({
+      workspaces: [
+        { path: oldWorkspace, displayName: 'old', addedAt: 1, lastOpenedAt: 1 },
+        { path, displayName: 'new', addedAt: 2, lastOpenedAt: 2 },
+      ],
+    }))
+    mocks.chat.getMessagesByConvIdWithPagination.mockResolvedValue({ data: [], total: 0 })
+    mocks.chat.getMessagesByConvId.mockResolvedValue([])
+    mocks.chat.getConversationById.mockResolvedValue(undefined)
+  })
+
+  it('添加新工作区后发送消息,会话归属新工作区而非旧工作区', async () => {
+    const createdConversations: IConversations[] = []
+    mocks.agent.startTurn.mockImplementation(async (opts: { workspacePath?: string }) => {
+      const conv: IConversations = {
+        id: 'conv-new',
+        workspacePath: opts.workspacePath,
+        title: 'new conv',
+        createdAt: 1,
+        updatedAt: 1,
+        settings: { modelId: 'm1', providerId: 'p1', systemPrompt: '', temperature: 0, maxTokens: 1024 },
+      } as IConversations
+      createdConversations.push(conv)
+      return { taskId: 't1', conversationId: conv.id, userMessageId: 'u1', conversation: conv }
+    })
+
+    renderGui('/chat')
+    await screen.findByTestId('chat-input')
+
+    // 添加新工作区(模拟 WorkspacePanels.handlePickerConfirm 的路径)
+    await useWorkspaceStore.getState().addWorkspace(newWorkspace)
+    const { activateWorkspace } = await import('../store/conversation/actions')
+    await activateWorkspace(newWorkspace)
+
+    // 此时 workspaceStore.currentWorkspacePath 应为新工作区
+    expect(useWorkspaceStore.getState().currentWorkspacePath).toBe(newWorkspace)
+
+    // 发送消息
+    fireEvent.change(screen.getByTestId('chat-input'), { target: { value: 'hello' } })
+    fireEvent.click(screen.getByTestId('chat-submit'))
+
+    await waitFor(() => {
+      expect(mocks.agent.startTurn).toHaveBeenCalledWith(expect.objectContaining({
+        workspacePath: newWorkspace,
+      }))
+    })
+    // 会话归属新工作区,不是旧工作区
+    expect(createdConversations[0].workspacePath).toBe(newWorkspace)
+    expect(createdConversations[0].workspacePath).not.toBe(oldWorkspace)
+  })
+
+  it('删除当前工作区后,当前路径回退到 lastOpenedAt 最大者,后续发送归属回退后的工作区', async () => {
+    // 预置:当前为新工作区,列表含旧+新
+    useWorkspaceStore.setState({
+      currentWorkspacePath: newWorkspace,
+      workspaceData: {
+        workspaces: [
+          { path: oldWorkspace, displayName: 'old', isDefault: false, lastOpenedAt: 5 },
+          { path: newWorkspace, displayName: 'new', isDefault: false, lastOpenedAt: 9 },
+        ],
+      },
+    })
+    mocks.workspace.listWorkspaces.mockResolvedValue({
+      workspaces: [
+        { path: oldWorkspace, displayName: 'old', isDefault: false, lastOpenedAt: 5 },
+      ],
+    })
+
+    // 删除当前工作区(新)
+    await useWorkspaceStore.getState().removeWorkspace(newWorkspace)
+    const { activateWorkspace } = await import('../store/conversation/actions')
+    await activateWorkspace(useWorkspaceStore.getState().currentWorkspacePath)
+
+    // 当前路径回退到旧工作区(lastOpenedAt 最大者)
+    expect(useWorkspaceStore.getState().currentWorkspacePath).toBe(oldWorkspace)
+
+    mocks.agent.startTurn.mockImplementation(async (opts: { workspacePath?: string }) => ({
+      taskId: 't2', conversationId: 'c2', userMessageId: 'u2',
+      conversation: {
+        id: 'c2', workspacePath: opts.workspacePath, title: 'c2', createdAt: 1, updatedAt: 1,
+        settings: { modelId: 'm1', providerId: 'p1', systemPrompt: '', temperature: 0, maxTokens: 1024 },
+      } as IConversations,
+    }))
+
+    renderGui('/chat')
+    await screen.findByTestId('chat-input')
+    fireEvent.change(screen.getByTestId('chat-input'), { target: { value: 'after delete' } })
+    fireEvent.click(screen.getByTestId('chat-submit'))
+
+    await waitFor(() => {
+      expect(mocks.agent.startTurn).toHaveBeenCalledWith(expect.objectContaining({
+        workspacePath: oldWorkspace,
+      }))
+    })
+  })
+})
+
+function renderGui(initialPath: string) {
+  const router = createMemoryRouter([
+    {
+      path: '/',
+      Component: AppWrapper,
+      children: [
+        { index: true, element: <Navigate replace to="/chat" /> },
+        { path: 'chat', Component: ChatLayout, children: [{ index: true, Component: ChatPage }] },
+      ],
+    },
+  ], { initialEntries: [initialPath] })
+  return render(<RouterProvider router={router} />)
+}
+```
+
+- [ ] **Step 3: 运行新测试确认通过**
+
+Run: `pnpm --filter @ant-chat/web test -- workspace-bug activateWorkspace`
+Expected: PASS。若失败,定位是 store 派生逻辑还是组件读取源问题,回看 Task 6/9/10/11。
+
+- [ ] **Step 4: 运行全量 check**
+
+Run: `pnpm check`
+Expected: PASS(type-check + lint + unit tests 全绿)。
+
+> 若 `pnpm check` 报错:
+> - 类型错误:运行 `pnpm type-check` 看 `tsc -b` 跨包报错,定位漏改的 `currentWorkspacePath`/`switchWorkspaceConversationsAction`/`getCurrentWorkspacePath` 引用。
+> - Lint 错误:运行 `pnpm lint --fix` 自动修复导入排序等。
+> - 测试失败:确认是否为本整合导致,修复逻辑后重跑全量 `pnpm check`。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add apps/web/src/store/conversation/__tests__/activateWorkspace.spec.ts apps/web/src/__tests__/workspace-bug.spec.tsx
+git commit -m "test(web): 补 activateWorkspace 竞态守护与原 bug 行为回归测试"
+```
+
+---
+
+## Self-Review
+
+### 1. Spec coverage(设计文档逐节核对)
+
+- §背景/根因:闭包陷阱(Task 9 删 `reloadCurrentWorkspace`)、删除不同步(Task 9 `handleDeleteWorkspace` 调 `activateWorkspace`)、第三源(Task 10 消除 `WorkspaceSelector` 本地 state)——均覆盖。
+- §目标 SSOT:Task 6 新增顶层字段;Task 7 删 `conversationsStore.currentWorkspacePath`;Task 10 删 `WorkspaceSelector` 本地——覆盖。
+- §架构 `activateWorkspace`:Task 8 新增,签名与行为与设计文档一致——覆盖。
+- §逐文件改动 1-8:
+  - store/workspace/store.ts → Task 6 ✓
+  - conversation/initialState.ts → Task 7 ✓
+  - conversation/conversationsStore.ts → Task 7(`switchWorkspaceSlice`/`getCurrentWorkspacePath`/`reset`/`saveCurrentWorkspaceSlice`)✓
+  - conversation/actions.ts → Task 8(`activateWorkspace`/`clearConversationsAction`/`nextPageConversationsAction` 竞态守护)✓
+  - WorkspacePanels.tsx → Task 9 ✓
+  - WorkspaceSelector.tsx → Task 10 ✓
+  - Chat.tsx → Task 11 ✓
+  - Sender.tsx → Task 11 ✓
+- §后端方案 B:
+  - workspaceService.ts → Task 2 ✓
+  - appRuntime.ts → Task 3 ✓
+  - agentTurnService.ts → Task 4 ✓
+  - rpcHandlers.ts/app-rpc.ts/ipc-events.ts → Task 1 + Task 3 ✓
+  - ListWorkspacesData 删字段 → Task 1 ✓
+- §错误处理与边界:空路径 no-op(Task 8)、分页竞态(Task 8 + Task 13)、循环依赖(Task 7 单向导入)、跨实例通知(Task 10 保留 `emitWorkspaceChanged`)、后端写操作未传抛错(Task 3/4)、listConversations 全量语义(Task 3)、启动派生(Task 6)——覆盖。
+- §测试:前端 6 项 + 后端 4 项,散落于各 Task 的测试步骤与 Task 13——覆盖。
+- §迁移策略:单 PR,顺序后端→前端 store→组件→测试,每步 `pnpm check`——Task 顺序与提交点对应。
+- **边界补充(用户决策)**:`searchFiles` 端点入参必传(Task 1 类型 + Task 3 实现 + Task 11 前端调用 + Task 12 测试);`parseConfig` 容忍旧字段(Task 2 实现 + Task 2 测试)——覆盖。
+
+### 2. Placeholder scan
+
+无 "TBD/TODO/implement later"。每个代码步骤含完整代码块;测试步骤含完整测试代码;命令含 expected 输出。
+
+### 3. Type consistency
+
+- `activateWorkspace(workspacePath: string): Promise<void>`:Task 8 定义,Task 9/10/11/13 调用一致。
+- `switchWorkspaceSlice(workspacePath: string)`:Task 7 定义,Task 8(`ensureWorkspaceConversationsAction` 内部改引用)+ Task 13(竞态测试直接调用)一致。
+- `getCurrentWorkspacePath(): string`:Task 7(conversationsStore 内部)+ Task 8(actions 内部)各自定义同名 helper,均读 `useWorkspaceStore.getState().currentWorkspacePath`——一致(两处独立定义避免跨模块导出内部 helper,符合现有代码风格)。
+- `useWorkspaceStore.getState().currentWorkspacePath`:Task 6 定义顶层字段,Task 7/8/9/10/11/13 读取一致。
+- `WorkspaceConfig`/`ListWorkspacesData` 无 `currentWorkspacePath`:Task 1 定义,Task 2/3/6/12 一致使用。
+- `workspace.searchWorkspaceFiles` 入参 `{ workspacePath: string, query?, limit? }`:Task 1 契约,Task 3 实现 `searchFiles(workspacePath, query, limit)`,Task 11 `workspaceApi.searchWorkspaceFiles(workspacePath, query, limit)`,Task 12 测试断言 `('/tmp/workspace', 'res', 50)`——一致。
+- `StartAgentTurnOptions.workspacePath: string`:Task 1 必传,Task 4 实现,Task 11/13 前端传值一致。
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-21-workspace-state-consolidation.md`. Two execution options:
+
+**1. Subagent-Driven(推荐)** — 每个 Task 派发独立子代理,任务间两阶段评审,快速迭代。
+
+**2. Inline Execution** — 在当前会话用 executing-plans 批量执行,带检查点评审。
+
+Which approach?

--- a/docs/superpowers/specs/2026-06-21-workspace-state-consolidation-design.md
+++ b/docs/superpowers/specs/2026-06-21-workspace-state-consolidation-design.md
@@ -28,7 +28,7 @@ Sender 的「切换工作区」路径(`Sender.tsx:493-496`)用入参 `nextWorksp
 
 ## 目标
 
-以 `useWorkspaceStore.workspaceData.currentWorkspacePath` 为唯一事实源(SSOT)。删除 `conversationsStore.currentWorkspacePath` 字段,删除 `WorkspaceSelector` 的本地 `workspaceData`。所有需要「当前工作区」的读写统一从 workspaceStore 取。`conversationsStore` 的分片缓存 `workspaceConversations: Record<path, Slice>` 保留,但其 save/restore 用的 key 改为跨 store 从 workspaceStore 读取。
+以 `useWorkspaceStore.currentWorkspacePath`(workspaceStore 顶层字段,整合后新增)为唯一事实源(SSOT)。删除 `conversationsStore.currentWorkspacePath` 字段,删除 `WorkspaceSelector` 的本地 `workspaceData`。所有需要「当前工作区」的读写统一从 workspaceStore 顶层字段取。`conversationsStore` 的分片缓存 `workspaceConversations: Record<path, Slice>` 保留,但其 save/restore 用的 key 改为跨 store 从 workspaceStore 读取。
 
 整合后,显示(Sender 读 workspaceStore)与归属(Chat 读 workspaceStore)天然一致,因为只剩一个源;闭包陷阱、删除不同步、第三源三个缺口一并消除。
 
@@ -36,13 +36,13 @@ Sender 的「切换工作区」路径(`Sender.tsx:493-496`)用入参 `nextWorksp
 
 ```
 useWorkspaceStore  ← 唯一事实源(SSOT)
-  .workspaceData.currentWorkspacePath   写入:增/删/切/refresh
-  .workspaceData.workspaces             工作区列表
+  .currentWorkspacePath                       顶层字段,写入:增/删/切/refresh(前端显式设置+启动派生)
+  .workspaceData.workspaces                   工作区列表(后端不再回传 currentWorkspacePath)
 
 useConversationsStore  ← 不再持有 currentWorkspacePath
   .workspaceConversations: Record<path, Slice>   分片缓存,key 来自 workspaceStore
   .conversations / pageIndex / conversationsTotal / loadVersion   顶层=当前工作区 slice 的投影
-  需要「当前 path」时 → useWorkspaceStore.getState().workspaceData.currentWorkspacePath
+  需要「当前 path」时 → useWorkspaceStore.getState().currentWorkspacePath
 ```
 
 ### 写入收口:统一入口 `activateWorkspace`
@@ -58,9 +58,9 @@ useConversationsStore  ← 不再持有 currentWorkspacePath
 export async function activateWorkspace(workspacePath: string): Promise<void>
 ```
 
-- **入参**:目标工作区绝对路径。由调用方从 workspaceStore action 的返回值(`data.currentWorkspacePath`)或 `item.path` 传入,**不依赖任何闭包渲染期变量**。
+- **入参**:目标工作区绝对路径。由调用方传入,与紧邻的 workspaceStore action 的 `path` 入参一致(如 `addWorkspace(path)` 后调 `activateWorkspace(path)`),或从 `useWorkspaceStore.getState().currentWorkspacePath` 取(如 `removeWorkspace`/`refresh` 后,workspaceStore action 已派生好新当前路径)。**不依赖任何闭包渲染期变量**。
 - **行为**:空路径 → 仅 `setActiveConversationsId('')`;非空 → `ensureWorkspaceConversationsAction(path)` + `switchWorkspaceSlice(path)` + 必要时 `nextPageConversationsAction()` 补加载首页。
-- **返回**:无返回值。调用方需要 `ListWorkspacesData` 时从 workspaceStore action 的返回值拿。
+- **返回**:无返回值。不写 workspaceStore(由 workspaceStore action 负责)。
 - **幂等**:目标路径已是当前路径时,`switchWorkspaceSlice` 内部 no-op,`ensureWorkspaceConversationsAction` 内部有 `loaded` 守卫,安全。
 
 ## 数据流(以「添加工作区」为例)
@@ -77,19 +77,28 @@ reloadCurrentWorkspace() → 用闭包旧 path → switchWorkspaceConversationsA
 
 ```
 handlePickerConfirm(path):
-  data = await addWorkspace(path)                      // workspaceStore 切新(SSOT 更新)
-  await activateWorkspace(data.currentWorkspacePath)   // 用返回值,不依赖闭包
+  await addWorkspace(path)                              // workspaceStore action: set currentWorkspacePath=path (SSOT 更新)
+  await activateWorkspace(path)                         // 同步会话分片缓存到该路径,用入参不依赖闭包
     → ensureWorkspaceConversationsAction(path)
-    → switchWorkspaceSlice(path)                       // 只做分片 save/restore,不写 currentWorkspacePath
+    → switchWorkspaceSlice(path)                        // 只做分片 save/restore,不写 currentWorkspacePath
 ```
 
 显示(Sender 读 workspaceStore)与归属(Chat 读 workspaceStore)天然一致。
 
+**职责边界**:workspaceStore action(`addWorkspace`/`openWorkspace`/`removeWorkspace`/`refresh`)负责设置 SSOT 的 `currentWorkspacePath`;`activateWorkspace(path)` 只负责把会话分片缓存切换到该路径(ensure + switchSlice + 补加载)。调用方先调 workspaceStore action,再调 `activateWorkspace(同一 path)`。`activateWorkspace` 不写 workspaceStore,避免双写。
+
 ## 逐文件改动
 
-### 1. `store/workspace/store.ts`(SSOT,代码不变)
+### 1. `store/workspace/store.ts`(SSOT,承担当前路径的显式设置)
 
-workspaceStore 保持四个 action(`refresh`/`openWorkspace`/`addWorkspace`/`removeWorkspace`)各自 `set({ workspaceData: data })`。承担 SSOT 角色,**代码不改**。
+workspaceStore 保持四个 action(`refresh`/`openWorkspace`/`addWorkspace`/`removeWorkspace`),但行为调整以适配后端不再回传 `currentWorkspacePath`(详见「后端 `currentWorkspacePath`:去掉持久化」):
+
+- store state 新增 `currentWorkspacePath: string`(前端派生+显式设置的 SSOT 字段,初始 `''`)。`workspaceData` 保留 `workspaces` 列表,但不再含 `currentWorkspacePath`(后端已删该字段)。
+- `refresh`:拉取 `workspaces` 列表后,若当前 `currentWorkspacePath` 为空或不在列表中,取 `workspaces` 中 `lastOpenedAt` 最大者为当前工作区;列表为空时取默认工作区。
+- `openWorkspace(path)`/`addWorkspace(path)`:后端返回新 `workspaces` 列表后,`set({ workspaceData: { workspaces }, currentWorkspacePath: path })` —— 操作的目标路径即为新当前工作区,前端显式设置。
+- `removeWorkspace(path)`:后端返回新列表后,若删的是当前工作区,`currentWorkspacePath` 回退到 `workspaces` 中 `lastOpenedAt` 最大者。
+
+workspaceStore 仍是 SSOT,只是 `currentWorkspacePath` 来源从「后端回传」改为「前端在操作时显式设置 + 启动时按 `lastOpenedAt` 派生」。
 
 ### 2. `store/conversation/initialState.ts` — 删除字段
 
@@ -103,9 +112,11 @@ workspaceStore 保持四个 action(`refresh`/`openWorkspace`/`addWorkspace`/`rem
 
 ```ts
 function getCurrentWorkspacePath(): string {
-  return useWorkspaceStore.getState().workspaceData?.currentWorkspacePath ?? ''
+  return useWorkspaceStore.getState().currentWorkspacePath ?? ''
 }
 ```
+
+(读 workspaceStore 新增的顶层 `currentWorkspacePath` 字段,而非 `workspaceData.currentWorkspacePath` —— 后者已随后端去字段而删除。)
 
 - `switchWorkspace(path)` 重命名为 `switchWorkspaceSlice(path)`:
   - no-op 守卫 `workspacePath === state.currentWorkspacePath` 改为 `workspacePath === getCurrentWorkspacePath()`。
@@ -121,7 +132,7 @@ function getCurrentWorkspacePath(): string {
 
 `switchWorkspaceConversationsAction` 删除,所有外部调用点改为调 `activateWorkspace`。注意 `ensureWorkspaceConversationsAction`(actions.ts:72)内部原直接调用 `useConversationsStore.getState().switchWorkspace(workspacePath)`,改名后同步改为 `switchWorkspaceSlice`;但 `activateWorkspace` 已统一封装 ensure+switch,外部调用方不再单独调 `ensureWorkspaceConversationsAction` + `switchWorkspace`,仅在 `WorkspacePanels.toggleWorkspace`(展开非当前工作区面板预加载)这类只需 ensure 不需切换顶层 slice的场景保留单独调 `ensureWorkspaceConversationsAction`。
 
-`clearConversationsAction`、`nextPageConversationsAction` 的 `currentWorkspacePath` 改从 `useWorkspaceStore.getState().workspaceData?.currentWorkspacePath` 取。
+`clearConversationsAction`、`nextPageConversationsAction` 的 `currentWorkspacePath` 改从 `useWorkspaceStore.getState().currentWorkspacePath` 取。
 
 `nextPageConversationsAction` 的竞态守护:
 
@@ -129,7 +140,7 @@ function getCurrentWorkspacePath(): string {
 // 修复前
 if (draft.currentWorkspacePath !== currentWorkspacePath || ...) return
 // 修复后:produce 回调内读 workspaceStore 当前路径与发起时的 currentWorkspacePath 比较
-if (useWorkspaceStore.getState().workspaceData?.currentWorkspacePath !== currentWorkspacePath || ...) return
+if (useWorkspaceStore.getState().currentWorkspacePath !== currentWorkspacePath || ...) return
 ```
 
 语义不变:分页加载是异步的,加载期间用户可能切了工作区,加载回来时若 workspaceStore 当前路径已不是发起时的路径,则丢弃结果,不污染新工作区顶层 conversations。
@@ -137,65 +148,151 @@ if (useWorkspaceStore.getState().workspaceData?.currentWorkspacePath !== current
 ### 5. `components/Workspace/WorkspacePanels.tsx`
 
 - 删除 `reloadCurrentWorkspace`(闭包陷阱根源,`WorkspacePanels.tsx:92-97`)。
-- 删除本地 `currentWorkspacePath` 派生(`WorkspacePanels.tsx:72`),改为 `const currentWorkspacePath = workspaceData?.currentWorkspacePath ?? ''`。
-- `handlePickerConfirm`:`addWorkspace(path)` 后调 `await activateWorkspace(data.currentWorkspacePath)`,用返回值不用闭包。
-- `handleDeleteWorkspace`:`removeWorkspace(path)` 后调 `await activateWorkspace(data.currentWorkspacePath)`(后端返回删除后的新当前路径),修复删除不同步缺口。
+- 删除本地 `currentWorkspacePath` 派生(`WorkspacePanels.tsx:72`),改为 `const currentWorkspacePath = useWorkspaceStore(state => state.currentWorkspacePath)`(读 workspaceStore 顶层字段)。
+- `handlePickerConfirm`:`await addWorkspace(path)` 后调 `await activateWorkspace(path)`。`addWorkspace` 内部已 `set({ currentWorkspacePath: path })`,故用入参 `path`(或 `useWorkspaceStore.getState().currentWorkspacePath`),不依赖闭包渲染期变量。
+- `handleDeleteWorkspace`:`removeWorkspace(path)` 后调 `await activateWorkspace(useWorkspaceStore.getState().currentWorkspacePath)`(removeWorkspace action 内部已回退到 `lastOpenedAt` 最大者),修复删除不同步缺口。
 - `openConversation`/`createConversation`:`openWorkspace` 后调 `activateWorkspace(workspacePath)`。
-- `initialize`:`refreshWorkspace()` 后调 `activateWorkspace(data.currentWorkspacePath)`。
+- `initialize`:`refreshWorkspace()` 后调 `activateWorkspace(useWorkspaceStore.getState().currentWorkspacePath)`(refresh action 内部已按 `lastOpenedAt` 派生当前路径)。
 
 ### 6. `components/Workspace/WorkspaceSelector.tsx` — 消除第三源
 
-- 删除本地 `useReducer workspaceData`、`refreshWorkspaces` 里的 `setWorkspaceData`。
-- 改读 `useWorkspaceStore(state => state.workspaceData)`。
-- `applyWorkspaceData` 改为:不再 `setWorkspaceData`(workspaceStore action 已 set),只 `setActiveConversationsId('') + activateWorkspace(data.currentWorkspacePath)`。
-- `handlePickerConfirm`/`confirmRemoveWorkspace`/`handleOpenWorkspace` 改调 workspaceStore 的 `addWorkspace`/`removeWorkspace`/`openWorkspace` + `activateWorkspace`。
+- 删除本地 `useReducer workspaceData` 与 `refreshWorkspaces` 里的 `setWorkspaceData`。
+- 改读 `useWorkspaceStore(state => state.workspaceData)`(列表)与 `useWorkspaceStore(state => state.currentWorkspacePath)`(当前)。
+- 删除 `applyWorkspaceData` 中间函数。三个操作直接走 workspaceStore action + `activateWorkspace`:
+  - `handlePickerConfirm(path)`:`await addWorkspace(path)`(内部 set currentWorkspacePath)→ `await activateWorkspace(path)`。
+  - `confirmRemoveWorkspace(path)`:`await removeWorkspace(path)`(内部回退 currentWorkspacePath)→ `await activateWorkspace(useWorkspaceStore.getState().currentWorkspacePath)`。
+  - `handleOpenWorkspace(item)`:`await openWorkspace(item.path)`(内部 set currentWorkspacePath)→ `await activateWorkspace(item.path)`。
+  - 每个操作前 `await setActiveConversationsId('')`。
+- `refreshWorkspaces` 简化为:调 `useWorkspaceStore.getState().refresh()`(不再自己调 `workspaceApi.listWorkspaces`)。组件挂载 useEffect 改为依赖 workspaceStore,无需本地 refresh。
 - `emitWorkspaceChanged` 保留(通知其他实例),但不再是补同步兜底。
-- `handleOpenWorkspace` 的 `item.path === workspaceData?.currentWorkspacePath` 守卫改用 workspaceStore 的值。
+- `handleOpenWorkspace` 的 `item.path === workspaceData?.currentWorkspacePath` 守卫改用 `useWorkspaceStore.getState().currentWorkspacePath`。
 
 ### 7. `components/Chat/Chat.tsx`
 
-- `currentWorkspacePath`(`Chat.tsx:28`)从 `useConversationsStore` 改为 `useWorkspaceStore(state => state.workspaceData?.currentWorkspacePath)`。
-- 其余不动,发送消息归属(`Chat.tsx:83` 的 `workspacePath: currentWorkspacePath`)自然正确。
+- `currentWorkspacePath`(`Chat.tsx:28`)从 `useConversationsStore` 改为 `useWorkspaceStore(state => state.currentWorkspacePath)`(读 workspaceStore 顶层字段)。
+- 其余不动,发送消息归属(`Chat.tsx:83` 的 `workspacePath: currentWorkspacePath`)自然正确。`currentWorkspacePath` 现在恒为 workspaceStore 的 SSOT 值,发送时显式传给后端,后端 `createConversation`/`startTurn` 必收必用。
 
 ### 8. `components/Sender/Sender.tsx`
 
-- 已读 workspaceStore,基本不动。
-- `handleSwitchWorkspace`(`Sender.tsx:478-504`)的 `openWorkspace` + `switchWorkspaceConversationsAction` 改为 `openWorkspace` + `activateWorkspace(nextWorkspacePath)`,与统一入口对齐。
+- 显示工作区名仍读 `workspaceData.workspaces` + `useWorkspaceStore(state => state.currentWorkspacePath)`(从匹配 `workspaceData.currentWorkspacePath` 改为读顶层字段)。
+- `handleSwitchWorkspace`(`Sender.tsx:478-504`):`openWorkspace(nextWorkspacePath)`(内部已 set `currentWorkspacePath`)后,将 `switchWorkspaceConversationsAction(nextWorkspacePath)` 改为 `activateWorkspace(nextWorkspacePath)`,与统一入口对齐。
+- `selectableWorkspaces`、`hasWorkspace` 等读 `workspaceData` 列表的逻辑不变。
+
+## 后端 `currentWorkspacePath`:去掉持久化(方案 B)
+
+### 现状与判断
+
+后端 `WorkspaceService` 持久化一份 `currentWorkspacePath`(`packages/app-data/src/workspace/workspaceService.ts`),由 `addWorkspace`/`openWorkspace`/`removeWorkspace` 即时写盘(`workspaceService.ts:95/116/133`),在会话域作为**归属兜底默认值**被读取:
+
+- `appRuntime.ts:161` `createConversation`:`workspacePath ?? getCurrentWorkspacePath()`
+- `appRuntime.ts:153` `listConversations`、`appRuntime.ts:177` `clearWorkspaceConversations`:同理兜底
+- `agentTurnService.ts:39` `startTurn`:`workspacePath ?? getCurrentWorkspacePath() ?? process.cwd()`
+
+但前端所有会话操作都经前端 store 显式传 `workspacePath`,后端兜底在正常路径下基本不被触发。它实际是一个「前端漏传时的隐式默认」,价值低且有害:
+
+1. **模糊强语义**:会话归属是强语义,不该有「隐式默认」。后端用「最近打开的工作区」兜底,把「前端忘了传/传错」这个错误静默吞掉,凑一个看似合理的结果。本 bug 正是因此藏住 —— 前端传错路径时后端照单全收。
+2. **制造前后端两份「当前工作区」**:前端一份(workspaceStore)、后端一份(持久化 config),靠「前端显式传值覆盖后端兜底」维系一致。一旦前端传错,后端兜底不仅不纠错,反而让错误结果落地。
+3. **「记住上次打开的工作区」可由前端启动逻辑承担**:后端 `workspaces` 列表的 `lastOpenedAt` 已记录最近打开顺序,启动时前端可据此选当前工作区,不需要 `currentWorkspacePath` 这个独立字段。
+4. **`startTurn` 的 `?? process.cwd()` 兜底**:说明连后端自己都不完全信任该字段一定有值,层层兜底本身就是价值不足的信号。
+
+### 决策:去掉后端 `currentWorkspacePath`,会话接口改读写区分语义
+
+- **写操作(createConversation、startTurn)**:`workspacePath` 改为必传(`string`),后端不再兜底,未传则抛错。会话创建必须显式归属某个工作区。
+- **读操作(listConversations)**:`workspacePath` 保持可选,但语义改为「未传 = 跨工作区全量查询」(对应 `workspace_path IS NULL` 或忽略筛选),**不再用 `currentWorkspacePath` 兜底**。这保留「全量查询」能力(如 `chat.getConversations` 全量入口)。
+- **clearWorkspaceConversations**:RPC schema 已声明 `workspacePath: string` 必传(`app-rpc.ts:52`),实现里却是 `workspacePath?: string` + 兜底(`appRuntime.ts:176`)。统一为必传,去掉兜底,与 schema 对齐。
+
+### 后端逐文件改动
+
+#### `packages/app-data/src/workspace/workspaceService.ts`
+
+- `WorkspaceConfig` 删除 `currentWorkspacePath` 字段(对应 `packages/shared/src/interfaces/workspace.ts:2` 的可选字段同步删除)。
+- `addWorkspace`/`openWorkspace`/`removeWorkspace` 的 `saveConfig` 不再写 `currentWorkspacePath`,只更新 `workspaces` 列表(及 `lastOpenedAt`)。
+- `ensureInitialized` 删除 `currentWorkspacePath` 的校验与回填逻辑(`workspaceService.ts:62-71`),只保证默认工作区存在于列表。
+- `listWorkspaces` 返回的 `ListWorkspacesData` 不再含 `currentWorkspacePath`。`currentWorkspacePath` 字段从 `ListWorkspacesData`(`packages/shared/src/interfaces/workspace.ts:18`)删除 —— 前端启动时改由「`workspaces` 列表中 `lastOpenedAt` 最大者」决定当前工作区。
+- 删除 `getCurrentWorkspacePath()` 方法(`workspaceService.ts:140-143`)及 `workspace.getCurrentWorkspacePath` RPC 端点(`app-rpc.ts:109`、`rpcHandlers.ts:80`)。
+
+#### `packages/app-runtime/src/appRuntime.ts`
+
+- `createConversation`(`appRuntime.ts:158-165`):`workspacePath` 改必传,删除 `?? getCurrentWorkspacePath()`。未传抛 `workspacePath is required`。
+- `listConversations`(`appRuntime.ts:152-156`):`workspacePath` 保持可选,语义明确为:**未传 = 全量查询(`getWorkspaceWhere` 返回空 WHERE,含所有工作区与 `workspace_path IS NULL` 的会话);传了 = 按该路径筛选**。删除 `?? getCurrentWorkspacePath()` 兜底,同时删除 `includeNullWorkspace` 的默认工作区特判(`appRuntime.ts:154`,`targetWorkspace === getDefaultWorkspacePath()` 时把 null 纳入)—— 该特判依赖后端「当前=默认工作区」概念,B 方案后该概念不存在。`includeNullWorkspace` 仍作为可选参数保留,语义为「传了 `workspacePath` 时是否额外纳入 null 工作区会话」,由调用方显式决定,默认 `false`。`chat.getConversations`(全量入口,`rpcHandlers.ts:17`)不传 `workspacePath`,自然走全量语义。`chat.getWorkspaceConversations` 传 `workspacePath`,走筛选语义。
+- `clearWorkspaceConversations`(`appRuntime.ts:176-192`):`workspacePath` 改必传,删除兜底,与 RPC schema 对齐。
+- `emitWorkspaceResult`(`appRuntime.ts:434-435`)与 `workspace:changed` 事件(`ipc-events.ts:71`):事件 payload 不再含 `currentWorkspacePath`。
+
+#### `packages/agent-runtime/src/agentTurnService.ts`
+
+- `startTurn`(`agentTurnService.ts:38-40`):`workspacePath` 改必传,删除 `?? getCurrentWorkspacePath() ?? process.cwd()`。未传抛错。`StartAgentTurnOptions.workspacePath`(`agent-runtime-electron.ts:14`)从可选改为必传 `string`。
+
+#### `packages/app-runtime/src/rpcHandlers.ts` / `packages/shared/src/interfaces/app-rpc.ts`
+
+- `chat.getConversations`(`app-rpc.ts` 对应端点、`rpcHandlers.ts:17`):全量查询入口,保持不传 `workspacePath`,语义为跨工作区全量。
+- `chat.getWorkspaceConversations`(`app-rpc.ts:47`):已声明 `workspacePath: string` 必传,不变。
+- `chat.clearWorkspaceConversations`(`app-rpc.ts:52`):已声明必传,实现对齐。
+- 删除 `workspace.getCurrentWorkspacePath` 端点。
+
+### 前端配套:启动时确定当前工作区
+
+后端不再返回 `currentWorkspacePath` 后,`ListWorkspacesData` 只剩 `workspaces` 列表。前端 workspaceStore 的 `refresh`/`openWorkspace`/`addWorkspace`/`removeWorkspace` 返回值不再含 `currentWorkspacePath`。当前工作区改由前端决定:
+
+- **启动时**:`refresh` 后,当前工作区 = `workspaces` 中 `lastOpenedAt` 最大者(最近打开);列表为空时取默认工作区。
+- **`openWorkspace`/`addWorkspace`**:操作的目标路径即为新的当前工作区(前端在调用方已知,无需后端回传)。
+- **`removeWorkspace`**:若删的是当前工作区,前端回退到 `workspaces` 中 `lastOpenedAt` 最大者。
+
+这要求 workspaceStore 持有「当前工作区路径」作为前端派生状态(SSOT),由前端工作区操作显式更新。后端 `workspaces` 列表只提供可选项与 `lastOpenedAt` 排序依据。
+
+> 注:这使前端 workspaceStore 的 `currentWorkspacePath` 从「后端回传的字段」变为「前端派生+显式设置的状态」。仍是 SSOT,只是来源从后端回传改为前端在操作时经 workspaceStore action 显式 `set`(`addWorkspace`/`openWorkspace` 内部 set 目标 path,`removeWorkspace`/`refresh` 内部按 `lastOpenedAt` 派生)。`activateWorkspace(path)` **不写 workspaceStore**,只同步会话分片缓存;调用方先调 workspaceStore action(已 set currentWorkspacePath),再调 `activateWorkspace(同一 path)`。
+
+### bug 视角
+
+本 bug 中前端 `conversationsStore` 停在旧路径,后端 `currentWorkspacePath` 已被 `addWorkspace` 设为新路径(后端状态其实正确),但 `Chat.tsx:83` 显式传了前端那个错的旧 `workspacePath`,绕过后端兜底,导致会话归属旧工作区。整合后:前端 workspaceStore 为 SSOT 且 `Chat.tsx:28` 读它,`currentWorkspacePath` 始终正确;后端写操作必传 `workspacePath` 且无兜底,即便前端某处漏传也会显式报错而非静默错归属 —— 错误从「静默错归属」变为「显式失败」,更易暴露与修复。
 
 ## 错误处理与边界
 
 - **workspaceStore 路径为空(初始化前)**:`activateWorkspace('')` 为 no-op,仅清空 `activeConversationsId`。`nextPageConversationsAction` 保留空路径守护。
-- **分页加载竞态**:守护从比较 `conversationsStore.currentWorkspacePath` 改为比较 workspaceStore 当前路径,语义不变。
-- **refresh 后补加载职责**:`WORKSPACE_CHANGED_EVENT` 全局监听器(`store/workspace/store.ts:56-58`)与 `useAppEventListener.ts:61` 触发 `workspaceStore.refresh()`,只更新 workspaceStore 数据。refresh 后若当前路径的 slice 未加载,由依赖 workspaceStore 的组件(`WorkspacePanels` 挂载时调 `activateWorkspace`)或 `activateWorkspace` 内部的 `ensure + nextPage` 补加载。refresh 本身不直接触发会话补加载,职责边界保持:workspaceStore 只管数据,conversations 层管缓存。
+- **分页加载竞态**:守护从比较 `conversationsStore.currentWorkspacePath` 改为比较 workspaceStore 当前路径(`useWorkspaceStore.getState().currentWorkspacePath`),语义不变。
+- **refresh 后补加载职责**:`WORKSPACE_CHANGED_EVENT` 全局监听器(`store/workspace/store.ts` 底部)与 `useAppEventListener.ts:61` 触发 `workspaceStore.refresh()`,refresh 内部按 `lastOpenedAt` 派生当前路径并更新 `workspaces`。refresh 后若当前路径的 slice 未加载,由依赖 workspaceStore 的组件(`WorkspacePanels` 挂载时调 `activateWorkspace`)或 `activateWorkspace` 内部的 `ensure + nextPage` 补加载。refresh 本身不直接触发会话补加载,职责边界保持:workspaceStore 只管数据与当前路径派生,conversations 层管缓存。
 - **循环依赖**:已确认 workspaceStore 不导入 conversationsStore,单向依赖,安全。
 - **跨实例通知**:`emitWorkspaceChanged` 保留,用于一个实例操作后通知其他实例 refresh。整合后不再是补同步的兜底,因为 conversationsStore 不再持有路径,refresh 只更新 SSOT,显示与归属自动一致。
+- **后端写操作未传 workspacePath**:`createConversation`/`startTurn`/`clearWorkspaceConversations` 改必传后,未传抛错(非静默兜底)。前端所有调用点已显式传 workspaceStore 的 SSOT 值,正常路径不触发。
+- **后端 `listConversations` 未传 workspacePath**:语义为跨工作区全量查询(含 `workspace_path IS NULL`),供 `chat.getConversations` 全量入口使用,不再用 `currentWorkspacePath` 兜底。
+- **启动时当前工作区派生**:`refresh` 后,`currentWorkspacePath` = `workspaces` 中 `lastOpenedAt` 最大者。后端 `ensureInitialized`(`workspaceService.ts:52-71`)已保证默认工作区始终存在于列表,故 `workspaces` 不会为空,该派生总有结果。无需前端单独获取默认工作区路径。
 
 ## 测试
 
+前端(web):
+
 - **行为测试 — 添加工作区后发送消息归属正确(覆盖原 bug)**:添加新工作区 → 发送消息 → 断言新建会话的 `workspacePath` === 新工作区路径,而非旧工作区。
-- **删除当前工作区**:删除当前工作区 → 断言 conversationsStore 顶层 slice 切到后端返回的新当前路径,无残留指向已删除工作区。
+- **删除当前工作区**:删除当前工作区 → 断言 conversationsStore 顶层 slice 切到 `lastOpenedAt` 最大者,无残留指向已删除工作区。
 - **切换工作区期间分页加载返回**:发起分页加载 → 加载未完成时切换工作区 → 加载返回 → 断言不污染新工作区顶层 conversations(竞态守护)。
 - **SSOT 不变性**:断言 `conversationsStore` 的 state 不再有 `currentWorkspacePath` 字段(类型层面由 `StoreState` 删除保证;运行时由 `createInitialState` 删除保证)。
+- **启动派生当前工作区**:`refresh` 后断言 `workspaceStore.currentWorkspacePath` === `workspaces` 中 `lastOpenedAt` 最大者。
 - **WorkspaceSelector 与 WorkspacePanels 一致**:两者都读 workspaceStore,任一实例切换工作区后,另一实例显示与归属一致。
 
-测试遵循项目规范:行为导向,mock 系统边界(HTTP/IPC),不 mock 内部 store 模块。框架 Vitest,环境 jsdom。
+后端(packages):
+
+- **`createConversation` 必传 `workspacePath`**:未传时抛错,不再用 `getCurrentWorkspacePath` 兜底。
+- **`startTurn` 必传 `workspacePath`**:未传时抛错,不再兜底 `process.cwd()`。
+- **`listConversations` 未传 `workspacePath`**:返回跨工作区全量(含 null),不依赖 `currentWorkspacePath`。
+- **`workspaceService` 不再持久化 `currentWorkspacePath`**:增删改工作区后,配置文件只更新 `workspaces` 列表,不含 `currentWorkspacePath` 字段;`getCurrentWorkspacePath` 方法与 RPC 端点已删除。
+
+测试遵循项目规范:行为导向,mock 系统边界(HTTP/IPC/文件系统),不 mock 内部 store/repository 模块。框架 Vitest。
 
 ## 迁移策略
 
-单 PR 完成。`conversationsStore.currentWorkspacePath` 字段删除是破坏性改动,半迁移会留双源,因此 store 层、action 入口、组件读取点在同一 PR 内一并改。
+单 PR 完成。`conversationsStore.currentWorkspacePath` 字段删除、后端 `currentWorkspacePath` 持久化删除、会话接口签名变更均为破坏性改动,半迁移会留双源或前后端不一致,因此前端 store/action/组件与后端 service/runtime/rpc 在同一 PR 内一并改。
 
 顺序:
 
-1. 改 store 层(`initialState.ts` 删字段、`conversationsStore.ts` 跨 store 读 key、新增 `getCurrentWorkspacePath`)。
-2. 改 action 层(`actions.ts` 新增 `activateWorkspace`、改 `clearConversationsAction`/`nextPageConversationsAction`、替换 `switchWorkspaceConversationsAction` 调用)。
-3. 改组件读取点(`WorkspacePanels`/`WorkspaceSelector`/`Chat`/`Sender`)。
-4. 每步运行 `pnpm check`(type-check + lint + unit tests),一次性修复所有错误再提交。
-5. 补行为测试,运行 `pnpm test:unit` 验证。
+1. **后端**:`workspaceService.ts` 删字段与方法 → `appRuntime.ts` 会话接口改读写区分语义 → `agentTurnService.ts` 必传 → `rpcHandlers.ts`/`app-rpc.ts`/`ipc-events.ts` 端点与事件 payload 对齐 → `ListWorkspacesData` 删 `currentWorkspacePath`。
+2. **前端 store**:`workspace/store.ts` 新增顶层 `currentWorkspacePath` 字段与派生逻辑;`conversation/initialState.ts` 删字段;`conversation/conversationsStore.ts` 跨 store 读 key;`conversation/actions.ts` 新增 `activateWorkspace`、改 `clearConversationsAction`/`nextPageConversationsAction`。
+3. **前端组件**:`WorkspacePanels`/`WorkspaceSelector`/`Chat`/`Sender` 读取点与调用入口对齐。
+4. 每步运行 `pnpm check`(type-check + lint + unit tests),一次性修复所有错误再提交。后端接口签名变更会触发 `tsc -b` 跨包报错,据此定位所有调用点。
+5. 补行为测试(前端 + 后端),运行 `pnpm test:unit` 验证。
 
 ## 影响范围
 
-改动文件:
+前端改动文件:
 
+- `apps/web/src/store/workspace/store.ts`(新增 SSOT 字段与派生)
 - `apps/web/src/store/conversation/initialState.ts`
 - `apps/web/src/store/conversation/conversationsStore.ts`
 - `apps/web/src/store/conversation/actions.ts`
@@ -205,4 +302,16 @@ if (useWorkspaceStore.getState().workspaceData?.currentWorkspacePath !== current
 - `apps/web/src/components/Sender/Sender.tsx`
 - 相关测试文件
 
-`workspaceStore` 代码不改,仅承担 SSOT 角色。后端 `workspaceService.ts` 不涉及(本 bug 纯前端状态层)。
+后端改动文件:
+
+- `packages/app-data/src/workspace/workspaceService.ts`(删 `currentWorkspacePath` 持久化与方法)
+- `packages/app-runtime/src/appRuntime.ts`(会话接口读写区分语义、删除兜底)
+- `packages/app-runtime/src/rpcHandlers.ts`(端点对齐)
+- `packages/agent-runtime/src/agentTurnService.ts`(`workspacePath` 必传)
+- `packages/shared/src/interfaces/workspace.ts`(`ListWorkspacesData`/`WorkspaceConfig` 删字段)
+- `packages/shared/src/interfaces/app-rpc.ts`(删 `workspace.getCurrentWorkspacePath` 端点、会话端点签名)
+- `packages/shared/src/interfaces/agent-runtime-electron.ts`(`StartAgentTurnOptions.workspacePath` 改必传)
+- `packages/shared/src/ipc-events.ts`(`workspace:changed` 事件 payload 删 `currentWorkspacePath`)
+- 相关测试文件
+
+本 bug 修复跨前后端:前端状态层整合为 SSOT,后端去掉 `currentWorkspacePath` 持久化并改会话接口为读写区分语义,从根上消除「隐式默认归属」这一 bug 藏身处。

--- a/docs/superpowers/specs/2026-06-21-workspace-state-consolidation-design.md
+++ b/docs/superpowers/specs/2026-06-21-workspace-state-consolidation-design.md
@@ -1,0 +1,208 @@
+# 工作区状态源整合设计
+
+## 背景与问题
+
+web 端存在一个 bug:在左侧工作区面板添加新工作区后,Sender 中显示的是新工作区,但发送消息时会话却归属到之前的工作区。即「Sender 显示的工作区」与「会话实际归属的工作区」不一致。
+
+### 根因
+
+「当前工作区路径」在 web 端被 **三处** 独立持有,彼此靠手动成对调用来维系同步,存在多个缺口:
+
+| 持有者 | 性质 | 用途 |
+|---|---|---|
+| `useWorkspaceStore.workspaceData.currentWorkspacePath` | zustand 全局 store | Sender 显示、WorkspacePanels 列表渲染 |
+| `useConversationsStore.currentWorkspacePath` | zustand 全局 store | 发送消息归属、分片缓存 key、分页加载竞态守护 |
+| `WorkspaceSelector` 的 `useReducer` 本地 `workspaceData` | 组件本地 state,完全绕开两个全局 store | `ConversationsManage` 头部的工作区选择器 |
+
+具体缺口:
+
+1. **闭包陷阱(触发本 bug 的直接原因)**:`WorkspacePanels.handlePickerConfirm`(`apps/web/src/components/Workspace/WorkspacePanels.tsx:103-116`)在 `await addWorkspace(path)` 后调用 `reloadCurrentWorkspace()`(`WorkspacePanels.tsx:92-97`)。`reloadCurrentWorkspace` 是依赖 `[currentWorkspacePath]` 的 `useCallback`,而 `currentWorkspacePath`(`WorkspacePanels.tsx:72`)是渲染期派生值。`addWorkspace` 内部 `useWorkspaceStore.setState` 触发的重渲染要等下一次渲染周期才让 `currentWorkspacePath` 生效,但 `handlePickerConfirm` 在同一执行流里紧接着调用 `reloadCurrentWorkspace()`,此时闭包捕获的仍是旧渲染周期的 `currentWorkspacePath`(原工作区路径)。于是 `switchWorkspaceConversationsAction(旧路径)` 把 `conversationsStore.currentWorkspacePath` 固化在旧工作区,而 `workspaceStore` 已切到新工作区 → 显示与归属脱节。发送时 `Chat.tsx:83` 用 `conversationsStore` 的旧路径,新会话归属旧工作区。
+
+2. **删除工作区不同步**:`WorkspacePanels.handleDeleteWorkspace`(`WorkspacePanels.tsx:118-130`)调 `removeWorkspace` 更新了 workspaceStore,但**不调** `switchWorkspaceConversationsAction`。若删的恰是当前工作区,后端会把 `currentWorkspacePath` 回退到默认工作区,但 conversationsStore 停在已删除的工作区路径上。
+
+3. **WorkspaceSelector 是第三源**:`WorkspaceSelector.tsx` 自带本地 `useReducer workspaceData`(`WorkspaceSelector.tsx:52`),与两个全局 store 并存。`refreshWorkspaces`(`WorkspaceSelector.tsx:71-75`)只更新本地 + conversationsStore,**不回写 workspaceStore**,靠 `emitWorkspaceChanged` 间接触发全局 refresh 来兜底对齐。本质是三源用事件互相补,结构脆弱。`WorkspaceSelector` 挂载于 `ConversationsManage`(`ConversationsManage.tsx:67`),`WorkspacePanels` 挂载于 `SiliderMenu`(`SiliderMenu.tsx:74`),两者并存于不同视图。
+
+### 反证对照
+
+Sender 的「切换工作区」路径(`Sender.tsx:493-496`)用入参 `nextWorkspacePath` 而非闭包变量调 `switchWorkspaceConversationsAction`,所以切换不报 bug。这印证根因是闭包陷阱,且说明「用 action 返回值/入参而非渲染期闭包变量」是正确范式。
+
+## 目标
+
+以 `useWorkspaceStore.workspaceData.currentWorkspacePath` 为唯一事实源(SSOT)。删除 `conversationsStore.currentWorkspacePath` 字段,删除 `WorkspaceSelector` 的本地 `workspaceData`。所有需要「当前工作区」的读写统一从 workspaceStore 取。`conversationsStore` 的分片缓存 `workspaceConversations: Record<path, Slice>` 保留,但其 save/restore 用的 key 改为跨 store 从 workspaceStore 读取。
+
+整合后,显示(Sender 读 workspaceStore)与归属(Chat 读 workspaceStore)天然一致,因为只剩一个源;闭包陷阱、删除不同步、第三源三个缺口一并消除。
+
+## 架构
+
+```
+useWorkspaceStore  ← 唯一事实源(SSOT)
+  .workspaceData.currentWorkspacePath   写入:增/删/切/refresh
+  .workspaceData.workspaces             工作区列表
+
+useConversationsStore  ← 不再持有 currentWorkspacePath
+  .workspaceConversations: Record<path, Slice>   分片缓存,key 来自 workspaceStore
+  .conversations / pageIndex / conversationsTotal / loadVersion   顶层=当前工作区 slice 的投影
+  需要「当前 path」时 → useWorkspaceStore.getState().workspaceData.currentWorkspacePath
+```
+
+### 写入收口:统一入口 `activateWorkspace`
+
+新增统一入口封装「workspaceStore 已更新当前路径后,同步会话分片缓存到该路径」的成对操作。所有切换/新增/删除场景调用此入口,避免手动拼装 `ensure + switch` 导致的遗漏与闭包陷阱。
+
+```ts
+/**
+ * 统一的工作区激活入口:在 workspaceStore 已更新当前路径后,
+ * 同步会话分片缓存到该路径。所有切换/新增/删除场景调用此入口,
+ * 避免手动拼装 ensure+switch 导致的遗漏与闭包陷阱。
+ */
+export async function activateWorkspace(workspacePath: string): Promise<void>
+```
+
+- **入参**:目标工作区绝对路径。由调用方从 workspaceStore action 的返回值(`data.currentWorkspacePath`)或 `item.path` 传入,**不依赖任何闭包渲染期变量**。
+- **行为**:空路径 → 仅 `setActiveConversationsId('')`;非空 → `ensureWorkspaceConversationsAction(path)` + `switchWorkspaceSlice(path)` + 必要时 `nextPageConversationsAction()` 补加载首页。
+- **返回**:无返回值。调用方需要 `ListWorkspacesData` 时从 workspaceStore action 的返回值拿。
+- **幂等**:目标路径已是当前路径时,`switchWorkspaceSlice` 内部 no-op,`ensureWorkspaceConversationsAction` 内部有 `loaded` 守卫,安全。
+
+## 数据流(以「添加工作区」为例)
+
+修复前(bug):
+
+```
+addWorkspace(path) → workspaceStore 切新
+reloadCurrentWorkspace() → 用闭包旧 path → switchWorkspaceConversationsAction(旧path)
+→ conversationsStore 停在旧工作区 ❌
+```
+
+修复后:
+
+```
+handlePickerConfirm(path):
+  data = await addWorkspace(path)                      // workspaceStore 切新(SSOT 更新)
+  await activateWorkspace(data.currentWorkspacePath)   // 用返回值,不依赖闭包
+    → ensureWorkspaceConversationsAction(path)
+    → switchWorkspaceSlice(path)                       // 只做分片 save/restore,不写 currentWorkspacePath
+```
+
+显示(Sender 读 workspaceStore)与归属(Chat 读 workspaceStore)天然一致。
+
+## 逐文件改动
+
+### 1. `store/workspace/store.ts`(SSOT,代码不变)
+
+workspaceStore 保持四个 action(`refresh`/`openWorkspace`/`addWorkspace`/`removeWorkspace`)各自 `set({ workspaceData: data })`。承担 SSOT 角色,**代码不改**。
+
+### 2. `store/conversation/initialState.ts` — 删除字段
+
+- `StoreState` 删除 `currentWorkspacePath: string`。
+- `createInitialState` 删除 `currentWorkspacePath: ''`。
+- `workspaceConversations: Record<string, WorkspaceConversationsState>` 保留。
+
+### 3. `store/conversation/conversationsStore.ts` — key 来源跨 store
+
+新增内部 helper:
+
+```ts
+function getCurrentWorkspacePath(): string {
+  return useWorkspaceStore.getState().workspaceData?.currentWorkspacePath ?? ''
+}
+```
+
+- `switchWorkspace(path)` 重命名为 `switchWorkspaceSlice(path)`:
+  - no-op 守卫 `workspacePath === state.currentWorkspacePath` 改为 `workspacePath === getCurrentWorkspacePath()`。
+  - save 旧分片时 key 用 `getCurrentWorkspacePath()`(旧路径),restore 新分片 key 用入参 `path`。
+  - 不再 set `currentWorkspacePath`。
+- `saveCurrentWorkspaceSlice`:key 从 `getCurrentWorkspacePath()` 取,空则 return。
+- `reset`:原在 zustand `set` 回调内读 `state.currentWorkspacePath` 决定保留哪个工作区的 slice。整合后在 `set` 回调外先用 `const currentPath = getCurrentWorkspacePath()` 取值,再传入 `set` 回调使用(避免在回调内跨 store 读取的时序歧义);`state.currentWorkspacePath` 的所有引用替换为该 `currentPath`。
+- **循环依赖确认**:`workspaceStore` 只导入 `workspaceApi` 与事件常量,不导入 conversationsStore;`conversationsStore` 导入 `workspaceStore` 为单向依赖,无循环。
+
+### 4. `store/conversation/actions.ts` — 新增统一入口 + 改 action
+
+新增 `activateWorkspace(workspacePath: string)`(签名见上),内部依次调用 `ensureWorkspaceConversationsAction(path)` → `switchWorkspaceSlice(path)` → 必要时 `nextPageConversationsAction()`。
+
+`switchWorkspaceConversationsAction` 删除,所有外部调用点改为调 `activateWorkspace`。注意 `ensureWorkspaceConversationsAction`(actions.ts:72)内部原直接调用 `useConversationsStore.getState().switchWorkspace(workspacePath)`,改名后同步改为 `switchWorkspaceSlice`;但 `activateWorkspace` 已统一封装 ensure+switch,外部调用方不再单独调 `ensureWorkspaceConversationsAction` + `switchWorkspace`,仅在 `WorkspacePanels.toggleWorkspace`(展开非当前工作区面板预加载)这类只需 ensure 不需切换顶层 slice的场景保留单独调 `ensureWorkspaceConversationsAction`。
+
+`clearConversationsAction`、`nextPageConversationsAction` 的 `currentWorkspacePath` 改从 `useWorkspaceStore.getState().workspaceData?.currentWorkspacePath` 取。
+
+`nextPageConversationsAction` 的竞态守护:
+
+```ts
+// 修复前
+if (draft.currentWorkspacePath !== currentWorkspacePath || ...) return
+// 修复后:produce 回调内读 workspaceStore 当前路径与发起时的 currentWorkspacePath 比较
+if (useWorkspaceStore.getState().workspaceData?.currentWorkspacePath !== currentWorkspacePath || ...) return
+```
+
+语义不变:分页加载是异步的,加载期间用户可能切了工作区,加载回来时若 workspaceStore 当前路径已不是发起时的路径,则丢弃结果,不污染新工作区顶层 conversations。
+
+### 5. `components/Workspace/WorkspacePanels.tsx`
+
+- 删除 `reloadCurrentWorkspace`(闭包陷阱根源,`WorkspacePanels.tsx:92-97`)。
+- 删除本地 `currentWorkspacePath` 派生(`WorkspacePanels.tsx:72`),改为 `const currentWorkspacePath = workspaceData?.currentWorkspacePath ?? ''`。
+- `handlePickerConfirm`:`addWorkspace(path)` 后调 `await activateWorkspace(data.currentWorkspacePath)`,用返回值不用闭包。
+- `handleDeleteWorkspace`:`removeWorkspace(path)` 后调 `await activateWorkspace(data.currentWorkspacePath)`(后端返回删除后的新当前路径),修复删除不同步缺口。
+- `openConversation`/`createConversation`:`openWorkspace` 后调 `activateWorkspace(workspacePath)`。
+- `initialize`:`refreshWorkspace()` 后调 `activateWorkspace(data.currentWorkspacePath)`。
+
+### 6. `components/Workspace/WorkspaceSelector.tsx` — 消除第三源
+
+- 删除本地 `useReducer workspaceData`、`refreshWorkspaces` 里的 `setWorkspaceData`。
+- 改读 `useWorkspaceStore(state => state.workspaceData)`。
+- `applyWorkspaceData` 改为:不再 `setWorkspaceData`(workspaceStore action 已 set),只 `setActiveConversationsId('') + activateWorkspace(data.currentWorkspacePath)`。
+- `handlePickerConfirm`/`confirmRemoveWorkspace`/`handleOpenWorkspace` 改调 workspaceStore 的 `addWorkspace`/`removeWorkspace`/`openWorkspace` + `activateWorkspace`。
+- `emitWorkspaceChanged` 保留(通知其他实例),但不再是补同步兜底。
+- `handleOpenWorkspace` 的 `item.path === workspaceData?.currentWorkspacePath` 守卫改用 workspaceStore 的值。
+
+### 7. `components/Chat/Chat.tsx`
+
+- `currentWorkspacePath`(`Chat.tsx:28`)从 `useConversationsStore` 改为 `useWorkspaceStore(state => state.workspaceData?.currentWorkspacePath)`。
+- 其余不动,发送消息归属(`Chat.tsx:83` 的 `workspacePath: currentWorkspacePath`)自然正确。
+
+### 8. `components/Sender/Sender.tsx`
+
+- 已读 workspaceStore,基本不动。
+- `handleSwitchWorkspace`(`Sender.tsx:478-504`)的 `openWorkspace` + `switchWorkspaceConversationsAction` 改为 `openWorkspace` + `activateWorkspace(nextWorkspacePath)`,与统一入口对齐。
+
+## 错误处理与边界
+
+- **workspaceStore 路径为空(初始化前)**:`activateWorkspace('')` 为 no-op,仅清空 `activeConversationsId`。`nextPageConversationsAction` 保留空路径守护。
+- **分页加载竞态**:守护从比较 `conversationsStore.currentWorkspacePath` 改为比较 workspaceStore 当前路径,语义不变。
+- **refresh 后补加载职责**:`WORKSPACE_CHANGED_EVENT` 全局监听器(`store/workspace/store.ts:56-58`)与 `useAppEventListener.ts:61` 触发 `workspaceStore.refresh()`,只更新 workspaceStore 数据。refresh 后若当前路径的 slice 未加载,由依赖 workspaceStore 的组件(`WorkspacePanels` 挂载时调 `activateWorkspace`)或 `activateWorkspace` 内部的 `ensure + nextPage` 补加载。refresh 本身不直接触发会话补加载,职责边界保持:workspaceStore 只管数据,conversations 层管缓存。
+- **循环依赖**:已确认 workspaceStore 不导入 conversationsStore,单向依赖,安全。
+- **跨实例通知**:`emitWorkspaceChanged` 保留,用于一个实例操作后通知其他实例 refresh。整合后不再是补同步的兜底,因为 conversationsStore 不再持有路径,refresh 只更新 SSOT,显示与归属自动一致。
+
+## 测试
+
+- **行为测试 — 添加工作区后发送消息归属正确(覆盖原 bug)**:添加新工作区 → 发送消息 → 断言新建会话的 `workspacePath` === 新工作区路径,而非旧工作区。
+- **删除当前工作区**:删除当前工作区 → 断言 conversationsStore 顶层 slice 切到后端返回的新当前路径,无残留指向已删除工作区。
+- **切换工作区期间分页加载返回**:发起分页加载 → 加载未完成时切换工作区 → 加载返回 → 断言不污染新工作区顶层 conversations(竞态守护)。
+- **SSOT 不变性**:断言 `conversationsStore` 的 state 不再有 `currentWorkspacePath` 字段(类型层面由 `StoreState` 删除保证;运行时由 `createInitialState` 删除保证)。
+- **WorkspaceSelector 与 WorkspacePanels 一致**:两者都读 workspaceStore,任一实例切换工作区后,另一实例显示与归属一致。
+
+测试遵循项目规范:行为导向,mock 系统边界(HTTP/IPC),不 mock 内部 store 模块。框架 Vitest,环境 jsdom。
+
+## 迁移策略
+
+单 PR 完成。`conversationsStore.currentWorkspacePath` 字段删除是破坏性改动,半迁移会留双源,因此 store 层、action 入口、组件读取点在同一 PR 内一并改。
+
+顺序:
+
+1. 改 store 层(`initialState.ts` 删字段、`conversationsStore.ts` 跨 store 读 key、新增 `getCurrentWorkspacePath`)。
+2. 改 action 层(`actions.ts` 新增 `activateWorkspace`、改 `clearConversationsAction`/`nextPageConversationsAction`、替换 `switchWorkspaceConversationsAction` 调用)。
+3. 改组件读取点(`WorkspacePanels`/`WorkspaceSelector`/`Chat`/`Sender`)。
+4. 每步运行 `pnpm check`(type-check + lint + unit tests),一次性修复所有错误再提交。
+5. 补行为测试,运行 `pnpm test:unit` 验证。
+
+## 影响范围
+
+改动文件:
+
+- `apps/web/src/store/conversation/initialState.ts`
+- `apps/web/src/store/conversation/conversationsStore.ts`
+- `apps/web/src/store/conversation/actions.ts`
+- `apps/web/src/components/Workspace/WorkspacePanels.tsx`
+- `apps/web/src/components/Workspace/WorkspaceSelector.tsx`
+- `apps/web/src/components/Chat/Chat.tsx`
+- `apps/web/src/components/Sender/Sender.tsx`
+- 相关测试文件
+
+`workspaceStore` 代码不改,仅承担 SSOT 角色。后端 `workspaceService.ts` 不涉及(本 bug 纯前端状态层)。

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,6 +27,7 @@ export default antfu(
       'apps/desktop/.ant-chat/**',
       '.claude/**',
       '.agents/**',
+      '.superpowers/**',
     ],
     rules: {
       'no-console': ['off'],

--- a/packages/agent-runtime/src/__tests__/agentService.spec.ts
+++ b/packages/agent-runtime/src/__tests__/agentService.spec.ts
@@ -62,9 +62,7 @@ const aiProvider = {
 const aiProviderFactory = vi.fn(async () => aiProvider)
 
 const appDataContext = {
-  workspaceService: {
-    getCurrentWorkspacePath: vi.fn(() => '/workspace'),
-  },
+  workspaceService: {} as unknown as AppDataContext['workspaceService'],
   modelCatalog: {
     resolveModel: vi.fn(async () => ({ model, provider })),
     getModel: vi.fn(async () => model),
@@ -103,6 +101,7 @@ describe('createAgentRuntimeController 行为', () => {
 
     await service.startTurn({
       prompt: 'inspect project',
+      workspacePath: '/workspace',
       modelConfig: {
         modelId: 'model-1',
         providerId: 'provider-1',
@@ -205,6 +204,7 @@ describe('createAgentRuntimeController 行为', () => {
 
     await expect(service.startTurn({
       prompt: 'inspect project',
+      workspacePath: '/workspace',
       modelConfig: {
         modelId: 'model-1',
         providerId: 'provider-1',
@@ -236,6 +236,7 @@ describe('createAgentRuntimeController 行为', () => {
 
     await service.startTurn({
       prompt: 'inspect project',
+      workspacePath: '/workspace',
       modelConfig: {
         modelId: 'model-1',
         providerId: 'provider-1',
@@ -272,6 +273,7 @@ describe('createAgentRuntimeController 行为', () => {
 
     await service.startTurn({
       prompt: 'inspect project',
+      workspacePath: '/workspace',
       modelConfig: {
         modelId: 'model-1',
         providerId: 'provider-1',
@@ -304,6 +306,7 @@ describe('createAgentRuntimeController 行为', () => {
 
     await service.startTurn({
       prompt: 'inspect project',
+      workspacePath: '/workspace',
       modelConfig: {
         modelId: 'model-1',
         providerId: 'provider-1',
@@ -319,6 +322,22 @@ describe('createAgentRuntimeController 行为', () => {
 
     expect(titleGenerator.updateTitle).toHaveBeenCalledWith('c1', { providerId: 'provider-1', modelId: 'model-1' })
     expect(emitConversationUpdated).toHaveBeenCalledWith(titledConversation)
+  })
+
+  it('startTurn 未传 workspacePath 时抛错,不再兜底 getCurrentWorkspacePath() 或 process.cwd()', async () => {
+    const service = createAgentRuntimeController(runtime, appDataContext, { aiProviderFactory })
+
+    await expect(service.startTurn({
+      prompt: 'inspect',
+      modelConfig: {
+        modelId: 'model-1',
+        providerId: 'provider-1',
+        systemPrompt: 'custom',
+        temperature: 0.2,
+        maxTokens: 2048,
+        features: { enableMCP: false },
+      },
+    } as any)).rejects.toThrow('workspacePath is required')
   })
 
   it('记住审批时写入工具白名单后再批准 pending action', () => {

--- a/packages/agent-runtime/src/agentTurnService.ts
+++ b/packages/agent-runtime/src/agentTurnService.ts
@@ -8,7 +8,6 @@ import type {
   StartAgentTurnOptions,
 } from '@ant-chat/shared'
 import type { ConversationTitleGenerator } from './conversationTitleGenerator'
-import process from 'node:process'
 
 const DEFAULT_TITLE = 'Untitled'
 
@@ -36,8 +35,9 @@ export function createAgentTurnService(deps: AgentTurnServiceDeps): AgentTurnSer
       }
 
       const workspacePath = options.workspacePath
-        ?? appDataContext.workspaceService.getCurrentWorkspacePath()
-        ?? process.cwd()
+      if (!workspacePath) {
+        throw new Error('workspacePath is required')
+      }
 
       const resolved = await appDataContext.modelCatalog.resolveModel({
         providerId: options.modelConfig.providerId,

--- a/packages/app-data/src/workspace/__tests__/workspaceService.spec.ts
+++ b/packages/app-data/src/workspace/__tests__/workspaceService.spec.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest'
-import { computeDisplayNames } from '../workspaceService'
+import { mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { computeDisplayNames, WorkspaceService } from '../workspaceService'
 
 describe('workspace display names', () => {
   it('同名目录从第一个不同上级目录开始展示', () => {
@@ -18,5 +21,88 @@ describe('workspace display names', () => {
       'test2/.../demo',
       'unique',
     ])
+  })
+})
+
+describe('workspaceService currentWorkspacePath 整合', () => {
+  let configPath: string
+  let service: WorkspaceService
+
+  beforeEach(() => {
+    configPath = path.join(mkdtempSync(path.join(tmpdir(), 'ant-chat-ws-')), 'workspace.json')
+    service = new WorkspaceService({ filePath: configPath })
+  })
+
+  afterEach(() => {
+    rmSync(path.dirname(configPath), { force: true, recursive: true })
+  })
+
+  it('listWorkspaces 不再返回 currentWorkspacePath', () => {
+    const data = service.listWorkspaces()
+    expect(data).not.toHaveProperty('currentWorkspacePath')
+    expect(data.workspaces.length).toBeGreaterThan(0)
+  })
+
+  it('addWorkspace 后配置文件只持久化 workspaces,不含 currentWorkspacePath', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'ant-chat-ws-added-'))
+    try {
+      service.addWorkspace(dir)
+      const raw = JSON.parse(readFileSync(configPath, 'utf8')) as Record<string, unknown>
+      expect(raw).not.toHaveProperty('currentWorkspacePath')
+      expect(Array.isArray(raw.workspaces)).toBe(true)
+    }
+    finally {
+      rmSync(dir, { force: true, recursive: true })
+    }
+  })
+
+  it('openWorkspace 只更新 lastOpenedAt,不写 currentWorkspacePath', () => {
+    const list = service.listWorkspaces()
+    const target = list.workspaces[0]
+    service.openWorkspace(target.path)
+    const raw = JSON.parse(readFileSync(configPath, 'utf8')) as Record<string, unknown>
+    expect(raw).not.toHaveProperty('currentWorkspacePath')
+    const opened = (raw.workspaces as Array<{ path: string, lastOpenedAt?: number }>)
+      .find(item => item.path === target.path)
+    expect(opened?.lastOpenedAt).toBeTypeOf('number')
+  })
+
+  it('removeWorkspace 删除当前工作区后配置仍不含 currentWorkspacePath', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'ant-chat-ws-rm-'))
+    try {
+      service.addWorkspace(dir)
+      service.removeWorkspace(dir)
+      const raw = JSON.parse(readFileSync(configPath, 'utf8')) as Record<string, unknown>
+      expect(raw).not.toHaveProperty('currentWorkspacePath')
+    }
+    finally {
+      rmSync(dir, { force: true, recursive: true })
+    }
+  })
+
+  it('读取含旧 currentWorkspacePath 字段的配置文件时容忍并忽略该字段', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'ant-chat-ws-legacy-'))
+    try {
+      // 先正常添加,再手写一个含旧字段的配置
+      service.addWorkspace(dir)
+      // workspaceService 内部使用 realpathSync.native 规范化路径(macOS 上 /var -> /private/var)
+      const realDir = realpathSync.native(dir)
+      const legacy = {
+        currentWorkspacePath: realDir,
+        workspaces: [
+          { path: realDir, addedAt: 1, lastOpenedAt: 2 },
+        ],
+      }
+      writeFileSync(configPath, JSON.stringify(legacy))
+
+      // 重新创建 service 读取旧配置,不应抛错
+      const legacyService = new WorkspaceService({ filePath: configPath })
+      const data = legacyService.listWorkspaces()
+      expect(data).not.toHaveProperty('currentWorkspacePath')
+      expect(data.workspaces.some(item => item.path === realDir)).toBe(true)
+    }
+    finally {
+      rmSync(dir, { force: true, recursive: true })
+    }
   })
 })

--- a/packages/app-data/src/workspace/workspaceService.ts
+++ b/packages/app-data/src/workspace/workspaceService.ts
@@ -62,14 +62,7 @@ export class WorkspaceService {
       ? normalizedWorkspaces
       : [{ path: defaultPath, addedAt: Date.now(), lastOpenedAt: Date.now() }, ...normalizedWorkspaces]
 
-    const currentWorkspacePath = current.currentWorkspacePath && workspaces.some(item => item.path === current.currentWorkspacePath)
-      ? current.currentWorkspacePath
-      : defaultPath
-
-    const next = {
-      currentWorkspacePath,
-      workspaces: this.dedupeWorkspaces(workspaces),
-    }
+    const next = { workspaces: this.dedupeWorkspaces(workspaces) }
     this.saveConfig(next)
     return next
   }
@@ -77,7 +70,6 @@ export class WorkspaceService {
   listWorkspaces(): ListWorkspacesData {
     const config = this.ensureInitialized()
     return {
-      currentWorkspacePath: config.currentWorkspacePath || this.getDefaultWorkspacePath(),
       workspaces: this.toWorkspaceItems(config.workspaces),
     }
   }
@@ -92,7 +84,6 @@ export class WorkspaceService {
 
     const now = Date.now()
     this.saveConfig({
-      currentWorkspacePath: normalizedPath,
       workspaces: [
         ...config.workspaces,
         { path: normalizedPath, addedAt: now, lastOpenedAt: now },
@@ -113,7 +104,6 @@ export class WorkspaceService {
       : [{ path: defaultPath, addedAt: Date.now(), lastOpenedAt: Date.now() }, ...workspaces]
 
     this.saveConfig({
-      currentWorkspacePath: config.currentWorkspacePath === normalizedPath ? defaultPath : config.currentWorkspacePath,
       workspaces: nextWorkspaces,
     })
 
@@ -130,16 +120,10 @@ export class WorkspaceService {
 
     const now = Date.now()
     this.saveConfig({
-      currentWorkspacePath: normalizedPath,
       workspaces: config.workspaces.map(item => item.path === normalizedPath ? { ...item, lastOpenedAt: now } : item),
     })
 
     return this.listWorkspaces()
-  }
-
-  getCurrentWorkspacePath(): string {
-    const config = this.ensureInitialized()
-    return config.currentWorkspacePath || this.getDefaultWorkspacePath()
   }
 
   listDirectories(inputPath?: string): WorkspaceDirectoryListing {
@@ -255,12 +239,8 @@ export class WorkspaceService {
       }
     })
 
-    if (record.currentWorkspacePath !== undefined && typeof record.currentWorkspacePath !== 'string') {
-      throw new Error(`Invalid workspace settings file: ${this.options.filePath}`)
-    }
-
+    // 兼容旧配置文件中残留的 currentWorkspacePath 字段:忽略不解析
     return {
-      currentWorkspacePath: record.currentWorkspacePath,
       workspaces,
     }
   }

--- a/packages/app-data/src/workspace/workspaceService.ts
+++ b/packages/app-data/src/workspace/workspaceService.ts
@@ -35,7 +35,7 @@ export class WorkspaceService {
   }
 
   getDefaultWorkspacePath(): string {
-    return path.normalize(path.join(os.homedir(), '.ant-chat'))
+    return path.normalize(path.join(os.homedir(), 'antChatProject'))
   }
 
   ensureInitialized(): WorkspaceConfig {

--- a/packages/app-runtime/src/__tests__/appRuntime.spec.ts
+++ b/packages/app-runtime/src/__tests__/appRuntime.spec.ts
@@ -31,54 +31,75 @@ describe('app runtime', () => {
     vi.clearAllMocks()
   })
 
-  it('applies the current workspace when creating and listing conversations', async () => {
-    const workspacePath = runtime.workspace.getCurrentPath()
-    const conversation = await runtime.chat.createConversation({
-      title: 'Runtime conversation',
+  it('createConversation 必传 workspacePath,未传时抛错', async () => {
+    await expect(runtime.chat.createConversation({
+      title: 'no workspace',
       createdAt: 1,
       updatedAt: 1,
-      settings: {
-        modelId: 'model-1',
-        providerId: 'provider-1',
-        systemPrompt: '',
-        temperature: 0.7,
-        maxTokens: 1024,
-      },
-    })
-
-    const result = await runtime.chat.listConversations(0, 20)
-
-    expect(conversation.workspacePath).toBe(workspacePath)
-    expect(result.total).toBe(1)
-    expect(result.data).toEqual([expect.objectContaining({
-      id: conversation.id,
-      workspacePath,
-      title: 'Runtime conversation',
-    })])
+      settings: { modelId: 'model-1', providerId: 'provider-1', systemPrompt: '', temperature: 0.7, maxTokens: 1024 },
+    } as any)).rejects.toThrow('workspacePath is required')
   })
 
-  it('emits domain events after settings and workspace changes', async () => {
-    const settingsEvents: { keys: string[] }[] = []
-    const workspaceEvents: { currentWorkspacePath: string }[] = []
-    runtime.events.on('settings:updated', event => settingsEvents.push(event))
+  it('createConversation 传入 workspacePath 时归属该工作区', async () => {
+    const workspacePath = runtime.workspace.getDefaultPath()
+    const conversation = await runtime.chat.createConversation({
+      title: 'explicit workspace',
+      createdAt: 1,
+      updatedAt: 1,
+      workspacePath,
+      settings: { modelId: 'model-1', providerId: 'provider-1', systemPrompt: '', temperature: 0.7, maxTokens: 1024 },
+    })
+
+    expect(conversation.workspacePath).toBe(workspacePath)
+    const result = await runtime.chat.listConversations(0, 20, workspacePath)
+    expect(result.data).toEqual([expect.objectContaining({ id: conversation.id, workspacePath })])
+  })
+
+  it('listConversations 未传 workspacePath 时返回跨工作区全量', async () => {
+    const defaultPath = runtime.workspace.getDefaultPath()
+    await runtime.chat.createConversation({
+      title: 'in default',
+      createdAt: 1,
+      updatedAt: 1,
+      workspacePath: defaultPath,
+      settings: { modelId: 'm', providerId: 'p', systemPrompt: '', temperature: 0.7, maxTokens: 1024 },
+    })
+
+    const result = await runtime.chat.listConversations(0, 100)
+
+    // 全量查询:不依赖 currentWorkspacePath 兜底,返回所有会话
+    expect(result.total).toBeGreaterThanOrEqual(1)
+  })
+
+  it('workspace:changed 事件 payload 为空对象', async () => {
+    const workspaceEvents: Record<string, never>[] = []
     runtime.events.on('workspace:changed', event => workspaceEvents.push(event))
 
-    await runtime.settings.update({ assistantModelId: 'model-2' })
     const workspace = runtime.workspace.list().workspaces[0]
     runtime.workspace.open(workspace.path)
 
-    expect(settingsEvents).toEqual([{ keys: ['assistantModelId'] }])
-    expect(workspaceEvents).toEqual([{ currentWorkspacePath: workspace.path }])
+    expect(workspaceEvents).toEqual([{}])
   })
 
-  it('clears all conversations in current workspace', async () => {
-    await runtime.chat.createConversation({ title: 'Conv 1', createdAt: 1, updatedAt: 1, settings: { modelId: 'm', providerId: 'p', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
-    await runtime.chat.createConversation({ title: 'Conv 2', createdAt: 2, updatedAt: 2, settings: { modelId: 'm', providerId: 'p', systemPrompt: '', temperature: 0.7, maxTokens: 1024 } })
+  it('clearWorkspaceConversations 必传 workspacePath', async () => {
+    const defaultPath = runtime.workspace.getDefaultPath()
+    await runtime.chat.createConversation({
+      title: 'to clear',
+      createdAt: 1,
+      updatedAt: 1,
+      workspacePath: defaultPath,
+      settings: { modelId: 'm', providerId: 'p', systemPrompt: '', temperature: 0.7, maxTokens: 1024 },
+    })
 
-    const deletedIds = await runtime.chat.clearWorkspaceConversations()
+    await expect(runtime.chat.clearWorkspaceConversations(undefined as any)).rejects.toThrow('workspacePath is required')
 
-    expect(deletedIds.length).toBe(2)
-    const remaining = await runtime.chat.listConversations(0, 100)
-    expect(remaining.total).toBe(0)
+    const deletedIds = await runtime.chat.clearWorkspaceConversations(defaultPath)
+    expect(deletedIds.length).toBe(1)
+  })
+
+  it('searchFiles 必传 workspacePath', async () => {
+    const defaultPath = runtime.workspace.getDefaultPath()
+    const results = await runtime.workspace.searchFiles(defaultPath, '', 10)
+    expect(Array.isArray(results)).toBe(true)
   })
 })

--- a/packages/app-runtime/src/appRuntime.ts
+++ b/packages/app-runtime/src/appRuntime.ts
@@ -150,15 +150,18 @@ export function createAppRuntime(options: CreateAppRuntimeOptions) {
         return conversation
       },
       listConversations: async (pageIndex: number, pageSize: number, workspacePath?: string) => {
-        const targetWorkspace = workspacePath ?? context.workspaceService.getCurrentWorkspacePath()
-        const includeNullWorkspace = targetWorkspace === context.workspaceService.getDefaultWorkspacePath()
-        return await context.conversationRepository.list(pageIndex, pageSize, targetWorkspace, includeNullWorkspace)
+        // 未传 workspacePath = 跨工作区全量查询(含 workspace_path IS NULL);
+        // 传了 = 按该路径筛选。不再用 currentWorkspacePath 兜底。
+        return await context.conversationRepository.list(pageIndex, pageSize, workspacePath, false)
       },
       getConversation: (id: string) => context.conversationRepository.getById(id),
       createConversation: async (conversation: AddConversationsSchema) => {
+        if (!conversation.workspacePath) {
+          throw new Error('workspacePath is required')
+        }
         const result = await context.conversationRepository.create({
           ...conversation,
-          workspacePath: conversation.workspacePath ?? context.workspaceService.getCurrentWorkspacePath(),
+          workspacePath: conversation.workspacePath,
         })
         events.emit('conversation:updated', { conversation: result })
         return result
@@ -173,11 +176,13 @@ export function createAppRuntime(options: CreateAppRuntimeOptions) {
         await context.conversationRepository.delete(id)
         return null
       },
-      clearWorkspaceConversations: async (workspacePath?: string) => {
-        const targetWorkspace = workspacePath ?? context.workspaceService.getCurrentWorkspacePath()
-        const includeNullWorkspace = targetWorkspace === context.workspaceService.getDefaultWorkspacePath()
+      clearWorkspaceConversations: async (workspacePath: string) => {
+        if (!workspacePath) {
+          throw new Error('workspacePath is required')
+        }
+        const targetWorkspace = workspacePath
 
-        const listResult = await context.conversationRepository.list(0, Number.MAX_SAFE_INTEGER, targetWorkspace, includeNullWorkspace)
+        const listResult = await context.conversationRepository.list(0, Number.MAX_SAFE_INTEGER, targetWorkspace, false)
         const targetIds = listResult.data.map(c => c.id)
 
         if (targetIds.length === 0) {
@@ -188,7 +193,7 @@ export function createAppRuntime(options: CreateAppRuntimeOptions) {
           await agentRuntime.closeConversation(id)
         }
 
-        return await context.conversationRepository.deleteByWorkspace(targetWorkspace, includeNullWorkspace)
+        return await context.conversationRepository.deleteByWorkspace(targetWorkspace, false)
       },
       listMessages: (conversationId: string) => context.messageRepository.listByConversation(conversationId),
       getMessage: (id: string) => context.messageRepository.getById(id),
@@ -364,13 +369,14 @@ export function createAppRuntime(options: CreateAppRuntimeOptions) {
       add: (path: string) => emitWorkspaceResult(context.workspaceService.addWorkspace(path)),
       remove: (path: string) => emitWorkspaceResult(context.workspaceService.removeWorkspace(path)),
       open: (path: string) => emitWorkspaceResult(context.workspaceService.openWorkspace(path)),
-      getCurrentPath: () => context.workspaceService.getCurrentWorkspacePath(),
       getDefaultPath: () => context.workspaceService.getDefaultWorkspacePath(),
       listDirectories: (path?: string) => context.workspaceService.listDirectories(path),
       createDirectory: (parentPath: string, name: string) => context.workspaceService.createDirectory(parentPath, name),
-      searchFiles: async (query = '', limit = 50) => {
-        const workspacePath = context.workspaceService.getCurrentWorkspacePath()
-        return workspacePath ? await searchWorkspaceFiles(workspacePath, query, limit) : []
+      searchFiles: async (workspacePath: string, query = '', limit = 50) => {
+        if (!workspacePath) {
+          throw new Error('workspacePath is required')
+        }
+        return await searchWorkspaceFiles(workspacePath, query, limit)
       },
     },
     agent: {
@@ -432,7 +438,7 @@ export function createAppRuntime(options: CreateAppRuntimeOptions) {
   }
 
   function emitWorkspaceResult(result: ReturnType<typeof context.workspaceService.listWorkspaces>) {
-    events.emit('workspace:changed', { currentWorkspacePath: result.currentWorkspacePath })
+    events.emit('workspace:changed', {})
     return result
   }
 

--- a/packages/app-runtime/src/rpcHandlers.ts
+++ b/packages/app-runtime/src/rpcHandlers.ts
@@ -77,11 +77,10 @@ export function createAppRpcHandlers(runtime: AppRuntime): AppRpcHandlers {
     'workspace.addWorkspace': input => runtime.workspace.add(input.path),
     'workspace.removeWorkspace': input => runtime.workspace.remove(input.path),
     'workspace.openWorkspace': input => runtime.workspace.open(input.path),
-    'workspace.getCurrentWorkspacePath': () => runtime.workspace.getCurrentPath(),
     'workspace.getDefaultWorkspacePath': () => runtime.workspace.getDefaultPath(),
     'workspace.listDirectories': input => runtime.workspace.listDirectories(input?.path),
     'workspace.createDirectory': input => runtime.workspace.createDirectory(input.parentPath, input.name),
-    'workspace.searchWorkspaceFiles': input => runtime.workspace.searchFiles(input?.query, input?.limit),
+    'workspace.searchWorkspaceFiles': input => runtime.workspace.searchFiles(input.workspacePath, input?.query, input?.limit),
 
     'agent.startTurn': input => runtime.agent.startTurn(input.options),
     'agent.approvePendingAction': input => runtime.agent.approvePendingAction(input.options),

--- a/packages/local-server/src/__tests__/server.spec.ts
+++ b/packages/local-server/src/__tests__/server.spec.ts
@@ -95,11 +95,11 @@ describe('listen', () => {
 
   it('通过 SSE 推送运行时事件', async () => {
     const payload = await readSseEvent('workspace:changed', () => {
-      eventEmitter.emit('workspace:changed', { currentWorkspacePath: '/tmp/workspace' })
+      eventEmitter.emit('workspace:changed', {})
     })
 
     expect(payload).toContain('event: workspace:changed')
-    expect(payload).toContain('data: {"currentWorkspacePath":"/tmp/workspace"}')
+    expect(payload).toContain('data: {}')
   })
 
   it('通过 SSE 推送敏感信息请求事件', async () => {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "build": "tsdown",
     "clean": "rm -rf dist node_modules",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/shared/src/appPaths.ts
+++ b/packages/shared/src/appPaths.ts
@@ -1,39 +1,13 @@
-import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import process from 'node:process'
 
 const APP_DIR = '.ant-chat'
 
 /**
- * Walk up from `start` looking for pnpm-workspace.yaml.
- * Returns the directory containing it, or `start` if not found.
- */
-export function findWorkspaceRoot(start: string): string {
-  let current = start
-  while (true) {
-    if (fs.existsSync(path.join(current, 'pnpm-workspace.yaml'))) {
-      return current
-    }
-
-    const parent = path.dirname(current)
-    if (parent === current) {
-      return start
-    }
-    current = parent
-  }
-}
-
-/**
  * Application data root directory.
  *
- * - non-production: <workspace-root>/.ant-chat
  * - production:     ~/.ant-chat
  */
 export function resolveAppDataRoot(): string {
-  if (process.env.NODE_ENV === 'production') {
-    return path.join(os.homedir(), APP_DIR)
-  }
-
-  return path.join(findWorkspaceRoot(process.cwd()), APP_DIR)
+  return path.join(os.homedir(), APP_DIR)
 }

--- a/packages/shared/src/interfaces/__tests__/workspace-types.spec.ts
+++ b/packages/shared/src/interfaces/__tests__/workspace-types.spec.ts
@@ -1,0 +1,24 @@
+import { APP_RENDERER_EVENT_NAMES } from '../../ipc-events'
+import type { AppRendererEvents } from '../../ipc-events'
+import type { ListWorkspacesData, WorkspaceConfig } from '../workspace'
+import { describe, expect, it } from 'vitest'
+
+describe('workspace shared types', () => {
+  it('listWorkspacesData 不再含 currentWorkspacePath', () => {
+    const data: ListWorkspacesData = { workspaces: [] }
+    // 类型断言:该字段已不存在,访问应报类型错误(运行时此断言恒真,仅作占位)
+    expect(data).not.toHaveProperty('currentWorkspacePath')
+  })
+
+  it('workspaceConfig 不再含 currentWorkspacePath', () => {
+    const config: WorkspaceConfig = { workspaces: [] }
+    expect(config).not.toHaveProperty('currentWorkspacePath')
+  })
+
+  it('workspace:changed 事件名仍在注册表且 payload 为空', () => {
+    expect(APP_RENDERER_EVENT_NAMES).toContain('workspace:changed')
+    // payload 类型为空对象:无法合法携带 currentWorkspacePath
+    const payload: AppRendererEvents['workspace:changed'] = {}
+    expect(payload).toEqual({})
+  })
+})

--- a/packages/shared/src/interfaces/__tests__/workspace-types.spec.ts
+++ b/packages/shared/src/interfaces/__tests__/workspace-types.spec.ts
@@ -1,7 +1,8 @@
+import { describe, expect, it } from 'vitest'
+
 import { APP_RENDERER_EVENT_NAMES } from '../../ipc-events'
 import type { AppRendererEvents } from '../../ipc-events'
 import type { ListWorkspacesData, WorkspaceConfig } from '../workspace'
-import { describe, expect, it } from 'vitest'
 
 describe('workspace shared types', () => {
   it('listWorkspacesData 不再含 currentWorkspacePath', () => {

--- a/packages/shared/src/interfaces/agent-runtime-electron.ts
+++ b/packages/shared/src/interfaces/agent-runtime-electron.ts
@@ -11,7 +11,7 @@ export interface StartAgentTurnOptions {
   content?: IMessageContent
   referencedFiles?: string[]
   selectedSkill?: string
-  workspacePath?: string
+  workspacePath: string
   mode?: AgentMode
   modelConfig: Omit<ModelSettings, 'model' | 'features'> & {
     modelId: string

--- a/packages/shared/src/interfaces/app-rpc.ts
+++ b/packages/shared/src/interfaces/app-rpc.ts
@@ -106,11 +106,10 @@ export interface AppRpcContract {
   'workspace.addWorkspace': RpcEndpoint<{ path: string }, ListWorkspacesData>
   'workspace.removeWorkspace': RpcEndpoint<{ path: string }, ListWorkspacesData>
   'workspace.openWorkspace': RpcEndpoint<{ path: string }, ListWorkspacesData>
-  'workspace.getCurrentWorkspacePath': RpcEndpoint<undefined, string>
   'workspace.getDefaultWorkspacePath': RpcEndpoint<undefined, string>
   'workspace.listDirectories': RpcEndpoint<{ path?: string } | undefined, WorkspaceDirectoryListing>
   'workspace.createDirectory': RpcEndpoint<{ parentPath: string, name: string }, { name: string, path: string }>
-  'workspace.searchWorkspaceFiles': RpcEndpoint<{ query?: string, limit?: number } | undefined, WorkspaceFileSearchResult[]>
+  'workspace.searchWorkspaceFiles': RpcEndpoint<{ workspacePath: string, query?: string, limit?: number }, WorkspaceFileSearchResult[]>
 
   'agent.startTurn': RpcEndpoint<{ options: StartAgentTurnOptions }, AgentTurnResult>
   'agent.approvePendingAction': RpcEndpoint<{ options: ApprovePendingActionOptions }, null>

--- a/packages/shared/src/interfaces/workspace.ts
+++ b/packages/shared/src/interfaces/workspace.ts
@@ -1,5 +1,4 @@
 export interface WorkspaceConfig {
-  currentWorkspacePath?: string
   workspaces: Array<{
     path: string
     addedAt: number
@@ -15,7 +14,6 @@ export interface WorkspaceItem {
 }
 
 export interface ListWorkspacesData {
-  currentWorkspacePath: string
   workspaces: WorkspaceItem[]
 }
 

--- a/packages/shared/src/ipc-events.ts
+++ b/packages/shared/src/ipc-events.ts
@@ -68,7 +68,7 @@ export interface AppRendererEvents {
   'agent:task-updated': { task: AgentTaskSnapshot }
   'agent:approval-required': { taskId: string, conversationId: string, pendingAction: AgentPendingAction }
   'agent:secret-requested': { request: SecretRequest }
-  'workspace:changed': { currentWorkspacePath: string }
+  'workspace:changed': Record<string, never>
   'settings:updated': { keys: string[] }
   'mcp:status-changed': { serverName: string, status: 'connected' | 'disconnected', error?: string }
   'provider:changed': { providerId?: string }

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    include: ['src/**/*.spec.{ts,tsx}'],
+    include: ['src/interfaces/__tests__/**/*.spec.{ts,tsx}'],
     globals: true,
   },
 })

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.spec.{ts,tsx}'],
+    globals: true,
+  },
+})


### PR DESCRIPTION
## 背景

此前工作区当前路径分散在三处：

- `workspaceStore`（zustand 的 SSOT）
- `conversationsStore`（副本）
- `workspaceService` / `workspaceApi.listWorkspaces` 返回的 `currentWorkspacePath`

三个源在异步操作和分片缓存逻辑中容易产生 staleness，导致 UI 状态不一致，切换/删除工作区后会话快照可能指向旧路径。

## 根因

`conversationsStore` 中的 `currentWorkspacePath` 是上游已存在的副本，`workspaceService` 的 `getCurrentWorkspacePath()` 持久化了同一概念，多个入口对同一信息的维护缺乏协调。

## 方案

1. **`conversationsStore` 删除 `currentWorkspacePath`** — 全部改为从 `workspaceStore` 读取（SSOT）
2. **`workspaceService` 不再持久化 `currentWorkspacePath`** — 改为按 `lastOpenedAt` 派生，存储层只保留 workspace 列表
3. **后端接口去隐式路径依赖** — `searchFiles`、`startTurn`、`clearWorkspaceConversations` 等方法的 `workspacePath` 改为必传，删除 `getCurrentWorkspacePath()` 兜底和 `process.cwd()` fallback
4. **新增 `activateWorkspace` 统一入口** — 封装 `clearActiveConversations + ensureWorkspaceConversations + switchWorkspaceSlice`，所有切换/新增/删除场景调用此入口，消除闭包陷阱
5. **跨 store 取路径规范化** — `clearConversationsAction`、`nextPageConversationsAction` 统一从 `workspaceStore` 取路径

## 变更清单

### 核心重构

| 文件 | 变更 |
|---|---|
| `packages/shared/src/interfaces/workspace.ts` | 删除 `currentWorkspacePath` 字段定义 |
| `packages/shared/src/interfaces/agent-runtime-electron.ts` | `searchFiles` 入参加 `workspacePath` |
| `packages/shared/src/interfaces/app-rpc.ts` | `searchWorkspaceFiles` 入参加 `workspacePath` |
| `packages/shared/src/ipc-events.ts` | `channel:workspace:changed` payload 对齐为空对象 |
| `packages/app-data/src/workspace/workspaceService.ts` | 去掉 `currentWorkspacePath` 持久化与方法，按 `lastOpenedAt` 派生 |
| `packages/app-runtime/src/appRuntime.ts` | 会话接口读写区分语义，`searchFiles` 必传 `workspacePath` |
| `packages/app-runtime/src/rpcHandlers.ts` | `searchWorkspaceFiles` 透传 `workspacePath` |
| `packages/agent-runtime/src/agentTurnService.ts` | `startTurn` 必传 `workspacePath`，删除兜底逻辑 |
| `apps/web/src/store/workspace/store.ts` | 新增 `currentWorkspacePath` SSOT 字段与 `lastOpenedAt` 派生 |
| `apps/web/src/store/conversation/actions.ts` | 新增 `activateWorkspace` 统一入口；`clearConversationsAction`/nextPageConversationsAction 跨 store 取路径 |
| `apps/web/src/store/conversation/conversationsStore.ts` | 删除 `currentWorkspacePath`、`switchWorkspace` → `switchWorkspaceSlice` |
| `apps/web/src/store/conversation/initialState.ts` | 删除 `currentWorkspacePath` 初始值 |

### 组件适配

| 文件 | 变更 |
|---|---|
| `apps/web/src/components/Chat/Chat.tsx` | 从 `workspaceStore` 读 `currentWorkspacePath` |
| `apps/web/src/components/Sender/Sender.tsx` | 同步 `currentWorkspacePath` SSOT；切换工作区改用 `activateWorkspace`；`searchWorkspaceFiles` 传路径 |
| `apps/web/src/components/Workspace/WorkspacePanels.tsx` | 删除 `reloadCurrentWorkspace`、删除双源合并公式，新建/删除/选择统一用 `activateWorkspace` |
| `apps/web/src/components/Workspace/WorkspaceSelector.tsx` | 消除本地第三源，直接走 workspaceStore action + `activateWorkspace` |

### 测试

| 文件 | 变更 |
|---|---|
| `apps/web/src/store/conversation/__tests__/activateWorkspace.spec.ts` | 新增，涵盖空路径 guard、分片加载、缓存复用、跨 store 取路径 |
| `apps/web/src/store/workspace/__tests__/store.spec.ts` | 新增，覆盖 SSOT 字段与派生逻辑 |
| `apps/web/src/__tests__/gui.spec.tsx` | mock workspace 空列表避免 `initialize → activateWorkspace` 干扰 |
| `apps/web/src/components/Sender/__tests__/Sender.spec.tsx` | 对齐 `workspaceStore` SSOT，升级 mock 为 hoisted |
| `packages/app-data/src/workspace/__tests__/workspaceService.spec.ts` | 覆盖不再返回/持久化 `currentWorkspacePath` |
| `packages/app-runtime/src/__tests__/appRuntime.spec.ts` | 覆盖 `searchFiles` 必传路径 |
| `packages/agent-runtime/src/__tests__/agentService.spec.ts` | 覆盖 `workspacePath` 必传、不传抛错 |
| `packages/local-server/src/__tests__/server.spec.ts` | 对齐 payload 变更 |

### 其他

| 文件 | 变更 |
|---|---|
| `eslint.config.mjs` | 添加 `.superpowers/**` 到 ignore |
| `.gitignore` | 添加 `docs/superpowers/` |
| `packages/shared/package.json` / `vitest.config.ts` | 收窄 test include 范围 |