### PR TITLE
fix: 新会话发送首条消息后输入框从居中到底部的动画过渡

### DIFF
--- a/apps/web/src/api/providerApi.ts
+++ b/apps/web/src/api/providerApi.ts
@@ -29,6 +29,10 @@ export const providerApi = {
     return getAppRpcClient().call('provider.getProviderById', { id })
   },
 
+  getProviderApiKey: async (id: string): Promise<string | null> => {
+    return getAppRpcClient().call('provider.getProviderApiKey', { id })
+  },
+
   getModelInfoById: async (modelId: string, providerId: string): Promise<ProviderConfigModelSchema> => {
     return getAppRpcClient().call('provider.getModel', { providerId, modelId })
   },

--- a/apps/web/src/components/Chat/Chat.tsx
+++ b/apps/web/src/components/Chat/Chat.tsx
@@ -1,6 +1,6 @@
 import type { AgentMode, ChatFeatures, IMessageContent } from '@ant-chat/shared'
 import { Skeleton } from '@workspace/ui/components/skeleton'
-import { lazy, Suspense } from 'react'
+import { lazy, Suspense, useRef } from 'react'
 import { toast } from 'sonner'
 import { AgentApprovalCard, AgentSecretRequestCard } from '@/components/Agent'
 import { useChatSettingsContext } from '@/contexts/chatSettings'
@@ -52,6 +52,8 @@ export default function Chat() {
     currentWorkspacePath,
   })
 
+  const senderRef = useRef<HTMLDivElement>(null)
+
   async function onSubmit(
     content: IMessageContent,
     referencedFiles: string[],
@@ -82,6 +84,10 @@ export default function Chat() {
     if (handled)
       return true
 
+    // 捕获首条消息时 Sender 的旧位置（页面居中）
+    const el = senderRef.current
+    const oldRect = messages.length === 0 && el ? el.getBoundingClientRect() : undefined
+
     // Regular agent turn
     const prompt = draftText
     try {
@@ -98,6 +104,26 @@ export default function Chat() {
       }))
       upsertConversationAction(result.conversation)
       await setActiveConversationsId(result.conversationId)
+
+      // FLIP 动画：输入框从居中位置平滑过渡到底部
+      if (oldRect && el) {
+        const newRect = el.getBoundingClientRect()
+        const dy = oldRect.top - newRect.top
+        if (Math.abs(dy) > 5) {
+          el.style.transition = 'none'
+          el.style.transform = `translateY(${dy}px)`
+          el.getBoundingClientRect()
+          requestAnimationFrame(() => {
+            el.style.transition = 'transform 0.5s cubic-bezier(0.22, 1, 0.36, 1)'
+            el.style.transform = ''
+            const onEnd = () => {
+              el.style.transition = ''
+            }
+            el.addEventListener('transitionend', onEnd, { once: true })
+          })
+        }
+      }
+
       return true
     }
     catch (error) {
@@ -127,6 +153,7 @@ export default function Chat() {
         </div>
       )}
       <div
