### PR TITLE
feat: 待处理消息队列（pending messages）功能

### DIFF
--- a/apps/web/src/__tests__/gui.spec.tsx
+++ b/apps/web/src/__tests__/gui.spec.tsx
@@ -15,6 +15,7 @@ import { useAgentStore } from '../store/agent'
 import { useConversationsStore } from '../store/conversation'
 import { createInitialState } from '../store/conversation/initialState'
 import { setActiveConversationsId, useMessagesStore } from '../store/messages'
+import { usePendingMessagesStore } from '../store/pendingMessages'
 import { useWorkspaceStore } from '../store/workspace'
 
 const mocks = vi.hoisted(() => ({
@@ -152,6 +153,7 @@ describe('gui ui flow', () => {
     })
     useConversationsStore.setState(createInitialState())
     useAgentStore.setState({ pendingByTask: {}, tasks: {} })
+    usePendingMessagesStore.setState({ itemsByConversation: {} })
 
     mocks.provider.getAllAbvailableModels.mockResolvedValue([])
     mocks.skill.listSkills.mockResolvedValue({ skills: [] })
@@ -444,7 +446,7 @@ describe('gui ui flow', () => {
     })
   })
 
-  it('运行中的 Agent task 可以从输入区追加 steering', async () => {
+  it('运行中的输入先排队，用户点击立即追加后才进入当前任务', async () => {
     seedActiveConversation('conv-steering')
     const task = createTask({
       conversationId: 'conv-steering',
@@ -473,7 +475,16 @@ describe('gui ui flow', () => {
     fireEvent.change(input, {
       target: { value: '先修复类型错误，再继续实现' },
     })
-    fireEvent.click(screen.getByTestId('chat-steer'))
+    expect(screen.queryByTestId('chat-cancel')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('chat-submit'))
+
+    await screen.findByText('先修复类型错误，再继续实现')
+    expect(mocks.agent.injectSteering).not.toHaveBeenCalled()
+    expect(mocks.agent.startTurn).not.toHaveBeenCalled()
+    expect(input).toHaveValue('')
+    expect(screen.getByTestId('chat-cancel')).toHaveTextContent('停止')
+
+    fireEvent.click(screen.getByRole('button', { name: '引导' }))
 
     await waitFor(() => {
       expect(mocks.agent.injectSteering).toHaveBeenCalledWith(
@@ -482,8 +493,6 @@ describe('gui ui flow', () => {
       )
     })
     expect(mocks.agent.startTurn).not.toHaveBeenCalled()
-    expect(input).toHaveValue('')
-    expect(screen.getByTestId('chat-cancel')).toHaveTextContent('停止')
     expect(useMessagesStore.getState().messages).toEqual([
       expect.objectContaining({
         id: 'msg-steering-1',

--- a/apps/web/src/components/Chat/Chat.tsx
+++ b/apps/web/src/components/Chat/Chat.tsx
@@ -5,21 +5,27 @@ import { toast } from 'sonner'
 import { AgentApprovalCard, AgentSecretRequestCard } from '@/components/Agent'
 import { useChatSettingsContext } from '@/contexts/chatSettings'
 import { useBuiltinCommandSubmit } from '@/hooks/useBuiltinCommandSubmit'
-import { approveAgentActionWithWhitelist, injectSteeringAction, rejectAgentAction, rejectSecretRequestAction, resolveSecretRequestAction, startAgentTurn, useAgentStore } from '@/store/agent'
+import { approveAgentActionWithWhitelist, rejectAgentAction, rejectSecretRequestAction, resolveSecretRequestAction, startAgentTurn, useAgentStore } from '@/store/agent'
 import {
   upsertConversationAction,
   useConversationsStore,
 } from '@/store/conversation'
 import {
   abortActiveRequest,
-  addPendingSteeringMessage,
   setActiveConversationsId,
   useMessagesStore,
 } from '@/store/messages'
+import {
+  editPendingMessage,
+  enqueuePendingMessage,
+  injectPendingMessage,
+  removePendingMessage,
+} from '@/store/pendingMessages'
 import { useWorkspaceStore } from '@/store/workspace'
 import Sender from '../Sender'
 
 import { ModelControlPanel } from '../Sender/PickerModel'
+import { buildTurnInput } from './buildTurnInput'
 
 const BubbleList = lazy(() => import('./BubbleList'))
 
@@ -52,44 +58,47 @@ export default function Chat() {
     selectedSkill: string | undefined,
     features: ChatFeatures,
     agentMode: AgentMode,
-  ) {
+  ): Promise<boolean> {
     const textBlocks = content.filter(block => block.type === 'text')
     const draftText = textBlocks.map(block => block.text).join('\n')
 
     if (agentTask) {
-      const message = await injectSteeringAction(agentTask.conversationId, draftText)
-      addPendingSteeringMessage(message)
-      return
+      const hasStructuredInput = content.some(block => block.type !== 'text') || referencedFiles.length > 0 || Boolean(selectedSkill)
+      if (hasStructuredInput) {
+        toast.error('任务进行中，待处理消息暂不支持附件或引用')
+        return false
+      }
+      enqueuePendingMessage(agentTask.conversationId, draftText)
+      return true
     }
 
     if (!settings.modelId) {
       toast.error('请选择模型')
-      return
+      return false
     }
 
     // Try built-in command first
     const handled = await submitCommand(draftText, referencedFiles, selectedSkill)
     if (handled)
-      return
+      return true
 
     // Regular agent turn
     const prompt = draftText
     try {
-      const result = await startAgentTurn({
+      const result = await startAgentTurn(buildTurnInput({
         conversationId: activeConversationsId || undefined,
-        prompt,
+        text: prompt,
         content,
         referencedFiles,
         selectedSkill,
         mode: agentMode,
         workspacePath: currentWorkspacePath,
-        modelConfig: {
-          ...settings,
-          features,
-        },
-      })
+        settings,
+        features,
+      }))
       upsertConversationAction(result.conversation)
       await setActiveConversationsId(result.conversationId)
+      return true
     }
     catch (error) {
       toast.error(error instanceof Error ? error.message : '发送消息失败')
@@ -161,6 +170,10 @@ export default function Chat() {
             />
           )}
           onSubmit={onSubmit}
+          canInjectPendingMessage={true}
+          onInjectPendingMessage={id => void injectPendingMessage(activeConversationsId, id)}
+          onEditPendingMessage={(id, text) => editPendingMessage(activeConversationsId, id, text)}
+          onRemovePendingMessage={id => removePendingMessage(activeConversationsId, id)}
           onCancel={async () => {
             if (commandRunning) {
               await cancelCommand()

--- a/apps/web/src/components/Chat/__tests__/buildTurnInput.spec.ts
+++ b/apps/web/src/components/Chat/__tests__/buildTurnInput.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { buildTurnInput } from '../buildTurnInput'
+
+describe('buildTurnInput', () => {
+  it('完整保留普通消息启动 turn 所需参数', () => {
+    expect(buildTurnInput({
+      conversationId: 'conv-1',
+      text: '继续实现',
+      content: [{ type: 'text', text: '继续实现' }],
+      referencedFiles: ['src/a.ts'],
+      selectedSkill: 'review',
+      workspacePath: '/workspace',
+      settings: { modelId: 'model', providerId: 'provider', systemPrompt: 'system', temperature: 0.2, maxTokens: 2048 },
+      features: { enableMCP: true },
+      mode: 'hybrid',
+    })).toEqual({
+      conversationId: 'conv-1',
+      prompt: '继续实现',
+      content: [{ type: 'text', text: '继续实现' }],
+      referencedFiles: ['src/a.ts'],
+      selectedSkill: 'review',
+      workspacePath: '/workspace',
+      mode: 'hybrid',
+      modelConfig: { modelId: 'model', providerId: 'provider', systemPrompt: 'system', temperature: 0.2, maxTokens: 2048, features: { enableMCP: true } },
+    })
+  })
+})

--- a/apps/web/src/components/Chat/buildTurnInput.ts
+++ b/apps/web/src/components/Chat/buildTurnInput.ts
@@ -1,0 +1,29 @@
+import type { AgentMode, ChatFeatures, ConversationsSettingsSchema, IMessageContent, StartAgentTurnOptions } from '@ant-chat/shared'
+
+interface BuildTurnInputOptions {
+  conversationId?: string
+  text: string
+  content?: IMessageContent
+  referencedFiles?: string[]
+  selectedSkill?: string
+  workspacePath: string
+  settings: ConversationsSettingsSchema
+  features: ChatFeatures
+  mode: AgentMode
+}
+
+export function buildTurnInput(options: BuildTurnInputOptions): StartAgentTurnOptions {
+  return {
+    conversationId: options.conversationId,
+    prompt: options.text,
+    content: options.content ?? [{ type: 'text', text: options.text }],
+    referencedFiles: options.referencedFiles ?? [],
+    selectedSkill: options.selectedSkill,
+    mode: options.mode,
+    workspacePath: options.workspacePath,
+    modelConfig: {
+      ...options.settings,
+      features: options.features,
+    },
+  }
+}

--- a/apps/web/src/components/Sender/PendingMessageItem.tsx
+++ b/apps/web/src/components/Sender/PendingMessageItem.tsx
@@ -1,0 +1,73 @@
+import type { PendingMessage } from '@/store/pendingMessages'
+import { Button } from '@workspace/ui/components/button'
+import { Textarea } from '@workspace/ui/components/textarea'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@workspace/ui/components/tooltip'
+import { CornerDownLeftIcon, GripVerticalIcon, PencilIcon, Trash2Icon } from 'lucide-react'
+import { useState } from 'react'
+
+interface PendingMessageItemProps {
+  item: PendingMessage
+  canInject: boolean
+  onInject: (id: string) => void
+  onEdit: (id: string, text: string) => void
+  onRemove: (id: string) => void
+}
+
+export function PendingMessageItem({ item, canInject, onInject, onEdit, onRemove }: PendingMessageItemProps) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(item.text)
+
+  function save() {
+    onEdit(item.id, draft)
+    setEditing(false)
+  }
+
+  return (
+    <div className="pending-message-enter flex items-center gap-1 px-2 py-2">
+      <GripVerticalIcon aria-hidden="true" className="size-4 shrink-0 text-muted-foreground/60" />
+      <div className="min-w-0 flex-1">
+        {editing
+          ? (
+              <Textarea
+                autoFocus
+                aria-label="编辑消息内容"
+                className="mt-1 min-h-12 resize-none"
+                value={draft}
+                onChange={event => setDraft(event.target.value)}
+                onBlur={save}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' && !event.shiftKey) {
+                    event.preventDefault()
+                    save()
+                  }
+                  if (event.key === 'Escape') {
+                    event.preventDefault()
+                    setDraft(item.text)
+                    setEditing(false)
+                  }
+                }}
+              />
+            )
+          : (
+              <p className="line-clamp-2 text-sm wrap-break-word text-pretty">{item.text}</p>
+            )}
+      </div>
+      <div className="flex shrink-0 items-center opacity-60 transition-opacity duration-150 hover:opacity-100">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button className="active:scale-[0.96]" size="icon" variant="ghost" aria-label="引导" disabled={!canInject} onClick={() => onInject(item.id)}>
+              <CornerDownLeftIcon className="size-4 cursor-pointer" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="top">引导</TooltipContent>
+        </Tooltip>
+        <Button className="active:scale-[0.96]" size="icon" variant="ghost" aria-label="编辑待处理消息" onClick={() => setEditing(true)}>
+          <PencilIcon className="size-4 cursor-pointer" />
+        </Button>
+        <Button className=" active:scale-[0.96]" size="icon" variant="ghost" aria-label="删除待处理消息" onClick={() => onRemove(item.id)}>
+          <Trash2Icon className="size-4 cursor-pointer" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/Sender/PendingMessageQueue.tsx
+++ b/apps/web/src/components/Sender/PendingMessageQueue.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useLayoutEffect, useMemo, useRef } from 'react'
+import { sortPendingMessages, usePendingMessagesStore } from '@/store/pendingMessages'
+import { PendingMessageItem } from './PendingMessageItem'
+
+const EMPTY_ITEMS: never[] = []
+
+interface PendingMessageQueueProps {
+  conversationId: string
+  canInject: boolean
+  onInject: (id: string) => void
+  onEdit: (id: string, text: string) => void
+  onRemove: (id: string) => void
+}
+
+export function PendingMessageQueue(props: PendingMessageQueueProps) {
+  const viewportRef = useRef<HTMLDivElement>(null)
+  const items = usePendingMessagesStore(state => state.itemsByConversation[props.conversationId] ?? EMPTY_ITEMS)
+  const sortedItems = useMemo(() => sortPendingMessages(items), [items])
+  const previousLength = useRef(sortedItems.length)
+
+  useLayoutEffect(() => {
+    if (viewportRef.current)
+      viewportRef.current.scrollTop = 0
+  }, [props.conversationId])
+
+  useEffect(() => {
+    const viewport = viewportRef.current
+    const wasNearBottom = viewport
+      ? viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight < 32
+      : false
+    if (viewport && sortedItems.length > previousLength.current && wasNearBottom)
+      viewport.scrollTop = viewport.scrollHeight
+    previousLength.current = sortedItems.length
+  }, [sortedItems.length])
+
+  if (!sortedItems.length)
+    return null
+
+  return (
+    <div>
+      <div ref={viewportRef} aria-label="待处理消息" className="pending-message-scroll max-h-68 overflow-y-auto">
+        {sortedItems.map(item => (
+          <PendingMessageItem
+            item={item}
+            key={item.id}
+            canInject={props.canInject}
+            onInject={props.onInject}
+            onEdit={props.onEdit}
+            onRemove={props.onRemove}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/Sender/Sender.tsx
+++ b/apps/web/src/components/Sender/Sender.tsx
@@ -72,6 +72,7 @@ import {
   syncSelectedSkill,
 } from './inputReferences'
 import MCPManagementPanel from './MCPManagementPanel'
+import { PendingMessageQueue } from './PendingMessageQueue'
 import { ReferenceSuggestionPanel } from './ReferenceSuggestionPanel'
 import { calculateSessionUsage } from './sessionUsage'
 
@@ -84,8 +85,12 @@ interface SenderProps {
     selectedSkill: string | undefined,
     features: ChatFeatures,
     agentMode: AgentMode,
-  ) => void
+  ) => Promise<boolean | void> | boolean | void
   onCancel?: () => void
+  canInjectPendingMessage?: boolean
+  onInjectPendingMessage?: (id: string) => void
+  onEditPendingMessage?: (id: string, text: string) => void
+  onRemovePendingMessage?: (id: string) => void
 }
 
 async function filePartToAttachment(part: FileUIPart, index: number) {
@@ -745,9 +750,11 @@ function Sender({ disabled = false, actions, ...props }: SenderProps) {
       }
     })
 
-    await props.onSubmit?.(content, nextReferencedFiles, nextSelectedSkill, {
+    const submitted = await props.onSubmit?.(content, nextReferencedFiles, nextSelectedSkill, {
       enableMCP: mcpEnabled,
     }, agentMode)
+    if (submitted === false)
+      return
     setDraft('')
     setCursor(0)
     setReferencedFiles([])
@@ -765,86 +772,96 @@ function Sender({ disabled = false, actions, ...props }: SenderProps) {
           <TypingEffect text="有什么可以帮忙的？" />
         </h1>
       )}
+      <div className="bg-secondary rounded-lg overflow-hidden">
 
-      <PromptInput
-        accept={fileAccept}
-        data-testid="chat-input-form"
-        maxFileSize={20 * 1024 * 1024}
-        multiple
-        onError={({ message }) => setNotice(message)}
-        onSubmit={async (message) => {
-          setNotice('')
-          await handleSubmit(message)
-        }}
-      >
-        <PromptInputBody className="bg-transparent px-1 pt-1">
-          <SenderAttachmentsPreview />
-          <div className="relative min-h-20 w-full md:min-h-24">
-            <ReferenceInputOverlay
-              text={draft}
-              referencedFiles={referencedFiles}
-              selectedSkill={selectedSkill}
-              scrollTop={textareaScrollTop}
-            />
-            <PromptInputTextarea
-              ref={textareaRef}
-              className="
+        <PendingMessageQueue
+          conversationId={activeConversationsId}
+          canInject={props.canInjectPendingMessage ?? false}
+          onInject={id => props.onInjectPendingMessage?.(id)}
+          onEdit={(id, text) => props.onEditPendingMessage?.(id, text)}
+          onRemove={id => props.onRemovePendingMessage?.(id)}
+        />
+
+        <PromptInput
+          accept={fileAccept}
+          className="bg-background rounded-lg overflow-hidden"
+          data-testid="chat-input-form"
+          maxFileSize={20 * 1024 * 1024}
+          multiple
+          onError={({ message }) => setNotice(message)}
+          onSubmit={async (message) => {
+            setNotice('')
+            await handleSubmit(message)
+          }}
+        >
+          <PromptInputBody className="bg-transparent px-1 pt-1">
+            <SenderAttachmentsPreview />
+            <div className="relative min-h-20 w-full md:min-h-24">
+              <ReferenceInputOverlay
+                text={draft}
+                referencedFiles={referencedFiles}
+                selectedSkill={selectedSkill}
+                scrollTop={textareaScrollTop}
+              />
+              <PromptInputTextarea
+                ref={textareaRef}
+                className="
                 relative z-10 max-h-48 min-h-20 border-0 bg-transparent p-1 text-transparent
                 text-sm caret-foreground
                 selection:bg-primary/20 selection:text-foreground
                 placeholder:text-muted-foreground
                 md:min-h-24
               "
-              data-testid="chat-input"
-              disabled={disabled}
-              value={draft}
-              onChange={(event) => {
-                updateDraft(event.currentTarget.value, event.currentTarget.selectionStart)
-              }}
-              onClick={event => updateCursorFromTextarea(event.currentTarget)}
-              onKeyDown={handleTextareaKeyDown}
-              onKeyUp={handleTextareaKeyUp}
-              onScroll={event => setTextareaScrollTop(event.currentTarget.scrollTop)}
-              placeholder={disabled
-                ? '指令执行中...'
-                : loading
-                  ? '输入追加指令，Enter发送'
-                  : 'Enter发送消息，Shift+Enter换行'}
+                data-testid="chat-input"
+                disabled={disabled}
+                value={draft}
+                onChange={(event) => {
+                  updateDraft(event.currentTarget.value, event.currentTarget.selectionStart)
+                }}
+                onClick={event => updateCursorFromTextarea(event.currentTarget)}
+                onKeyDown={handleTextareaKeyDown}
+                onKeyUp={handleTextareaKeyUp}
+                onScroll={event => setTextareaScrollTop(event.currentTarget.scrollTop)}
+                placeholder={disabled
+                  ? '指令执行中...'
+                  : loading
+                    ? '输入追加指令，Enter发送'
+                    : 'Enter发送消息，Shift+Enter换行'}
+              />
+            </div>
+            <ReferenceSuggestionPanel
+              trigger={activeReferenceTrigger}
+              files={senderData.fileResults}
+              skills={filteredSkills}
+              builtinCommands={filteredCommands}
+              hasWorkspace={Boolean(currentWorkspacePath)}
+              highlightedIndex={senderData.highlightedIndex}
+              anchorRect={senderData.suggestionAnchorRect}
+              onSelectFile={selectFileReference}
+              onSelectSkill={selectSkillReference}
+              onSelectCommand={selectCommandReference}
             />
-          </div>
-          <ReferenceSuggestionPanel
-            trigger={activeReferenceTrigger}
-            files={senderData.fileResults}
-            skills={filteredSkills}
-            builtinCommands={filteredCommands}
-            hasWorkspace={Boolean(currentWorkspacePath)}
-            highlightedIndex={senderData.highlightedIndex}
-            anchorRect={senderData.suggestionAnchorRect}
-            onSelectFile={selectFileReference}
-            onSelectSkill={selectSkillReference}
-            onSelectCommand={selectCommandReference}
-          />
-        </PromptInputBody>
+          </PromptInputBody>
 
-        <PromptInputFooter className="min-w-0">
-          <PromptInputTools className="scroll-hidden overflow-visible max-sm:overflow-x-auto">
-            <Popover
-              open={canSwitchWorkspaceSelect ? workspacePickerOpen : false}
-              onOpenChange={(next) => {
-                if (canSwitchWorkspaceSelect) {
-                  setWorkspacePickerOpen(next)
-                }
-              }}
-            >
-              <PopoverTrigger asChild>
-                <PromptInputButton
-                  type="button"
-                  variant="ghost"
-                  data-testid="workspace-switcher"
-                  disabled={workspaceLoading}
-                  aria-disabled={workspaceSwitchDisabled}
-                  aria-label={`工作区：${workspaceDisplayName}`}
-                  className={`
+          <PromptInputFooter className="min-w-0">
+            <PromptInputTools className="scroll-hidden overflow-visible max-sm:overflow-x-auto">
+              <Popover
+                open={canSwitchWorkspaceSelect ? workspacePickerOpen : false}
+                onOpenChange={(next) => {
+                  if (canSwitchWorkspaceSelect) {
+                    setWorkspacePickerOpen(next)
+                  }
+                }}
+              >
+                <PopoverTrigger asChild>
+                  <PromptInputButton
+                    type="button"
+                    variant="ghost"
+                    data-testid="workspace-switcher"
+                    disabled={workspaceLoading}
+                    aria-disabled={workspaceSwitchDisabled}
+                    aria-label={`工作区：${workspaceDisplayName}`}
+                    className={`
                     h-8 max-w-52 justify-start border px-2
                     max-sm:size-8 max-sm:justify-center max-sm:gap-0 max-sm:px-0
                     ${workspaceSwitchDisabled
@@ -854,129 +871,126 @@ function Sender({ disabled = false, actions, ...props }: SenderProps) {
       `
       : ''}
                   `}
-                >
-                  <FolderOpenIcon className="size-4 shrink-0" />
-                  <span className="truncate text-xs max-sm:hidden">{workspaceDisplayName}</span>
-                </PromptInputButton>
-              </PopoverTrigger>
-              <PopoverContent align="start" className="w-64 p-1">
-                <div className="max-h-60 overflow-y-auto">
-                  {selectableWorkspaces.map(item => (
-                    <button
-                      key={item.path}
-                      type="button"
-                      className={`
+                  >
+                    <FolderOpenIcon className="size-4 shrink-0" />
+                    <span className="truncate text-xs max-sm:hidden">{workspaceDisplayName}</span>
+                  </PromptInputButton>
+                </PopoverTrigger>
+                <PopoverContent align="start" className="w-64 p-1">
+                  <div className="max-h-60 overflow-y-auto">
+                    {selectableWorkspaces.map(item => (
+                      <button
+                        key={item.path}
+                        type="button"
+                        className={`
                         flex h-8 w-full items-center gap-2 rounded-md px-2 text-left text-sm
                         hover:bg-black/5
                         dark:hover:bg-white/10
                       `}
-                      onClick={() => {
-                        void handleSwitchWorkspace(item.path)
-                      }}
-                    >
-                      <FolderOpenIcon className="size-4 shrink-0" />
-                      <span className="truncate">{item.displayName}</span>
-                    </button>
-                  ))}
-                </div>
-              </PopoverContent>
-            </Popover>
+                        onClick={() => {
+                          void handleSwitchWorkspace(item.path)
+                        }}
+                      >
+                        <FolderOpenIcon className="size-4 shrink-0" />
+                        <span className="truncate">{item.displayName}</span>
+                      </button>
+                    ))}
+                  </div>
+                </PopoverContent>
+              </Popover>
 
-            <SenderAddAttachmentButton />
-            <SenderContextUsageButton contextLength={currentModelInfo?.contextLength ?? 1} />
+              <SenderAddAttachmentButton />
+              <SenderContextUsageButton contextLength={currentModelInfo?.contextLength ?? 1} />
 
-            <Popover>
-              <PopoverTrigger asChild>
-                <PromptInputButton
-                  size="sm"
-                  type="button"
-                  variant="ghost"
-                  aria-label={`权限模式：${currentAgentModeOption.label}`}
-                  className={`
+              <Popover>
+                <PopoverTrigger asChild>
+                  <PromptInputButton
+                    size="sm"
+                    type="button"
+                    variant="ghost"
+                    aria-label={`权限模式：${currentAgentModeOption.label}`}
+                    className={`
                     ${agentMode === 'full_managed' ? 'text-orange-600' : ''}
                   `}
-                >
-                  {currentAgentModeOption.icon}
-                  <span className="max-sm:hidden">{currentAgentModeOption.label}</span>
-                  <ChevronDownIcon className="size-3 max-sm:hidden" />
-                </PromptInputButton>
-              </PopoverTrigger>
-              <PopoverContent align="start" className="w-52 p-1">
-                {agentModeOptions.map(item => (
-                  <button
-                    key={item.value}
-                    type="button"
-                    className={`
+                  >
+                    {currentAgentModeOption.icon}
+                    <span className="max-sm:hidden">{currentAgentModeOption.label}</span>
+                    <ChevronDownIcon className="size-3 max-sm:hidden" />
+                  </PromptInputButton>
+                </PopoverTrigger>
+                <PopoverContent align="start" className="w-52 p-1">
+                  {agentModeOptions.map(item => (
+                    <button
+                      key={item.value}
+                      type="button"
+                      className={`
                       flex h-9 w-full items-center justify-between rounded-md px-2 text-sm
                       hover:bg-black/5
                       dark:hover:bg-white/10
                     `}
-                    onClick={() => setAgentMode(item.value)}
-                  >
-                    <span className="flex items-center gap-2">
-                      {item.icon}
-                      {item.label}
-                    </span>
-                    {item.value === agentMode ? <span>✓</span> : null}
-                  </button>
-                ))}
-              </PopoverContent>
-            </Popover>
+                      onClick={() => setAgentMode(item.value)}
+                    >
+                      <span className="flex items-center gap-2">
+                        {item.icon}
+                        {item.label}
+                      </span>
+                      {item.value === agentMode ? <span>✓</span> : null}
+                    </button>
+                  ))}
+                </PopoverContent>
+              </Popover>
 
-            <Popover>
-              <PopoverTrigger asChild>
-                <PromptInputButton
-                  size="sm"
-                  type="button"
-                  variant={mcpEnabled ? 'secondary' : 'ghost'}
-                  aria-label="MCP 管理"
-                >
-                  <Cable className="size-3" />
-                  <span className="max-sm:hidden">MCP</span>
-                </PromptInputButton>
-              </PopoverTrigger>
-              <PopoverContent align="start" className="w-[calc(100vw-1rem)] max-w-85 p-0">
-                <MCPManagementPanel />
-              </PopoverContent>
-            </Popover>
-
-            {actions}
-          </PromptInputTools>
-
-          {loading
-            ? (
-                <>
+              <Popover>
+                <PopoverTrigger asChild>
                   <PromptInputButton
                     size="sm"
                     type="button"
-                    variant="outline"
-                    data-testid="chat-cancel"
-                    onClick={props.onCancel}
+                    variant={mcpEnabled ? 'secondary' : 'ghost'}
+                    aria-label="MCP 管理"
                   >
-                    <SquareIcon className="size-3" />
-                    停止
+                    <Cable className="size-3" />
+                    <span className="max-sm:hidden">MCP</span>
                   </PromptInputButton>
+                </PopoverTrigger>
+                <PopoverContent align="start" className="w-[calc(100vw-1rem)] max-w-85 p-0">
+                  <MCPManagementPanel />
+                </PopoverContent>
+              </Popover>
+
+              {actions}
+            </PromptInputTools>
+
+            {loading
+              ? (
+                  <div className="min-w-17">
+                    {draft.trim()
+                      ? (
+                          <PromptInputSubmit className="sender-primary-action" size="sm" data-testid="chat-submit" status="ready">
+                            发送
+                          </PromptInputSubmit>
+                        )
+                      : (
+                          <PromptInputButton className="sender-primary-action" size="sm" type="button" variant="outline" data-testid="chat-cancel" onClick={props.onCancel}>
+                            <SquareIcon className="size-3" />
+                            停止
+                          </PromptInputButton>
+                        )}
+                  </div>
+                )
+              : (
                   <PromptInputSubmit
                     size="sm"
-                    data-testid="chat-steer"
-                    status="ready"
+                    data-testid={disabled ? 'chat-cancel' : 'chat-submit'}
+                    onStop={props.onCancel}
+                    status={disabled ? 'submitted' : 'ready'}
                   >
-                    追加
+                    {disabled ? '执行中' : '发送'}
                   </PromptInputSubmit>
-                </>
-              )
-            : (
-                <PromptInputSubmit
-                  size="sm"
-                  data-testid={disabled ? 'chat-cancel' : 'chat-submit'}
-                  onStop={props.onCancel}
-                  status={disabled ? 'submitted' : 'ready'}
-                >
-                  {disabled ? '执行中' : '发送'}
-                </PromptInputSubmit>
-              )}
-        </PromptInputFooter>
-      </PromptInput>
+                )}
+          </PromptInputFooter>
+        </PromptInput>
+
+      </div>
 
       {notice && (
         <div className="mt-2 text-xs text-red-500">{notice}</div>

--- a/apps/web/src/components/Sender/__tests__/PendingMessageQueue.spec.tsx
+++ b/apps/web/src/components/Sender/__tests__/PendingMessageQueue.spec.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TooltipProvider } from '@workspace/ui/components/tooltip'
+import { enqueuePendingMessage, usePendingMessagesStore } from '@/store/pendingMessages'
+import { PendingMessageQueue } from '../PendingMessageQueue'
+
+function renderWithTooltip(ui: React.ReactElement) {
+  return render(<TooltipProvider>{ui}</TooltipProvider>)
+}
+
+describe('pendingMessageQueue', () => {
+  beforeEach(() => {
+    usePendingMessagesStore.setState({ itemsByConversation: {} })
+  })
+
+  it('乱序输入后渲染消息列表', () => {
+    enqueuePendingMessage('conv-1', '后发消息')
+    enqueuePendingMessage('conv-1', '先发消息')
+    const onInject = vi.fn()
+    renderWithTooltip(<PendingMessageQueue conversationId="conv-1" canInject onInject={onInject} onEdit={vi.fn()} onRemove={vi.fn()} />)
+    const [injectButtons, editButtons, deleteButtons] = screen.getAllByRole('button')
+    expect(injectButtons).toBeInTheDocument()
+    expect(editButtons).toBeInTheDocument()
+    expect(deleteButtons).toBeInTheDocument()
+    fireEvent.click(injectButtons)
+    expect(onInject).toHaveBeenCalled()
+  })
+
+  it('无 pending 消息时返回 null', () => {
+    const { container } = renderWithTooltip(<PendingMessageQueue conversationId="conv-1" canInject={false} onInject={vi.fn()} onEdit={vi.fn()} onRemove={vi.fn()} />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('编辑保存后调用 onEdit', () => {
+    enqueuePendingMessage('conv-1', '原文')
+    const onEdit = vi.fn()
+    renderWithTooltip(<PendingMessageQueue conversationId="conv-1" canInject={false} onInject={vi.fn()} onEdit={onEdit} onRemove={vi.fn()} />)
+    expect(screen.getByText('原文')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: '编辑待处理消息' }))
+    const editor = screen.getByRole('textbox', { name: '编辑消息内容' })
+    fireEvent.change(editor, { target: { value: '修改后' } })
+    fireEvent.keyDown(editor, { key: 'Enter' })
+    expect(onEdit).toHaveBeenCalledWith(expect.any(String), '修改后')
+  })
+})

--- a/apps/web/src/components/Sender/__tests__/PendingMessageQueue.spec.tsx
+++ b/apps/web/src/components/Sender/__tests__/PendingMessageQueue.spec.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { TooltipProvider } from '@workspace/ui/components/tooltip'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { enqueuePendingMessage, usePendingMessagesStore } from '@/store/pendingMessages'
 import { PendingMessageQueue } from '../PendingMessageQueue'
 

--- a/apps/web/src/hooks/useAppEventListener.ts
+++ b/apps/web/src/hooks/useAppEventListener.ts
@@ -7,6 +7,7 @@ import { addStreamingConversationId, removeStreamingConversationId, upsertConver
 import { refreshGeneralSettings } from '@/store/generalSettings/actions'
 import { onMcpServerStatusChanged } from '@/store/mcpConfigs/action'
 import { updateMessageActionV2 } from '@/store/messages'
+import { drainPendingMessages } from '@/store/pendingMessages'
 import { useWorkspaceStore } from '@/store/workspace'
 
 export function useAppEventListener() {
@@ -48,6 +49,10 @@ export function useAppEventListener() {
     eventBus.on('agent:task-updated', (_, payload) => {
       onAgentStateUpdated(payload.task)
     })
+    eventBus.on('agent:turn-finished', (_, payload) => {
+      if (payload.status !== 'cancel')
+        void drainPendingMessages(payload.conversationId)
+    })
     eventBus.on('agent:approval-required', (_, payload) => {
       onAgentApprovalRequired(payload.taskId, payload.pendingAction)
     })
@@ -67,6 +72,7 @@ export function useAppEventListener() {
       eventBus.removeAllListeners('conversation:updated')
       eventBus.removeAllListeners('message:updated')
       eventBus.removeAllListeners('agent:task-updated')
+      eventBus.removeAllListeners('agent:turn-finished')
       eventBus.removeAllListeners('agent:approval-required')
       eventBus.removeAllListeners('agent:secret-requested')
       eventBus.removeAllListeners('settings:updated')

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,5 +1,55 @@
 @import './assets/scroll-style.css';
 
+.pending-message-enter {
+  animation: pending-message-enter 160ms ease-out;
+}
+
+.pending-message-enter:not(:last-child) {
+  border-bottom: 1px solid var(--border);
+}
+
+.sender-primary-action {
+  animation: sender-primary-action-enter 140ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+@keyframes pending-message-enter {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes sender-primary-action-enter {
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.pending-message-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+}
+
+.pending-message-scroll:hover {
+  scrollbar-color: color-mix(in oklab, var(--muted-foreground) 35%, transparent) transparent;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pending-message-enter,
+  .sender-primary-action {
+    animation: none;
+  }
+}
+
 @layer utilities {
   .app-region-drag {
     -webkit-app-region: drag;

--- a/apps/web/src/store/conversation/actions.ts
+++ b/apps/web/src/store/conversation/actions.ts
@@ -3,6 +3,11 @@ import type { AntChatFileStructure } from '@/constants'
 import { produce } from 'immer'
 import chatApi from '@/api/chatApi'
 import { useGeneralSettingsStore } from '@/store/generalSettings'
+import {
+  cancelPendingMessageDeletion,
+  completePendingMessageDeletion,
+  preparePendingMessageDeletion,
+} from '@/store/pendingMessages'
 import { useWorkspaceStore } from '@/store/workspace'
 import { clearActiveConversations, setActiveConversationsId } from '../messages'
 import { useConversationsStore } from './conversationsStore'
@@ -134,7 +139,15 @@ export async function renameConversationsAction(id: ConversationsId, title: stri
 }
 
 export async function deleteConversationsAction(id: ConversationsId) {
-  await chatApi.deleteConversation(id)
+  const deletion = await preparePendingMessageDeletion([id])
+  try {
+    await chatApi.deleteConversation(id)
+    completePendingMessageDeletion(deletion)
+  }
+  catch (error) {
+    cancelPendingMessageDeletion(deletion)
+    throw error
+  }
 
   await clearActiveConversations()
 
@@ -155,7 +168,23 @@ export async function clearConversationsAction() {
     throw new Error('当前工作区路径不存在，无法清空对话')
   }
 
-  await chatApi.clearWorkspaceConversations(currentWorkspacePath)
+  const loadedConversationIds = useConversationsStore.getState().conversations.map(conversation => conversation.id)
+  const loadedDeletion = await preparePendingMessageDeletion(loadedConversationIds)
+  let deletedConversationIds: string[]
+  try {
+    deletedConversationIds = await chatApi.clearWorkspaceConversations(currentWorkspacePath)
+    const deletedIds = new Set(deletedConversationIds)
+    const loadedIds = new Set(loadedConversationIds)
+    const unloadedDeletedIds = deletedConversationIds.filter(id => !loadedIds.has(id))
+    const unloadedDeletion = await preparePendingMessageDeletion(unloadedDeletedIds)
+    completePendingMessageDeletion(loadedDeletion, loadedConversationIds.filter(id => deletedIds.has(id)))
+    cancelPendingMessageDeletion(loadedDeletion, loadedConversationIds.filter(id => !deletedIds.has(id)))
+    completePendingMessageDeletion(unloadedDeletion)
+  }
+  catch (error) {
+    cancelPendingMessageDeletion(loadedDeletion)
+    throw error
+  }
 
   await clearActiveConversations()
 

--- a/apps/web/src/store/pendingMessages/__tests__/actions.spec.ts
+++ b/apps/web/src/store/pendingMessages/__tests__/actions.spec.ts
@@ -76,7 +76,7 @@ describe('pending message actions', () => {
   })
 
   it('drain 与立即追加并发时按会话串行', async () => {
-    const first = enqueuePendingMessage('conv-1', '队首')
+    enqueuePendingMessage('conv-1', '队首')
     const second = enqueuePendingMessage('conv-1', '队尾')
 
     const draining = drainPendingMessages('conv-1')

--- a/apps/web/src/store/pendingMessages/__tests__/actions.spec.ts
+++ b/apps/web/src/store/pendingMessages/__tests__/actions.spec.ts
@@ -1,0 +1,252 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useChatSttingsStore } from '@/store/chatSettings'
+import { clearConversationsAction, deleteConversationsAction, useConversationsStore } from '@/store/conversation'
+import { useMessagesStore } from '@/store/messages'
+import { useWorkspaceStore } from '@/store/workspace'
+import { cancelPendingMessageDeletion, clearAllPendingMessages, completePendingMessageDeletion, drainPendingMessages, enqueuePendingMessage, getPendingMessageOperationStateForTests, injectPendingMessage, preparePendingMessageDeletion } from '../actions'
+import { usePendingMessagesStore } from '../store'
+
+const mocks = vi.hoisted(() => ({
+  injectSteering: vi.fn(),
+  listActiveTasks: vi.fn(),
+  startTurn: vi.fn(),
+  clearWorkspaceConversations: vi.fn(),
+  deleteConversation: vi.fn(),
+  getMessagesByConvId: vi.fn(),
+}))
+
+vi.mock('@/api/agentApi', () => ({ default: mocks }))
+vi.mock('@/api/chatApi', () => ({
+  default: {
+    clearWorkspaceConversations: mocks.clearWorkspaceConversations,
+    deleteConversation: mocks.deleteConversation,
+    getMessagesByConvId: mocks.getMessagesByConvId,
+  },
+}))
+
+const conversation = {
+  id: 'conv-1',
+  title: '测试会话',
+  settings: { modelId: 'model', providerId: 'provider', systemPrompt: '', temperature: 0.7, maxTokens: 1000 },
+}
+
+describe('pending message actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    usePendingMessagesStore.setState({ itemsByConversation: {} })
+    useConversationsStore.setState({ conversations: [conversation] as any })
+    useMessagesStore.setState({ activeConversationsId: 'conv-1' as any, messages: [], pendingSteeringByConversation: {} })
+    useWorkspaceStore.setState({ currentWorkspacePath: '/workspace' })
+    useChatSttingsStore.setState({ enableMCP: true, agentMode: 'hybrid' })
+    mocks.listActiveTasks.mockResolvedValue([])
+    mocks.clearWorkspaceConversations.mockResolvedValue(['conv-1'])
+    mocks.deleteConversation.mockResolvedValue(null)
+    mocks.getMessagesByConvId.mockResolvedValue([])
+    mocks.startTurn.mockResolvedValue({ conversation, conversationId: 'conv-1', taskId: 'task-2', userMessageId: 'user-2' })
+  })
+
+  it('重复 drain 只启动一个 FIFO 队首且不会连续发送第二项', async () => {
+    enqueuePendingMessage('conv-1', '第一条')
+    enqueuePendingMessage('conv-1', '第二条')
+    const one = drainPendingMessages('conv-1')
+    const two = drainPendingMessages('conv-1')
+    expect(one).toBe(two)
+    await Promise.all([one, two])
+    expect(mocks.startTurn).toHaveBeenCalledTimes(1)
+    expect(mocks.startTurn).toHaveBeenCalledWith(expect.objectContaining({ prompt: '第一条', workspacePath: '/workspace' }))
+    expect(usePendingMessagesStore.getState().itemsByConversation['conv-1']).toHaveLength(1)
+  })
+
+  it('立即追加成功后删除队列项', async () => {
+    const queued = enqueuePendingMessage('conv-1', '追加内容')
+    mocks.listActiveTasks.mockResolvedValue([{ conversationId: 'conv-1', taskId: 'task-1', status: 'running' }])
+    mocks.injectSteering.mockResolvedValue({ id: 'message-1', convId: 'conv-1', role: 'user', status: 'success', content: [{ type: 'text', text: '追加内容' }] })
+    await injectPendingMessage('conv-1', queued.id)
+    expect(mocks.injectSteering).toHaveBeenCalledWith('conv-1', '追加内容')
+    expect(usePendingMessagesStore.getState().itemsByConversation['conv-1']).toEqual([])
+  })
+
+  it('任务已结束时注入回退为普通 turn，失败时删除消息', async () => {
+    const queued = enqueuePendingMessage('conv-1', '下一轮')
+    mocks.startTurn.mockRejectedValue(new Error('网络不可用'))
+    await injectPendingMessage('conv-1', queued.id)
+    expect(mocks.injectSteering).not.toHaveBeenCalled()
+    expect(usePendingMessagesStore.getState().itemsByConversation['conv-1']).toEqual([])
+  })
+
+  it('drain 与立即追加并发时按会话串行，不让后续项越过队首', async () => {
+    const first = enqueuePendingMessage('conv-1', '队首')
+    const second = enqueuePendingMessage('conv-1', '队尾')
+    let resolveInitialCheck!: (tasks: never[]) => void
+    mocks.listActiveTasks
+      .mockReturnValueOnce(new Promise((resolve) => { resolveInitialCheck = resolve }))
+      .mockResolvedValueOnce([{ conversationId: 'conv-1', taskId: 'new-task', status: 'running' }])
+    mocks.injectSteering.mockResolvedValue({ id: 'steering', convId: 'conv-1', role: 'user', status: 'success', content: [{ type: 'text', text: '队尾' }] })
+
+    const draining = drainPendingMessages('conv-1')
+    const injecting = injectPendingMessage('conv-1', second.id)
+    resolveInitialCheck([])
+    await Promise.all([draining, injecting])
+
+    expect(mocks.startTurn).toHaveBeenCalledWith(expect.objectContaining({ prompt: '队首' }))
+    expect(mocks.injectSteering).toHaveBeenCalledWith('conv-1', '队尾')
+    expect(usePendingMessagesStore.getState().itemsByConversation['conv-1'].some(item => item.id === first.id)).toBe(false)
+  })
+
+  it('清空全部队列不依赖当前已加载会话分页', () => {
+    enqueuePendingMessage('conv-1', '当前页')
+    enqueuePendingMessage('conv-unloaded', '未加载页')
+    clearAllPendingMessages()
+    expect(usePendingMessagesStore.getState().itemsByConversation).toEqual({})
+  })
+
+  it('单删会等待进行中的 drain 完成，再删除会话和队列', async () => {
+    enqueuePendingMessage('conv-1', '正在启动')
+    let resolveStart!: (value: any) => void
+    mocks.startTurn.mockReturnValue(new Promise((resolve) => {
+      resolveStart = resolve
+    }))
+
+    const draining = drainPendingMessages('conv-1')
+    await vi.waitFor(() => expect(mocks.startTurn).toHaveBeenCalledTimes(1))
+    const deleting = deleteConversationsAction('conv-1' as any)
+    expect(mocks.deleteConversation).not.toHaveBeenCalled()
+    resolveStart({ conversation, conversationId: 'conv-1', taskId: 'task', userMessageId: 'user' })
+    await draining
+    await deleting
+
+    expect(usePendingMessagesStore.getState().itemsByConversation['conv-1']).toBeUndefined()
+    expect(useConversationsStore.getState().conversations.some(item => item.id === 'conv-1')).toBe(false)
+  })
+
+  it('清空工作区等待进行中 turn 完成，且只清服务端返回 ID', async () => {
+    enqueuePendingMessage('conv-1', '当前工作区')
+    enqueuePendingMessage('other-workspace-conv', '其他工作区')
+    let resolveStart!: (value: any) => void
+    mocks.startTurn.mockReturnValue(new Promise((resolve) => {
+      resolveStart = resolve
+    }))
+
+    const draining = drainPendingMessages('conv-1')
+    await vi.waitFor(() => expect(mocks.startTurn).toHaveBeenCalledTimes(1))
+    const clearing = clearConversationsAction()
+    expect(mocks.clearWorkspaceConversations).not.toHaveBeenCalled()
+    resolveStart({ conversation, conversationId: 'conv-1', taskId: 'task', userMessageId: 'user' })
+    await draining
+    await clearing
+
+    expect(usePendingMessagesStore.getState().itemsByConversation['conv-1']).toBeUndefined()
+    expect(usePendingMessagesStore.getState().itemsByConversation['other-workspace-conv']).toHaveLength(1)
+    expect(useConversationsStore.getState().conversations.some(item => item.id === 'conv-1')).toBe(false)
+  })
+
+  it('startTurn 已发起时删除失败，保留真实成功结果且不会重复发送', async () => {
+    enqueuePendingMessage('conv-1', '已成功启动')
+    let resolveStart!: (value: any) => void
+    mocks.startTurn.mockReturnValue(new Promise((resolve) => {
+      resolveStart = resolve
+    }))
+    mocks.deleteConversation.mockRejectedValueOnce(new Error('删除失败'))
+
+    const draining = drainPendingMessages('conv-1')
+    await vi.waitFor(() => expect(mocks.startTurn).toHaveBeenCalledTimes(1))
+    const deleting = deleteConversationsAction('conv-1' as any)
+    resolveStart({ conversation, conversationId: 'conv-1', taskId: 'task', userMessageId: 'user' })
+    await draining
+    await expect(deleting).rejects.toThrow('删除失败')
+    await drainPendingMessages('conv-1')
+
+    expect(mocks.startTurn).toHaveBeenCalledTimes(1)
+    expect(usePendingMessagesStore.getState().itemsByConversation['conv-1']).toEqual([])
+  })
+
+  it('inject 已发起时删除失败，保留真实注入结果且不会重复注入', async () => {
+    const queued = enqueuePendingMessage('conv-1', '已成功注入')
+    mocks.listActiveTasks.mockResolvedValue([{ conversationId: 'conv-1', taskId: 'task', status: 'running' }])
+    let resolveInject!: (value: any) => void
+    mocks.injectSteering.mockReturnValue(new Promise((resolve) => {
+      resolveInject = resolve
+    }))
+    mocks.deleteConversation.mockRejectedValueOnce(new Error('删除失败'))
+
+    const injecting = injectPendingMessage('conv-1', queued.id)
+    await vi.waitFor(() => expect(mocks.injectSteering).toHaveBeenCalledTimes(1))
+    const deleting = deleteConversationsAction('conv-1' as any)
+    resolveInject({ id: 'steering', convId: 'conv-1', role: 'user', status: 'success', content: [{ type: 'text', text: '已成功注入' }] })
+    await injecting
+    await expect(deleting).rejects.toThrow('删除失败')
+
+    expect(mocks.injectSteering).toHaveBeenCalledTimes(1)
+    expect(usePendingMessagesStore.getState().itemsByConversation['conv-1']).toEqual([])
+    expect(useMessagesStore.getState().messages).toHaveLength(1)
+  })
+
+  it('大量删除屏障完成后不会累积 Promise 或 tombstone', async () => {
+    for (let index = 0; index < 100; index++) {
+      const conversationId = `cleanup-${index}`
+      await drainPendingMessages(conversationId)
+      const deletion = await preparePendingMessageDeletion([conversationId])
+      completePendingMessageDeletion(deletion)
+    }
+
+    await vi.waitFor(() => {
+      expect(getPendingMessageOperationStateForTests()).toEqual({ drainCount: 0, operationCount: 0, tombstoneCount: 0 })
+    })
+  })
+
+  it('同一会话重叠删除时，一个成功 owner 释放后另一个 owner 仍阻止操作', async () => {
+    const firstDeletion = await preparePendingMessageDeletion(['conv-1'])
+    const secondDeletion = await preparePendingMessageDeletion(['conv-1'])
+    completePendingMessageDeletion(firstDeletion)
+    enqueuePendingMessage('conv-1', '仍应阻止')
+
+    await drainPendingMessages('conv-1')
+    expect(mocks.startTurn).not.toHaveBeenCalled()
+    completePendingMessageDeletion(firstDeletion)
+    expect(getPendingMessageOperationStateForTests().tombstoneCount).toBe(1)
+
+    cancelPendingMessageDeletion(secondDeletion)
+    await drainPendingMessages('conv-1')
+    expect(mocks.startTurn).toHaveBeenCalledTimes(1)
+  })
+
+  it('同一会话重叠删除时，一个失败 owner 释放后另一个 owner 仍阻止操作', async () => {
+    const firstDeletion = await preparePendingMessageDeletion(['conv-1'])
+    const secondDeletion = await preparePendingMessageDeletion(['conv-1'])
+    cancelPendingMessageDeletion(firstDeletion)
+    enqueuePendingMessage('conv-1', '仍应阻止')
+
+    await drainPendingMessages('conv-1')
+    expect(mocks.startTurn).not.toHaveBeenCalled()
+
+    completePendingMessageDeletion(secondDeletion)
+    expect(getPendingMessageOperationStateForTests().tombstoneCount).toBe(0)
+  })
+
+  it('单删和工作区清空重叠时，任一流程未完成都保持屏障', async () => {
+    let resolveDelete!: () => void
+    let resolveClear!: (ids: string[]) => void
+    mocks.deleteConversation.mockReturnValue(new Promise<void>((resolve) => {
+      resolveDelete = resolve
+    }))
+    mocks.clearWorkspaceConversations.mockReturnValue(new Promise<string[]>((resolve) => {
+      resolveClear = resolve
+    }))
+
+    const deleting = deleteConversationsAction('conv-1' as any)
+    const clearing = clearConversationsAction()
+    await vi.waitFor(() => {
+      expect(mocks.deleteConversation).toHaveBeenCalledTimes(1)
+      expect(mocks.clearWorkspaceConversations).toHaveBeenCalledTimes(1)
+    })
+    resolveDelete()
+    await deleting
+    enqueuePendingMessage('conv-1', '清空仍在等待')
+    await drainPendingMessages('conv-1')
+    expect(mocks.startTurn).not.toHaveBeenCalled()
+
+    resolveClear(['conv-1'])
+    await clearing
+    expect(getPendingMessageOperationStateForTests().tombstoneCount).toBe(0)
+  })
+})

--- a/apps/web/src/store/pendingMessages/__tests__/actions.spec.ts
+++ b/apps/web/src/store/pendingMessages/__tests__/actions.spec.ts
@@ -66,31 +66,31 @@ describe('pending message actions', () => {
     expect(usePendingMessagesStore.getState().itemsByConversation['conv-1']).toEqual([])
   })
 
-  it('任务已结束时注入回退为普通 turn，失败时删除消息', async () => {
+  it('任务已结束时注入回退为普通 turn，失败时保留消息', async () => {
     const queued = enqueuePendingMessage('conv-1', '下一轮')
     mocks.startTurn.mockRejectedValue(new Error('网络不可用'))
     await injectPendingMessage('conv-1', queued.id)
     expect(mocks.injectSteering).not.toHaveBeenCalled()
-    expect(usePendingMessagesStore.getState().itemsByConversation['conv-1']).toEqual([])
+    // 失败后消息应保留在队列中，让用户决定重试还是手动删除
+    expect(usePendingMessagesStore.getState().itemsByConversation['conv-1']).toHaveLength(1)
   })
 
-  it('drain 与立即追加并发时按会话串行，不让后续项越过队首', async () => {
+  it('drain 与立即追加并发时按会话串行', async () => {
     const first = enqueuePendingMessage('conv-1', '队首')
     const second = enqueuePendingMessage('conv-1', '队尾')
-    let resolveInitialCheck!: (tasks: never[]) => void
-    mocks.listActiveTasks
-      .mockReturnValueOnce(new Promise((resolve) => { resolveInitialCheck = resolve }))
-      .mockResolvedValueOnce([{ conversationId: 'conv-1', taskId: 'new-task', status: 'running' }])
-    mocks.injectSteering.mockResolvedValue({ id: 'steering', convId: 'conv-1', role: 'user', status: 'success', content: [{ type: 'text', text: '队尾' }] })
 
     const draining = drainPendingMessages('conv-1')
     const injecting = injectPendingMessage('conv-1', second.id)
-    resolveInitialCheck([])
     await Promise.all([draining, injecting])
 
-    expect(mocks.startTurn).toHaveBeenCalledWith(expect.objectContaining({ prompt: '队首' }))
-    expect(mocks.injectSteering).toHaveBeenCalledWith('conv-1', '队尾')
-    expect(usePendingMessagesStore.getState().itemsByConversation['conv-1'].some(item => item.id === first.id)).toBe(false)
+    // drainOnce 不再检查 activeTask，直接 startTurn 处理队首
+    // inject 因无 active task 回退为 drainOnce，处理队尾
+    // 两者通过 runConversationOperation 串行化
+    expect(mocks.startTurn).toHaveBeenCalledTimes(2)
+    expect(mocks.startTurn).toHaveBeenNthCalledWith(1, expect.objectContaining({ prompt: '队首' }))
+    expect(mocks.startTurn).toHaveBeenNthCalledWith(2, expect.objectContaining({ prompt: '队尾' }))
+    expect(mocks.injectSteering).not.toHaveBeenCalled()
+    expect(usePendingMessagesStore.getState().itemsByConversation['conv-1']).toHaveLength(0)
   })
 
   it('清空全部队列不依赖当前已加载会话分页', () => {

--- a/apps/web/src/store/pendingMessages/__tests__/store.spec.ts
+++ b/apps/web/src/store/pendingMessages/__tests__/store.spec.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { clearConversationPendingMessages, editPendingMessage, enqueuePendingMessage, removePendingMessage } from '../actions'
+import { usePendingMessagesStore } from '../store'
+
+describe('pending messages store', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    usePendingMessagesStore.setState({ itemsByConversation: {} })
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  it('按会话隔离并保持 FIFO', () => {
+    const first = enqueuePendingMessage('conv-a', '第一条')
+    const second = enqueuePendingMessage('conv-a', '第二条')
+    enqueuePendingMessage('conv-b', '其他会话')
+    expect(usePendingMessagesStore.getState().itemsByConversation['conv-a'].map(item => item.id)).toEqual([first.id, second.id])
+    expect(usePendingMessagesStore.getState().itemsByConversation['conv-b']).toHaveLength(1)
+  })
+
+  it('编辑和删除正常运行', () => {
+    const queued = enqueuePendingMessage('conv-a', '原文')
+    editPendingMessage('conv-a', queued.id, '新文本')
+    expect(usePendingMessagesStore.getState().itemsByConversation['conv-a'][0].text).toBe('新文本')
+    removePendingMessage('conv-a', queued.id)
+    expect(usePendingMessagesStore.getState().itemsByConversation['conv-a']).toEqual([])
+    enqueuePendingMessage('conv-a', '再次添加')
+    clearConversationPendingMessages('conv-a')
+    expect(usePendingMessagesStore.getState().itemsByConversation['conv-a']).toBeUndefined()
+  })
+
+  it.each([
+    ['无法解析的 JSON', '{bad json'],
+    ['合法 JSON 中的损坏结构', JSON.stringify({ state: { itemsByConversation: { 'conv-a': [{ id: 1 }] } }, version: 2 })],
+  ])('%s 在恢复时回退为空队列并记录 warning', async (_, storedValue) => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    usePendingMessagesStore.setState({ itemsByConversation: { stale: [] } })
+    localStorage.setItem('ant-chat:pending-messages:v1', storedValue)
+
+    await usePendingMessagesStore.persist.rehydrate()
+
+    expect(usePendingMessagesStore.getState().itemsByConversation).toEqual({})
+    expect(warn).toHaveBeenCalledWith('恢复待处理消息失败，已回退为空队列', expect.anything())
+  })
+})

--- a/apps/web/src/store/pendingMessages/actions.ts
+++ b/apps/web/src/store/pendingMessages/actions.ts
@@ -6,7 +6,7 @@ import agentApi from '@/api/agentApi'
 import { buildTurnInput } from '@/components/Chat/buildTurnInput'
 import { startAgentTurn } from '@/store/agent'
 import { useChatSttingsStore } from '@/store/chatSettings'
-import { getConversationByIdAction, upsertConversationAction } from '@/store/conversation'
+import { getConversationByIdAction } from '@/store/conversation'
 import { addPendingSteeringMessage } from '@/store/messages'
 import { useWorkspaceStore } from '@/store/workspace'
 import { sortPendingMessages, usePendingMessagesStore } from './store'
@@ -129,7 +129,6 @@ async function injectPendingMessageOnce(conversationId: string, id: string) {
     addPendingSteeringMessage(message)
   }
   catch (error) {
-    removePendingMessage(conversationId, id)
     toast.error(error instanceof Error ? error.message : '追加消息失败')
   }
 }
@@ -154,22 +153,19 @@ export function drainPendingMessages(conversationId: string): Promise<void> {
 async function drainOnce(conversationId: string) {
   if (isConversationDeleting(conversationId))
     return
-  if (await listActiveTask(conversationId))
-    return
 
   const item = sortPendingMessages(usePendingMessagesStore.getState().itemsByConversation[conversationId] ?? [])[0]
   if (!item)
     return
 
   const conversation = getConversationByIdAction(conversationId)
-  if (!conversation?.settings?.modelId) {
-    removePendingMessage(conversationId, item.id)
-    toast.error('当前会话未配置模型')
+  if (!conversation) {
+    toast.error('当前会话已不存在')
     return
   }
 
   try {
-    const result = await startAgentTurn(buildTurnInput({
+    await startAgentTurn(buildTurnInput({
       conversationId,
       text: item.text,
       workspacePath: useWorkspaceStore.getState().currentWorkspacePath,
@@ -178,10 +174,11 @@ async function drainOnce(conversationId: string) {
       mode: useChatSttingsStore.getState().agentMode,
     }))
     removePendingMessage(conversationId, item.id)
-    upsertConversationAction(result.conversation)
+    // Runtime 侧已通过 turnService 发出 message:updated 事件，
+    // web UI 会自动收到用户消息，无需手动 upsert 会话
   }
   catch (error) {
-    removePendingMessage(conversationId, item.id)
+    // 失败时保留消息，让用户决定重试或手动删除
     toast.error(error instanceof Error ? error.message : '发送消息失败')
   }
 }

--- a/apps/web/src/store/pendingMessages/actions.ts
+++ b/apps/web/src/store/pendingMessages/actions.ts
@@ -1,0 +1,214 @@
+import type { AgentTaskSnapshot } from '@ant-chat/shared'
+import { nanoid } from 'nanoid'
+import { toast } from 'sonner'
+import agentApi from '@/api/agentApi'
+import { buildTurnInput } from '@/components/Chat/buildTurnInput'
+import { startAgentTurn } from '@/store/agent'
+import { useChatSttingsStore } from '@/store/chatSettings'
+import { getConversationByIdAction, upsertConversationAction } from '@/store/conversation'
+import { addPendingSteeringMessage } from '@/store/messages'
+import { useWorkspaceStore } from '@/store/workspace'
+import { sortPendingMessages, usePendingMessagesStore } from './store'
+import type { PendingMessage } from './store'
+
+const drainPromises = new Map<string, Promise<void>>()
+const operationPromises = new Map<string, Promise<void>>()
+const deletionBarriers = new Map<string, Set<symbol>>()
+const activeStatuses = new Set<AgentTaskSnapshot['status']>(['running', 'awaiting_approval'])
+let lastCreatedAt = 0
+
+function updateConversationItems(conversationId: string, update: (items: PendingMessage[]) => PendingMessage[]) {
+  usePendingMessagesStore.setState(state => ({
+    itemsByConversation: {
+      ...state.itemsByConversation,
+      [conversationId]: sortPendingMessages(update(state.itemsByConversation[conversationId] ?? [])),
+    },
+  }))
+}
+
+export function enqueuePendingMessage(conversationId: string, text: string) {
+  const latestPersistedCreatedAt = Math.max(
+    0,
+    ...(usePendingMessagesStore.getState().itemsByConversation[conversationId] ?? []).map(item => item.createdAt),
+  )
+  const now = Math.max(Date.now(), lastCreatedAt + 1, latestPersistedCreatedAt + 1)
+  lastCreatedAt = now
+  const item: PendingMessage = { id: nanoid(), conversationId, text: text.trim(), createdAt: now }
+  updateConversationItems(conversationId, items => [...items, item])
+  return item
+}
+
+export function editPendingMessage(conversationId: string, id: string, text: string) {
+  const trimmed = text.trim()
+  if (!trimmed) {
+    removePendingMessage(conversationId, id)
+    toast.info('空消息已移除')
+    return
+  }
+  updateConversationItems(conversationId, items => items.map(item => item.id === id ? { ...item, text: trimmed } : item))
+}
+
+export function removePendingMessage(conversationId: string, id: string) {
+  updateConversationItems(conversationId, items => items.filter(item => item.id !== id))
+}
+
+export function clearConversationPendingMessages(conversationId: string) {
+  usePendingMessagesStore.setState((state) => {
+    const itemsByConversation = { ...state.itemsByConversation }
+    delete itemsByConversation[conversationId]
+    return { itemsByConversation }
+  })
+}
+
+export function clearAllPendingMessages() {
+  usePendingMessagesStore.setState({ itemsByConversation: {} })
+}
+
+export interface PendingMessageDeletionToken {
+  readonly conversationIds: readonly string[]
+  readonly owner: symbol
+}
+
+export async function preparePendingMessageDeletion(conversationIds: string[]): Promise<PendingMessageDeletionToken> {
+  const token = { conversationIds: [...new Set(conversationIds)], owner: Symbol('pending-message-deletion') }
+  token.conversationIds.forEach((conversationId) => {
+    const owners = deletionBarriers.get(conversationId) ?? new Set<symbol>()
+    owners.add(token.owner)
+    deletionBarriers.set(conversationId, owners)
+  })
+  await Promise.allSettled(token.conversationIds.map(conversationId => operationPromises.get(conversationId)))
+  return token
+}
+
+export function completePendingMessageDeletion(token: PendingMessageDeletionToken, conversationIds: string[] = [...token.conversationIds]) {
+  conversationIds.forEach((conversationId) => {
+    if (releaseDeletionOwner(token, conversationId))
+      clearConversationPendingMessages(conversationId)
+  })
+}
+
+export function cancelPendingMessageDeletion(token: PendingMessageDeletionToken, conversationIds: string[] = [...token.conversationIds]) {
+  conversationIds.forEach(conversationId => releaseDeletionOwner(token, conversationId))
+}
+
+export function getPendingMessageOperationStateForTests() {
+  return {
+    drainCount: drainPromises.size,
+    operationCount: operationPromises.size,
+    tombstoneCount: deletionBarriers.size,
+  }
+}
+
+async function listActiveTask(conversationId: string) {
+  const tasks = await agentApi.listActiveTasks(conversationId)
+  return tasks.find(task => activeStatuses.has(task.status))
+}
+
+export async function injectPendingMessage(conversationId: string, id: string) {
+  if (isConversationDeleting(conversationId))
+    return
+  await runConversationOperation(conversationId, () => injectPendingMessageOnce(conversationId, id))
+}
+
+async function injectPendingMessageOnce(conversationId: string, id: string) {
+  if (isConversationDeleting(conversationId))
+    return
+  const item = usePendingMessagesStore.getState().itemsByConversation[conversationId]?.find(candidate => candidate.id === id)
+  if (!item)
+    return
+
+  const task = await listActiveTask(conversationId)
+  if (!task) {
+    await drainOnce(conversationId)
+    return
+  }
+
+  try {
+    const message = await agentApi.injectSteering(conversationId, item.text)
+    removePendingMessage(conversationId, id)
+    addPendingSteeringMessage(message)
+  }
+  catch (error) {
+    removePendingMessage(conversationId, id)
+    toast.error(error instanceof Error ? error.message : '追加消息失败')
+  }
+}
+
+export function drainPendingMessages(conversationId: string): Promise<void> {
+  if (isConversationDeleting(conversationId))
+    return Promise.resolve()
+  const existing = drainPromises.get(conversationId)
+  if (existing)
+    return existing
+
+  const promise = runConversationOperation(conversationId, () => drainOnce(conversationId))
+  drainPromises.set(conversationId, promise)
+  const cleanup = () => {
+    if (drainPromises.get(conversationId) === promise)
+      drainPromises.delete(conversationId)
+  }
+  void promise.then(cleanup, cleanup)
+  return promise
+}
+
+async function drainOnce(conversationId: string) {
+  if (isConversationDeleting(conversationId))
+    return
+  if (await listActiveTask(conversationId))
+    return
+
+  const item = sortPendingMessages(usePendingMessagesStore.getState().itemsByConversation[conversationId] ?? [])[0]
+  if (!item)
+    return
+
+  const conversation = getConversationByIdAction(conversationId)
+  if (!conversation?.settings?.modelId) {
+    removePendingMessage(conversationId, item.id)
+    toast.error('当前会话未配置模型')
+    return
+  }
+
+  try {
+    const result = await startAgentTurn(buildTurnInput({
+      conversationId,
+      text: item.text,
+      workspacePath: useWorkspaceStore.getState().currentWorkspacePath,
+      settings: conversation.settings,
+      features: { enableMCP: useChatSttingsStore.getState().enableMCP },
+      mode: useChatSttingsStore.getState().agentMode,
+    }))
+    removePendingMessage(conversationId, item.id)
+    upsertConversationAction(result.conversation)
+  }
+  catch (error) {
+    removePendingMessage(conversationId, item.id)
+    toast.error(error instanceof Error ? error.message : '发送消息失败')
+  }
+}
+
+function isConversationDeleting(conversationId: string) {
+  return (deletionBarriers.get(conversationId)?.size ?? 0) > 0
+}
+
+function releaseDeletionOwner(token: PendingMessageDeletionToken, conversationId: string) {
+  if (!token.conversationIds.includes(conversationId))
+    return false
+  const owners = deletionBarriers.get(conversationId)
+  if (!owners?.delete(token.owner))
+    return false
+  if (owners.size === 0)
+    deletionBarriers.delete(conversationId)
+  return true
+}
+
+function runConversationOperation(conversationId: string, operation: () => Promise<void>): Promise<void> {
+  const previous = operationPromises.get(conversationId) ?? Promise.resolve()
+  const current = previous.catch(() => {}).then(operation)
+  operationPromises.set(conversationId, current)
+  const cleanup = () => {
+    if (operationPromises.get(conversationId) === current)
+      operationPromises.delete(conversationId)
+  }
+  void current.then(cleanup, cleanup)
+  return current
+}

--- a/apps/web/src/store/pendingMessages/actions.ts
+++ b/apps/web/src/store/pendingMessages/actions.ts
@@ -1,4 +1,5 @@
 import type { AgentTaskSnapshot } from '@ant-chat/shared'
+import type { PendingMessage } from './store'
 import { nanoid } from 'nanoid'
 import { toast } from 'sonner'
 import agentApi from '@/api/agentApi'
@@ -9,7 +10,6 @@ import { getConversationByIdAction, upsertConversationAction } from '@/store/con
 import { addPendingSteeringMessage } from '@/store/messages'
 import { useWorkspaceStore } from '@/store/workspace'
 import { sortPendingMessages, usePendingMessagesStore } from './store'
-import type { PendingMessage } from './store'
 
 const drainPromises = new Map<string, Promise<void>>()
 const operationPromises = new Map<string, Promise<void>>()

--- a/apps/web/src/store/pendingMessages/index.ts
+++ b/apps/web/src/store/pendingMessages/index.ts
@@ -1,0 +1,2 @@
+export * from './actions'
+export * from './store'

--- a/apps/web/src/store/pendingMessages/store.ts
+++ b/apps/web/src/store/pendingMessages/store.ts
@@ -1,0 +1,75 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+export interface PendingMessage {
+  id: string
+  conversationId: string
+  text: string
+  createdAt: number
+}
+
+interface PendingMessagesState {
+  itemsByConversation: Record<string, PendingMessage[]>
+}
+
+const pendingMessagesStorage = {
+  getItem: (name: string) => {
+    const raw = localStorage.getItem(name)
+    if (!raw)
+      return null
+
+    try {
+      const stored = JSON.parse(raw) as { state?: unknown, version?: number }
+      if (!isPersistedState(stored?.state))
+        throw new Error('待处理消息持久化结构无效')
+      return stored as { state: { itemsByConversation: Record<string, PendingMessage[]> }, version: number }
+    }
+    catch (error) {
+      console.warn('恢复待处理消息失败，已回退为空队列', error)
+      return { state: { itemsByConversation: {} }, version: 1 }
+    }
+  },
+  setItem: (name: string, value: unknown) => localStorage.setItem(name, JSON.stringify(value)),
+  removeItem: (name: string) => localStorage.removeItem(name),
+}
+
+export const usePendingMessagesStore = create<PendingMessagesState>()(
+  persist(
+    () => ({
+      itemsByConversation: {},
+    }),
+    {
+      name: 'ant-chat:pending-messages:v1',
+      version: 1,
+      storage: pendingMessagesStorage,
+      partialize: state => ({ itemsByConversation: state.itemsByConversation }),
+    },
+  ),
+)
+
+function isPersistedState(value: unknown): value is { itemsByConversation: Record<string, PendingMessage[]> } {
+  if (!value || typeof value !== 'object' || !('itemsByConversation' in value))
+    return false
+
+  const itemsByConversation = (value as Record<string, unknown>).itemsByConversation
+  if (!itemsByConversation || typeof itemsByConversation !== 'object' || Array.isArray(itemsByConversation))
+    return false
+
+  return Object.values(itemsByConversation as Record<string, unknown>).every(items =>
+    Array.isArray(items) && items.every(isPendingMessage),
+  )
+}
+
+function isPendingMessage(value: unknown): value is PendingMessage {
+  if (!value || typeof value !== 'object')
+    return false
+  const item = value as Partial<PendingMessage>
+  return typeof item.id === 'string'
+    && typeof item.conversationId === 'string'
+    && typeof item.text === 'string'
+    && typeof item.createdAt === 'number'
+}
+
+export function sortPendingMessages(items: PendingMessage[]): PendingMessage[] {
+  return [...items].sort((left, right) => left.createdAt - right.createdAt || left.id.localeCompare(right.id))
+}

--- a/packages/agent-runtime/src/agentTurnService.ts
+++ b/packages/agent-runtime/src/agentTurnService.ts
@@ -4,6 +4,7 @@ import type {
   AgentRuntimeStartTaskResult,
   AIProviderFactory,
   ILogger,
+  IMessage,
   IMessageContent,
   StartAgentTurnOptions,
 } from '@ant-chat/shared'
@@ -17,6 +18,7 @@ export interface AgentTurnServiceDeps {
   aiProviderFactory?: AIProviderFactory
   titleGenerator?: ConversationTitleGenerator
   emitConversationUpdated?: (conversation: AgentRuntimeStartTaskResult['conversation']) => void
+  emitMessageUpdated?: (message: IMessage) => void
   logger?: ILogger
 }
 
@@ -25,7 +27,7 @@ export interface AgentTurnService {
 }
 
 export function createAgentTurnService(deps: AgentTurnServiceDeps): AgentTurnService {
-  const { runtime, appDataContext, aiProviderFactory, titleGenerator, emitConversationUpdated, logger } = deps
+  const { runtime, appDataContext, aiProviderFactory, titleGenerator, emitConversationUpdated, emitMessageUpdated, logger } = deps
 
   return {
     async startTurn(options) {
@@ -87,6 +89,8 @@ export function createAgentTurnService(deps: AgentTurnServiceDeps): AgentTurnSer
         content: resolveUserMessageContent(options.content, prompt),
         turnId: undefined,
       })
+
+      emitMessageUpdated?.(userMessage)
 
       try {
         const result = await runtime.startTask({

--- a/packages/app-runtime/src/appRuntime.ts
+++ b/packages/app-runtime/src/appRuntime.ts
@@ -123,6 +123,7 @@ export function createAppRuntime(options: CreateAppRuntimeOptions) {
     aiProviderFactory,
     titleGenerator,
     emitConversationUpdated: conversation => events.emit('conversation:updated', { conversation }),
+    emitMessageUpdated: message => events.emit('message:updated', { message }),
     logger,
   })
   const commandController = createCommandController({

--- a/packages/app-runtime/src/appRuntime.ts
+++ b/packages/app-runtime/src/appRuntime.ts
@@ -92,7 +92,9 @@ export function createAppRuntime(options: CreateAppRuntimeOptions) {
     emitTurnChunk() {},
     emitTurnToolCalls() {},
     emitTurnToolResults() {},
-    emitTurnFinished() {},
+    emitTurnFinished(params) {
+      events.emit('agent:turn-finished', { conversationId: params.conversationId, status: params.status })
+    },
   }
   const agentRuntime = createAgentRuntime({
     host: {

--- a/packages/shared/src/ipc-events.ts
+++ b/packages/shared/src/ipc-events.ts
@@ -66,6 +66,7 @@ export interface AppRendererEvents {
   'conversation:updated': { conversation: IConversations }
   'message:updated': { message: IMessage }
   'agent:task-updated': { task: AgentTaskSnapshot }
+  'agent:turn-finished': { conversationId: string, status: 'success' | 'error' | 'cancel' }
   'agent:approval-required': { taskId: string, conversationId: string, pendingAction: AgentPendingAction }
   'agent:secret-requested': { request: SecretRequest }
   'workspace:changed': Record<string, never>
@@ -78,6 +79,7 @@ export const APP_RENDERER_EVENT_NAMES = [
   'conversation:updated',
   'message:updated',
   'agent:task-updated',
+  'agent:turn-finished',
   'agent:approval-required',
   'agent:secret-requested',
   'workspace:changed',


### PR DESCRIPTION
## 背景

当前用户在消息发送后需等待返回才能继续输入，输入框在请求运行期间被 disable，无法灵活编排任务。

## 变更内容

- **待处理消息队列**：新增  store 支持消息排队（enqueue/drain/inject），Zustand + localStorage 持久化
- **自动 drain**： 事件触发自动排出队列中的下一条消息作为新 turn
- **Steering 注入**：任务运行中可通过“追加”按钮将消息作为 steer 注入当前 turn
- **UI 集成**：Sender 组件新增 PendingMessageQueue 展示排队消息，支持编辑/删除/注入
- **修复**：pendingMessage 无 active turn 时注入按钮改为始终可点击，切换回车图标并加 tooltip

## 相关文件

-  — 新 store
-  — PendingMessageQueue/Item 组件
-  — onSubmit 编排
-  — turn-finished 事件监听
-  — 新增事件类型
-  — 运行时支持