### PR TITLE
feat: 升级 Zod v3 → v4 并迁移废弃 API

### DIFF
--- a/apps/web/src/components/Chat/BubbleList.tsx
+++ b/apps/web/src/components/Chat/BubbleList.tsx
@@ -147,7 +147,7 @@ function useActiveMessageTracking(
   infiniteScrollRef: { readonly current: { readonly containerRef: { readonly current: HTMLElement | null } } | null },
   userMessages: IMessage[],
 ): string | null {
-  const storeRef = useRef<{ state: string | null; listeners: Set<() => void> }>({
+  const storeRef = useRef<{ state: string | null, listeners: Set<() => void> }>({
     state: null,
     listeners: new Set(),
   })
@@ -173,7 +173,9 @@ function useActiveMessageTracking(
       (entries) => {
         for (const entry of entries) {
           const id = (entry.target as HTMLElement).dataset.messageId
-          if (!id) { continue }
+          if (!id) {
+            continue
+          }
           if (entry.isIntersecting) {
             map.set(id, entry.intersectionRatio)
           }
@@ -199,14 +201,18 @@ function useActiveMessageTracking(
       { root: container, threshold: [0, 0.25, 0.5, 0.75, 1] },
     )
 
-    for (const el of elements) { observer.observe(el) }
+    for (const el of elements) {
+      observer.observe(el)
+    }
     return () => observer.disconnect()
   }, [userMessages, infiniteScrollRef])
 
   const subscribe = useCallback(
     (onStoreChange: () => void) => {
       storeRef.current.listeners.add(onStoreChange)
-      return () => { storeRef.current.listeners.delete(onStoreChange) }
+      return () => {
+        storeRef.current.listeners.delete(onStoreChange)
+      }
     },
     [],
   )

--- a/packages/shared/src/schemas/mcpConfigs.ts
+++ b/packages/shared/src/schemas/mcpConfigs.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 export const BaseMcpConfig = z.object({
-  serverName: z.string({ message: 'serverName 是必填项' }),
+  serverName: z.string({ error: 'serverName 是必填项' }),
   icon: z.string(),
   description: z.string().optional().nullable(),
   timeout: z.number().optional(),
@@ -10,17 +10,17 @@ export const BaseMcpConfig = z.object({
 
 export const SSEMcpConfig = BaseMcpConfig.extend({
   transportType: z.literal('sse'),
-  url: z.string({ message: 'url 是必填项' }).url({ message: 'url格式错误' }),
-  headers: z.record(z.string()).optional(),
+  url: z.url({ error: 'url格式错误' }),
+  headers: z.record(z.string(), z.string()).optional(),
 })
 
 export type SSEMcpConfig = z.infer<typeof SSEMcpConfig>
 
 export const StdioMcpConfig = BaseMcpConfig.extend({
   transportType: z.literal('stdio'),
-  command: z.string({ message: '缺少command参数' }),
+  command: z.string({ error: '缺少command参数' }),
   args: z.array(z.string()).optional(),
-  env: z.record(z.any()).optional(),
+  env: z.record(z.string(), z.any()).optional(),
 })
 
 export type StdioMcpConfig = z.infer<typeof StdioMcpConfig>

--- a/packages/shared/src/schemas/messages.ts
+++ b/packages/shared/src/schemas/messages.ts
@@ -31,7 +31,7 @@ export const ToolCallContentSchema = z.object({
   type: z.literal('tool-call'),
   toolCallId: z.string(),
   toolName: z.string(),
-  args: z.record(z.unknown()),
+  args: z.record(z.string(), z.unknown()),
   serverName: z.string().optional(),
   executeState: z.enum(['executing', 'completed']).optional(),
 })
@@ -182,7 +182,7 @@ export const McpToolCallSchema = z.object({
   id: z.string(),
   serverName: z.string(),
   toolName: z.string(),
-  args: z.record(z.unknown()),
+  args: z.record(z.string(), z.unknown()),
   executeState: z.enum(['await', 'executing', 'completed']),
   result: McpToolResultSchema.optional(),
 })
@@ -190,7 +190,7 @@ export const McpToolCallSchema = z.object({
 export type McpToolCall = z.infer<typeof McpToolCallSchema>
 
 const BaseMessage = z.object({
-  id: z.string().nanoid(),
+  id: z.nanoid(),
   convId: z.string(),
   content: MessageContentSchema,
   createAt: z.number(),

--- a/packages/shared/src/schemas/providerConfig.ts
+++ b/packages/shared/src/schemas/providerConfig.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 export const ProviderConfigSchema = z.object({
   id: z.string(),
   name: z.string(),
-  baseUrl: z.string().url(),
+  baseUrl: z.url(),
   apiKey: z.string().optional(),
   apiKeySecretId: z.string().optional(),
   hasApiKey: z.boolean().optional(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ catalogs:
       specifier: 4.1.7
       version: 4.1.7
     zod:
-      specifier: ^3.25.76
-      version: 3.25.76
+      specifier: ^4.0.0
+      version: 4.4.3
 
 importers:
 
@@ -64,7 +64,7 @@ importers:
     dependencies:
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^6.2.0
@@ -258,7 +258,7 @@ importers:
         version: 3.9.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ai:
         specifier: ^6.0.69
-        version: 6.0.105(zod@3.25.76)
+        version: 6.0.105(zod@4.4.3)
       dayjs:
         specifier: ^1.11.13
         version: 1.11.20
@@ -349,29 +349,29 @@ importers:
     dependencies:
       '@ai-sdk/anthropic':
         specifier: ^3.0.36
-        version: 3.0.50(zod@3.25.76)
+        version: 3.0.50(zod@4.4.3)
       '@ai-sdk/deepseek':
         specifier: ^2.0.34
-        version: 2.0.34(zod@3.25.76)
+        version: 2.0.34(zod@4.4.3)
       '@ai-sdk/google':
         specifier: ^3.0.20
-        version: 3.0.34(zod@3.25.76)
+        version: 3.0.34(zod@4.4.3)
       '@ai-sdk/openai':
         specifier: ^3.0.25
-        version: 3.0.37(zod@3.25.76)
+        version: 3.0.37(zod@4.4.3)
       '@ant-chat/shared':
         specifier: workspace:^
         version: link:../shared
       ai:
         specifier: ^6.0.69
-        version: 6.0.105(zod@3.25.76)
+        version: 6.0.105(zod@4.4.3)
     devDependencies:
       '@copilotkit/aimock':
         specifier: ^1.16.4
         version: 1.16.4(vitest@4.1.7)
       openai:
         specifier: ^5.23.2
-        version: 5.23.2(ws@8.19.0)(zod@3.25.76)
+        version: 5.23.2(ws@8.19.0)(zod@4.4.3)
       tsdown:
         specifier: 'catalog:'
         version: 0.20.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(synckit@0.11.12)(typescript@5.9.3)
@@ -492,13 +492,13 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
-        version: 1.29.0(zod@3.25.76)
+        version: 1.29.0(zod@4.4.3)
       fast-deep-equal:
         specifier: ^3.1.3
         version: 3.1.3
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
     devDependencies:
       '@ant-chat/shared':
         specifier: workspace:^
@@ -514,7 +514,7 @@ importers:
     dependencies:
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
     devDependencies:
       tsdown:
         specifier: 'catalog:'
@@ -566,7 +566,7 @@ importers:
         version: 12.10.2(@types/react@19.2.14)(immer@10.2.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ai:
         specifier: ^6.0.105
-        version: 6.0.105(zod@3.25.76)
+        version: 6.0.105(zod@4.4.3)
       ansi-to-react:
         specifier: ^6.2.6
         version: 6.2.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -632,7 +632,7 @@ importers:
         version: 1.1.3(react@19.2.4)
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
     devDependencies:
       '@iconify-json/clarity':
         specifier: ^1.2.4
@@ -9053,50 +9053,50 @@ snapshots:
 
   '@adobe/css-tools@4.5.0': {}
 
-  '@ai-sdk/anthropic@3.0.50(zod@3.25.76)':
+  '@ai-sdk/anthropic@3.0.50(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.16(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 4.0.16(zod@4.4.3)
+      zod: 4.4.3
 
-  '@ai-sdk/deepseek@2.0.34(zod@3.25.76)':
+  '@ai-sdk/deepseek@2.0.34(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      zod: 4.4.3
 
-  '@ai-sdk/gateway@3.0.59(zod@3.25.76)':
+  '@ai-sdk/gateway@3.0.59(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.16(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.16(zod@4.4.3)
       '@vercel/oidc': 3.1.0
-      zod: 3.25.76
+      zod: 4.4.3
 
-  '@ai-sdk/google@3.0.34(zod@3.25.76)':
+  '@ai-sdk/google@3.0.34(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.16(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 4.0.16(zod@4.4.3)
+      zod: 4.4.3
 
-  '@ai-sdk/openai@3.0.37(zod@3.25.76)':
+  '@ai-sdk/openai@3.0.37(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.16(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 4.0.16(zod@4.4.3)
+      zod: 4.4.3
 
-  '@ai-sdk/provider-utils@4.0.16(zod@3.25.76)':
+  '@ai-sdk/provider-utils@4.0.16(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.8
-      zod: 3.25.76
+      zod: 4.4.3
 
-  '@ai-sdk/provider-utils@4.0.27(zod@3.25.76)':
+  '@ai-sdk/provider-utils@4.0.27(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.8
-      zod: 3.25.76
+      zod: 4.4.3
 
   '@ai-sdk/provider@3.0.10':
     dependencies:
@@ -10490,6 +10490,28 @@ snapshots:
       raw-body: 3.0.2
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.9(hono@4.12.3)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.2.1(express@5.2.1)
+      hono: 4.12.3
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.1(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -12623,13 +12645,13 @@ snapshots:
       screenfull: 5.2.0
       tslib: 2.8.1
 
-  ai@6.0.105(zod@3.25.76):
+  ai@6.0.105(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 3.0.59(zod@3.25.76)
+      '@ai-sdk/gateway': 3.0.59(zod@4.4.3)
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.16(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.16(zod@4.4.3)
       '@opentelemetry/api': 1.9.0
-      zod: 3.25.76
+      zod: 4.4.3
 
   ajv-formats@2.1.1(ajv@8.18.0):
     optionalDependencies:
@@ -16340,6 +16362,11 @@ snapshots:
       ws: 8.19.0
       zod: 3.25.76
 
+  openai@5.23.2(ws@8.19.0)(zod@4.4.3):
+    optionalDependencies:
+      ws: 8.19.0
+      zod: 4.4.3
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -18255,6 +18282,10 @@ snapshots:
   zod-to-json-schema@3.25.1(zod@3.25.76):
     dependencies:
       zod: 3.25.76
+
+  zod-to-json-schema@3.25.1(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,7 +32,7 @@ catalog:
   typescript-eslint: ^8.54.0
   vite-bundle-analyzer: ^1.3.2
   vitest: 4.1.7
-  zod: ^3.25.76
+  zod: ^4.0.0
 onlyBuiltDependencies:
   - better-sqlite3
   - electron


### PR DESCRIPTION
## 变更摘要

将 Zod 从 v3 升级到 v4，并迁移所有废弃的 API 用法。

## 变更详情

### 版本升级
- `pnpm-workspace.yaml` catalog: `zod ^3.25.76` → `^4.0.0`
- 安装 Zod **v4.4.3**（零外部依赖，无兼容性问题）

### API 迁移

| 变更 | 原因 | 涉及文件 |
|---|---|---|
| `{ message: '...' }` → `{ error: '...' }` | Zod v4 废弃了 `message` 参数 | `mcpConfigs.ts` (4处) |
| `z.string().nanoid()` → `z.nanoid()` | 改用顶层函数（方法形式已废弃） | `messages.ts` |
| `z.string().url()` → `z.url()` | 改用顶层函数（方法形式已废弃） | `providerConfig.ts`, `mcpConfigs.ts` |
| `z.record(单参数)` → `z.record(z.string(), ...)` | v4 要求显式提供 key schema | `messages.ts` (2处), `mcpConfigs.ts` (2处) |

### 验证结果
- ✅ 类型检查 (`tsc -b`) — 通过
- ✅ 单元测试 — 全部通过（574 tests, 9 packages）
- ✅ Lint — 无新增错误

## 依赖兼容性

Zod v4.4.3 兼容已有依赖：
- `ai` / `@ai-sdk/*` (v6) — 已正确解析 peer dependency
- `@modelcontextprotocol/sdk` — 已正确解析 peer dependency
- `openai` — 已正确解析 peer dependency