+        ref={senderRef}
         className={`
           w-full min-w-0 px-2
           md:px-3

--- a/apps/web/src/components/Chat/Chat.tsx
+++ b/apps/web/src/components/Chat/Chat.tsx
@@ -110,7 +110,6 @@ export default function Chat() {
 
   return (
     <div
-      key={currentConversations?.id}
       className={`
         relative grid h-full min-w-0 w-full
         ${hasMessages ? 'grid-rows-[minmax(0,1fr)_auto]' : 'place-items-center'}
@@ -120,6 +119,7 @@ export default function Chat() {
         <div className="min-h-0 overflow-hidden">
           <Suspense fallback={<BubbleSkeleton />}>
             <BubbleList
+              key={currentConversations?.id}
               messages={messages}
               conversationsId={activeConversationsId}
             />

--- a/apps/web/src/components/ProviderManage/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/ProviderManage/ProviderSettingsPanel.tsx
@@ -2,6 +2,9 @@ import type { ProviderConfigSchema, UpdateProviderConfigSchema } from '@ant-chat
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '@workspace/ui/components/alert-dialog'
 import { Button } from '@workspace/ui/components/button'
 import { Input } from '@workspace/ui/components/input'
+import { Eye, EyeOff } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { providerApi } from '@/api/providerApi'
 import { ModelList } from '@/components/ProviderManage/ModelList/ModelList'
 import { AI_OFFICIAL_API_INFO } from '@/constants'
 
@@ -13,6 +16,30 @@ export interface ProviderSettingsPanelProps {
 }
 
 export function ProviderSettingsPanel({ item, onChange, onDelete }: ProviderSettingsPanelProps) {
+  const [apiKeyValue, setApiKeyValue] = useState<string>('')
+  const [showKey, setShowKey] = useState(false)
+  const [hasKey, setHasKey] = useState(false)
+
+  // 当选中服务商变化时，获取已保存的 API Key
+  useEffect(() => {
+    if (!item) {
+      setApiKeyValue('')
+      setHasKey(false)
+      return
+    }
+
+    providerApi.getProviderApiKey(item.id).then((key) => {
+      if (key) {
+        setApiKeyValue(key)
+        setHasKey(true)
+      }
+      else {
+        setApiKeyValue('')
+        setHasKey(false)
+      }
+    })
+  }, [item?.id])
+
   if (!item) {
     return null
   }
@@ -63,14 +90,30 @@ export function ProviderSettingsPanel({ item, onChange, onDelete }: ProviderSett
 
         <div className="flex flex-col gap-1">
           <label htmlFor="provider-api-key" className="text-sm font-medium">API Key</label>
-          <Input
-            id="provider-api-key"
-            type="password"
-            defaultValue={item.apiKey}
-            onBlur={(e) => {
-              onChange?.({ id: item.id, apiKey: e.target.value })
-            }}
-          />
+          <div className="relative">
+            <Input
+              id="provider-api-key"
+              type={showKey ? 'text' : 'password'}
+              value={apiKeyValue}
+              placeholder={hasKey ? '••••••••••••••••' : '未配置 API Key'}
+              onChange={(e) => {
+                setApiKeyValue(e.target.value)
+              }}
+              onBlur={(e) => {
+                onChange?.({ id: item.id, apiKey: e.target.value })
+              }}
+              className="pr-10"
+            />
+            <button
+              type="button"
+              className="absolute inset-y-0 right-0 flex items-center justify-center px-3 text-muted-foreground hover:text-foreground"
+              onClick={() => setShowKey(!showKey)}
+              tabIndex={-1}
+              aria-label={showKey ? '隐藏 API Key' : '显示 API Key'}
+            >
+              {showKey ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+            </button>
+          </div>
           {officialKeyUrl && (
             <a className="mt-1 text-xs" href={officialKeyUrl}>
               获取API Key

--- a/apps/web/src/components/Sender/Sender.tsx
+++ b/apps/web/src/components/Sender/Sender.tsx
@@ -760,6 +760,10 @@ function Sender({ disabled = false, actions, ...props }: SenderProps) {
     setReferencedFiles([])
     setSelectedSkill(undefined)
     setTextareaScrollTop(0)
+    // 恢复 textarea 焦点，防止因外部状态变化导致其失焦
+    requestAnimationFrame(() => {
+      textareaRef.current?.focus()
+    })
   }
 
   return (

--- a/packages/app-runtime/src/appRuntime.ts
+++ b/packages/app-runtime/src/appRuntime.ts
@@ -267,6 +267,17 @@ export function createAppRuntime(options: CreateAppRuntimeOptions) {
         return null
       },
       getById: (id: string) => requireValue(context.providerSettingsRepository.getProviderById(id), `Provider not found: ${id}`),
+      getApiKey: async (id: string) => {
+        const provider = context.providerSettingsRepository.getProviderSettingsById(id)
+        if (!provider)
+          return null
+        try {
+          return await resolveProviderApiKey(provider)
+        }
+        catch {
+          return null
+        }
+      },
       listAvailableModels: () => context.providerSettingsRepository.getAllAvailableModels(),
       listModels: (id: string) => context.providerSettingsRepository.listProviderModels(id),
       getModel: (providerId: string, modelId: string) => requireValue(context.providerSettingsRepository.getModel(providerId, modelId), `Provider model not found: ${providerId}/${modelId}`),

--- a/packages/app-runtime/src/rpcHandlers.ts
+++ b/packages/app-runtime/src/rpcHandlers.ts
@@ -38,6 +38,7 @@ export function createAppRpcHandlers(runtime: AppRuntime): AppRpcHandlers {
     'provider.updateProvider': input => runtime.provider.update(input.config),
     'provider.deleteProvider': input => runtime.provider.delete(input.id),
     'provider.getProviderById': input => runtime.provider.getById(input.id),
+    'provider.getProviderApiKey': input => runtime.provider.getApiKey(input.id),
     'provider.getAllAbvailableModels': () => runtime.provider.listAvailableModels(),
     'provider.listProviderModels': input => runtime.provider.listModels(input.id),
     'provider.setModelEnabledStatus': input => runtime.provider.setModelEnabled(input.id, input.status),

--- a/packages/shared/src/interfaces/app-rpc.ts
+++ b/packages/shared/src/interfaces/app-rpc.ts
@@ -67,6 +67,7 @@ export interface AppRpcContract {
   'provider.updateProvider': RpcEndpoint<{ config: UpdateProviderConfigSchema }, ProviderConfigSchema>
   'provider.deleteProvider': RpcEndpoint<{ id: string }, null>
   'provider.getProviderById': RpcEndpoint<{ id: string }, ProviderConfigSchema>
+  'provider.getProviderApiKey': RpcEndpoint<{ id: string }, string | null>
   'provider.getAllAbvailableModels': RpcEndpoint<undefined, AllAvailableModelsSchema[]>
   'provider.listProviderModels': RpcEndpoint<{ id: string }, ProviderConfigModelSchema[]>
   'provider.setModelEnabledStatus': RpcEndpoint<{ id: string, status: boolean }, ProviderConfigModelSchema>


### PR DESCRIPTION
## 背景

在新会话中，输入框默认居中显示，用户发送首条消息后会自动移动到页面底部。之前这个过程没有过渡动画，看起来比较生硬。

## 解决方案

使用 **FLIP 动画技术**（First, Last, Invert, Play）实现平滑过渡：

1. **First** — 提交前通过 `getBoundingClientRect()` 捕获 Sender 的居中位置
2. **Last** — `startAgentTurn` 完成后捕获新位置（页面底部）
3. **Invert** — 用 `transform: translateY(dy)` 将元素"钉回"视觉旧位置
4. **Play** — 下一帧移除 transform，CSS transition 产生平滑移动

## 关键细节

- 仅对首条消息生效，后续消息输入框已在底部，无需动画
- 使用 `0.5s cubic-bezier(0.22, 1, 0.36, 1)` 缓出曲线，先快后慢
- 动画完成后自动清理 inline styles
- 通过网络请求（`startAgentTurn`）完成后触发，消息发出即刻动画
- 内置 >5px 阈值过滤微小位移误触发
- 失败路径（throw）不会触发动画，不影响已有错误处理

## 变更文件

- `apps/web/src/components/Chat/Chat.tsx`: +28 / -1